### PR TITLE
Fix SDP attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/webrtc-rs/webrtc"
 
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.2" }
-sdp = "0.4.0"
+sdp = "0.5.0"
 mdns = { package = "webrtc-mdns", version = "0.4.1" }
 stun = "0.4.1"
 turn = "0.5.2"

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -434,11 +434,10 @@ impl RTCPeerConnection {
                             || t.direction() == RTCRtpTransceiverDirection::Sendonly
                         {
                             if let (Some(desc_msid), Some(sender)) =
-                                (m.attribute(ATTR_KEY_MSID), t.sender().await)
+                                (m.attribute(ATTR_KEY_MSID).and_then(|o| o), t.sender().await)
                             {
                                 if let Some(track) = &sender.track().await {
-                                    if desc_msid.as_str()
-                                        != track.stream_id().to_owned() + " " + track.id()
+                                    if desc_msid != track.stream_id().to_owned() + " " + track.id()
                                     {
                                         return true;
                                     }

--- a/src/peer_connection/sdp/mod.rs
+++ b/src/peer_connection/sdp/mod.rs
@@ -706,8 +706,8 @@ pub(crate) fn extract_fingerprint(desc: &SessionDescription) -> Result<(String, 
     }
 
     for m in &desc.media_descriptions {
-        if let Some(fingerprint) = m.attribute("fingerprint") {
-            fingerprints.push(fingerprint.clone());
+        if let Some(fingerprint) = m.attribute("fingerprint").and_then(|o| o) {
+            fingerprints.push(fingerprint.to_owned());
         }
     }
 
@@ -744,11 +744,11 @@ pub(crate) async fn extract_ice_details(
     }
 
     for m in &desc.media_descriptions {
-        if let Some(ufrag) = m.attribute("ice-ufrag") {
-            remote_ufrags.push(ufrag.clone());
+        if let Some(ufrag) = m.attribute("ice-ufrag").and_then(|o| o) {
+            remote_ufrags.push(ufrag.to_owned());
         }
-        if let Some(pwd) = m.attribute("ice-pwd") {
-            remote_pwds.push(pwd.clone());
+        if let Some(pwd) = m.attribute("ice-pwd").and_then(|o| o) {
+            remote_pwds.push(pwd.to_owned());
         }
 
         for a in &m.attributes {
@@ -800,7 +800,7 @@ pub(crate) fn get_by_mid<'a, 'b>(
 ) -> Option<&'b MediaDescription> {
     if let Some(parsed) = &desc.parsed {
         for m in &parsed.media_descriptions {
-            if let Some(mid) = m.attribute(ATTR_KEY_MID) {
+            if let Some(mid) = m.attribute(ATTR_KEY_MID).and_then(|o| o) {
                 if mid == search_mid {
                     return Some(m);
                 }


### PR DESCRIPTION
This fixes a bug where `set_local_description` would immediately trigger `on_negotiation_needed` even though a negotiation isn't needed. This happens because the [check](https://github.com/webrtc-rs/webrtc/blob/fc7e1ef9f9e7b5b6208abe808079bda23beb15c8/src/peer_connection/mod.rs#L471) for step 5.3.3 in `check_negotiation_needed` would always fail. 

`MediaDescription::attribute` did not allow distinguishing between an attribute that was missing and one that was present but had no value, such as `a=recvonly`.


This PR depends on this sibling PR in `webrtc-rs/sdp`: https://github.com/webrtc-rs/sdp/pull/9.
