### PR TITLE
Make RTCIceCandidateInit conform to WebRTC spec

### DIFF
--- a/src/ice_transport/ice_candidate.rs
+++ b/src/ice_transport/ice_candidate.rs
@@ -175,3 +175,45 @@ pub struct RTCIceCandidateInit {
     pub sdp_mline_index: Option<u16>,
     pub username_fragment: Option<String>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ice_candidate_serialization() {
+        let tests = vec![
+            (
+                RTCIceCandidateInit {
+                    candidate: "candidate:abc123".to_string(),
+                    sdp_mid: Some("0".to_string()),
+                    sdp_mline_index: Some(0),
+                    username_fragment: Some("def".to_string()),
+                },
+                r#"{"candidate":"candidate:abc123","sdpMid":"0","sdpMLineIndex":0,"usernameFragment":"def"}"#,
+            ),
+            (
+                RTCIceCandidateInit {
+                    candidate: "candidate:abc123".to_string(),
+                    sdp_mid: None,
+                    sdp_mline_index: None,
+                    username_fragment: None,
+                },
+                r#"{"candidate":"candidate:abc123","sdpMid":null,"sdpMLineIndex":null,"usernameFragment":null}"#,
+            ),
+        ];
+
+        for (candidate_init, expected_string) in tests {
+            let result = serde_json::to_string(&candidate_init);
+            assert!(result.is_ok(), "testCase: marshal err: {:?}", result);
+            let candidate_data = result.unwrap();
+            assert_eq!(candidate_data, expected_string, "string is not expected");
+
+            let result = serde_json::from_str::<RTCIceCandidateInit>(&candidate_data);
+            assert!(result.is_ok(), "testCase: unmarshal err: {:?}", result);
+            if let Ok(actual_candidate_init) = result {
+                assert_eq!(candidate_init, actual_candidate_init);
+            }
+        }
+    }
+}

--- a/src/ice_transport/ice_candidate.rs
+++ b/src/ice_transport/ice_candidate.rs
@@ -148,9 +148,9 @@ impl RTCIceCandidate {
 
         Ok(RTCIceCandidateInit {
             candidate: format!("candidate:{}", candidate.marshal()),
-            sdp_mid: "".to_owned(),
-            sdp_mline_index: 0u16,
-            username_fragment: "".to_owned(),
+            sdp_mid: Some("".to_owned()),
+            sdp_mline_index: Some(0u16),
+            username_fragment: None,
         })
     }
 }
@@ -167,9 +167,11 @@ impl fmt::Display for RTCIceCandidate {
 
 /// ICECandidateInit is used to serialize ice candidates
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RTCIceCandidateInit {
     pub candidate: String,
-    pub sdp_mid: String,
-    pub sdp_mline_index: u16,
-    pub username_fragment: String,
+    pub sdp_mid: Option<String>,
+    #[serde(rename = "sdpMLineIndex")]
+    pub sdp_mline_index: Option<u16>,
+    pub username_fragment: Option<String>,
 }


### PR DESCRIPTION
The names of the `RTCIceCandidateInit` fields when serializing/deserializing are changed to match the names in the WebRTC specification ([link](https://www.w3.org/TR/webrtc/#dom-rtcicecandidateinit)). Three of the fields are also made optional(/nullable) according to the specification.

Without these changes one gets exceptions when interacting with other WebRTC implementations (when serializing/deserializing the candidate data using the `RTCIceCandidateInit` struct).

I'm unsure about what values to use when creating the new `RTCIceCandidateInit` in the `to_json` function. The WebRTC specification only specifies that at least one of the `sdpMid` and `sdpMLineIndex` fields must be set.
Currently the values are set in the same way as the pion implementation (`usernameFragment` set to null):
https://github.com/pion/webrtc/blob/980a56db7370171a20fa689a612169588ece6a11/icecandidate.go#L154

The unit tests are copied from the equivalent pion `RTCIceCandidateInit` struct unit tests: https://github.com/pion/webrtc/blob/980a56db7370171a20fa689a612169588ece6a11/icecandidateinit_test.go#L10