### PR TITLE
Remove async from register_header_extension

### DIFF
--- a/src/api/interceptor_registry/mod.rs
+++ b/src/api/interceptor_registry/mod.rs
@@ -14,7 +14,7 @@ use interceptor::twcc::{receiver::Receiver, sender::Sender};
 /// register_default_interceptors will register some useful interceptors.
 /// If you want to customize which interceptors are loaded, you should copy the
 /// code from this method and remove unwanted interceptors.
-pub async fn register_default_interceptors(
+pub fn register_default_interceptors(
     mut registry: Registry,
     media_engine: &mut MediaEngine,
 ) -> Result<Registry> {
@@ -22,7 +22,7 @@ pub async fn register_default_interceptors(
 
     registry = configure_rtcp_reports(registry);
 
-    registry = configure_twcc_receiver_only(registry, media_engine).await?;
+    registry = configure_twcc_receiver_only(registry, media_engine)?;
 
     Ok(registry)
 }
@@ -62,10 +62,7 @@ pub fn configure_nack(mut registry: Registry, media_engine: &mut MediaEngine) ->
 
 /// configure_twcc will setup everything necessary for adding
 /// a TWCC header extension to outgoing RTP packets and generating TWCC reports.
-pub async fn configure_twcc(
-    mut registry: Registry,
-    media_engine: &mut MediaEngine,
-) -> Result<Registry> {
+pub fn configure_twcc(mut registry: Registry, media_engine: &mut MediaEngine) -> Result<Registry> {
     media_engine.register_feedback(
         RTCPFeedback {
             typ: TYPE_RTCP_FB_TRANSPORT_CC.to_owned(),
@@ -73,15 +70,13 @@ pub async fn configure_twcc(
         },
         RTPCodecType::Video,
     );
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Video,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Video,
+        vec![],
+    )?;
 
     media_engine.register_feedback(
         RTCPFeedback {
@@ -90,15 +85,13 @@ pub async fn configure_twcc(
         },
         RTPCodecType::Audio,
     );
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Audio,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Audio,
+        vec![],
+    )?;
 
     let sender = Box::new(Sender::builder());
     let receiver = Box::new(Receiver::builder());
@@ -109,29 +102,25 @@ pub async fn configure_twcc(
 
 /// configure_twcc_sender will setup everything necessary for adding
 /// a TWCC header extension to outgoing RTP packets. This will allow the remote peer to generate TWCC reports.
-pub async fn configure_twcc_sender_only(
+pub fn configure_twcc_sender_only(
     mut registry: Registry,
     media_engine: &mut MediaEngine,
 ) -> Result<Registry> {
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Video,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Video,
+        vec![],
+    )?;
 
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Audio,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Audio,
+        vec![],
+    )?;
 
     let sender = Box::new(Sender::builder());
     registry.add(sender);
@@ -139,7 +128,7 @@ pub async fn configure_twcc_sender_only(
 }
 
 /// configure_twcc_receiver will setup everything necessary for generating TWCC reports.
-pub async fn configure_twcc_receiver_only(
+pub fn configure_twcc_receiver_only(
     mut registry: Registry,
     media_engine: &mut MediaEngine,
 ) -> Result<Registry> {
@@ -150,15 +139,13 @@ pub async fn configure_twcc_receiver_only(
         },
         RTPCodecType::Video,
     );
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Video,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Video,
+        vec![],
+    )?;
 
     media_engine.register_feedback(
         RTCPFeedback {
@@ -167,15 +154,13 @@ pub async fn configure_twcc_receiver_only(
         },
         RTPCodecType::Audio,
     );
-    media_engine
-        .register_header_extension(
-            RTCRtpHeaderExtensionCapability {
-                uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
-            },
-            RTPCodecType::Audio,
-            vec![],
-        )
-        .await?;
+    media_engine.register_header_extension(
+        RTCRtpHeaderExtensionCapability {
+            uri: sdp::extmap::TRANSPORT_CC_URI.to_owned(),
+        },
+        RTPCodecType::Audio,
+        vec![],
+    )?;
 
     let receiver = Box::new(Receiver::builder());
     registry.add(receiver);

--- a/src/api/media_engine/media_engine_test.rs
+++ b/src/api/media_engine/media_engine_test.rs
@@ -190,8 +190,7 @@ a=rtpmap:111 opus/48000/2
                 },
                 RTPCodecType::Audio,
                 vec![],
-            )
-            .await?;
+            )?;
         }
 
         m.update_from_remote_description(&must_parse(HEADER_EXTENSIONS)?)
@@ -531,8 +530,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             },
             RTPCodecType::Audio,
             vec![],
-        )
-        .await?;
+        )?;
 
         let params = m
             .get_rtp_parameters_by_kind(
@@ -554,8 +552,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             },
             RTPCodecType::Audio,
             vec![RTCRtpTransceiverDirection::Recvonly],
