### PR TITLE
fix: Stop transceiver correctly.

### DIFF
--- a/src/peer/peer_connection.rs
+++ b/src/peer/peer_connection.rs
@@ -1247,7 +1247,7 @@ impl RTCPeerConnection {
                                 let t = if let Some(t) =
                                     find_by_mid(mid_value, &mut local_transceivers).await
                                 {
-                                    if direction == RTCRtpTransceiverDirection::Inactive { 
+                                    if direction == RTCRtpTransceiverDirection::Inactive {
                                         t.stop().await?;
                                     }
                                     Some(t)

--- a/src/peer/peer_connection.rs
+++ b/src/peer/peer_connection.rs
@@ -1247,7 +1247,9 @@ impl RTCPeerConnection {
                                 let t = if let Some(t) =
                                     find_by_mid(mid_value, &mut local_transceivers).await
                                 {
-                                    t.stop().await?;
+                                    if direction == RTCRtpTransceiverDirection::Inactive { 
+                                        t.stop().await?;
+                                    }
                                     Some(t)
                                 } else {
                                     satisfy_type_and_direction(


### PR DESCRIPTION
fix some issues in https://github.com/webrtc-rs/webrtc/issues/97.

> 2). why play-from-disk-renegotiation example can't add more grid

After the repair, `play-from-disk-renegotiation` can `addVideo` correctly.