-        )
-        .await?;
+        )?;
 
         let params = m
             .get_rtp_parameters_by_kind(
@@ -577,8 +574,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             },
             RTPCodecType::Audio,
             vec![RTCRtpTransceiverDirection::Sendonly],
-        )
-        .await?;
+        )?;
 
         let params = m
             .get_rtp_parameters_by_kind(
@@ -595,44 +591,38 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
         let mut m = MediaEngine::default();
         register_codec(&mut m)?;
 
-        let result = m
-            .register_header_extension(
-                RTCRtpHeaderExtensionCapability {
-                    uri: "webrtc-header-test".to_owned(),
-                },
-                RTPCodecType::Audio,
-                vec![RTCRtpTransceiverDirection::Sendrecv],
-            )
-            .await;
+        let result = m.register_header_extension(
+            RTCRtpHeaderExtensionCapability {
+                uri: "webrtc-header-test".to_owned(),
+            },
+            RTPCodecType::Audio,
+            vec![RTCRtpTransceiverDirection::Sendrecv],
+        );
         if let Err(err) = result {
             assert_eq!(Error::ErrRegisterHeaderExtensionInvalidDirection, err);
         } else {
             assert!(false);
         }
 
-        let result = m
-            .register_header_extension(
-                RTCRtpHeaderExtensionCapability {
-                    uri: "webrtc-header-test".to_owned(),
-                },
-                RTPCodecType::Audio,
-                vec![RTCRtpTransceiverDirection::Inactive],
-            )
-            .await;
+        let result = m.register_header_extension(
+            RTCRtpHeaderExtensionCapability {
+                uri: "webrtc-header-test".to_owned(),
+            },
+            RTPCodecType::Audio,
+            vec![RTCRtpTransceiverDirection::Inactive],
+        );
         if let Err(err) = result {
             assert_eq!(Error::ErrRegisterHeaderExtensionInvalidDirection, err);
         } else {
             assert!(false);
         }
-        let result = m
-            .register_header_extension(
-                RTCRtpHeaderExtensionCapability {
-                    uri: "webrtc-header-test".to_owned(),
-                },
-                RTPCodecType::Audio,
-                vec![RTCRtpTransceiverDirection::Unspecified],
-            )
-            .await;
+        let result = m.register_header_extension(
+            RTCRtpHeaderExtensionCapability {
+                uri: "webrtc-header-test".to_owned(),
+            },
+            RTPCodecType::Audio,
+            vec![RTCRtpTransceiverDirection::Unspecified],
+        );
         if let Err(err) = result {
             assert_eq!(Error::ErrRegisterHeaderExtensionInvalidDirection, err);
         } else {
@@ -724,8 +714,7 @@ async fn test_update_header_extenstion_to_cloned_media_engine() -> Result<()> {
         },
         RTPCodecType::Audio,
         vec![],
-    )
-    .await?;
+    )?;
 
     validate(&m).await?;
     validate(&m.clone_to()).await?;

--- a/src/api/media_engine/mod.rs
+++ b/src/api/media_engine/mod.rs
@@ -414,7 +414,7 @@ impl MediaEngine {
 
     /// register_header_extension adds a header extension to the MediaEngine
     /// To determine the negotiated value use `GetHeaderExtensionID` after signaling is complete
-    pub async fn register_header_extension(
+    pub fn register_header_extension(
         &mut self,
         extension: RTCRtpHeaderExtensionCapability,
         typ: RTPCodecType,


### PR DESCRIPTION
This changed when transitioning to 0.3, was wondering if we can revert to this not being async, it doesn't seem necessary, but I might be mistaken.