### PR TITLE
Fix RTP extension id collision

### DIFF
--- a/src/api/media_engine/media_engine_test.rs
+++ b/src/api/media_engine/media_engine_test.rs
@@ -809,6 +809,8 @@ a=rtpmap:111 opus/48000/2
         .find(|ext| ext.uri == "urn:3gpp:video-orientation")
         .unwrap();
     assert_ne!(orientation.id, 1);
+    assert_ne!(orientation.id, 7);
+    assert_ne!(orientation.id, 5);
 
     Ok(())
 }

--- a/src/api/media_engine/mod.rs
+++ b/src/api/media_engine/mod.rs
@@ -76,7 +76,7 @@ pub struct MediaEngine {
     pub(crate) negotiated_audio_codecs: Mutex<Vec<RTCRtpCodecParameters>>,
 
     header_extensions: Vec<MediaEngineHeaderExtension>,
-    pub(crate) proposed_header_extensions: Mutex<HashMap<isize, MediaEngineHeaderExtension>>,
+    proposed_header_extensions: Mutex<HashMap<isize, MediaEngineHeaderExtension>>,
     pub(crate) negotiated_header_extensions: Mutex<HashMap<isize, MediaEngineHeaderExtension>>,
 }
 
@@ -674,7 +674,7 @@ impl MediaEngine {
                     n_ext.1.is_audio |= typ == RTPCodecType::Audio;
                 } else {
                     let nid = n_ext.0;
-                    log::warn!("Invalid ext id mapping in update_header_extension. {extension} was negotiated as {nid}, but was {id} in call");
+                    log::warn!("Invalid ext id mapping in update_header_extension. {} was negotiated as {}, but was {} in call", extension, nid, id);
                 }
             } else {
                 // We either only have a proposal or we have neither proposal nor a negotiated id
@@ -682,7 +682,7 @@ impl MediaEngine {
 
                 if let Some(prev_ext) = negotiated_header_extensions.get(&id) {
                     let prev_uri = &prev_ext.uri;
-                    log::warn!("Assigning {id} to {extension} would override previous assignment to {prev_uri}, no action taken");
+                    log::warn!("Assigning {} to {} would override previous assignment to {}, no action taken", id, extension, prev_uri);
                 } else {
                     let h = MediaEngineHeaderExtension {
                         uri: extension.to_owned(),
@@ -861,7 +861,7 @@ impl MediaEngine {
                         !negotiated_header_extensions.keys().any(|nid| nid == id)
                             && !proposed_header_extensions.keys().any(|pid| pid == id)
                     })
-                    .nth(0);
+                    .next();
 
                 if let Some(id) = id {
                     proposed_header_extensions.insert(

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,6 +200,11 @@ pub enum Error {
     #[error("a header extension must be registered as 'recvonly', 'sendonly' or both")]
     ErrRegisterHeaderExtensionInvalidDirection,
 
+    /// ErrRegisterHeaderExtensionNoFreeID indicates that there was no extension ID available which
+    /// in turn means that all 15 available id(1 through 14) have been used.
+    #[error("no header extension ID was free to use(this means the maximum of 15 extensions have been registered)")]
+    ErrRegisterHeaderExtensionNoFreeID,
+
     /// ErrSimulcastProbeOverflow indicates that too many Simulcast probe streams are in flight and the requested SSRC was ignored
     #[error("simulcast probe limit has been reached, new SSRC has been discarded")]
     ErrSimulcastProbeOverflow,


### PR DESCRIPTION
Fixes an issue where we would incorrectly map a given RTP extension ID to more than a single extension URI e.g. we'd map the id `3` to `urn:ietf:params:rtp-hdrext:sdes:mid` for an audio stream, but then map it `urn:3gpp:video-orientation` for a video stream negotiated later.

In this fix I've introduced a new field `propsed_header_extensions` which keeps track of the mappings from id to extension URI we have proposed but haven't yet negotiated completely. `header_extension` is no longer used to generate the `id` we assign a given extension.

In pseudo code here's what happens when we generate extensions.

```
# Params
# typ the stream type i.e. audio or video
# direction the stream direction 

if stream_type_negotiated(typ)
  // Use negotiated mappings from negotiated_header_extensions as before
else
  for local_extension in header_extensions
    if not_relevant(local_extension, typ, direction)
      continue
    end
    
    negotiated_extension = find_negotiated_extension(
      local_extension.uri, negotiated_header_extensions
    )
    
    # If we have already negotiated an extension id for this extension URI before use that.
    # This can happen if we negotiate e.g. an audio track and are now negotiating 
    # the first video track, in which case we want to use the previously agreed id.
    if negotiated_extension      
      add_to_output(negotiated_extension)

      continue
    end
    
    proposed_extension = find_proposed_extension(
      local_extension.uri, proposed_header_extensions
    )
    
    # If we have already proposed an extension id for the this extension we should re-use it.
    # This can happen e.g. if we proposed an extension for an audio stream but the peer didn't
    # support it. We should re-use the same id when proposing it for the video stream. 
    if proposed_extension
      add_to_output(proposed_extension)
      
      continue
    end
    
    # Lastly, if we haven't negotiated or proposed this extension yet we must
    # generate an id to propose. This ID cannot be an id we are already proposing or
    # have negotiated.
    id = find_free_id(
      local_extension, proposed_header_extensions, negotiated_header_extensions
    )
    
    if id
      proposed = add_proposed_header_extension(id, local_extension)
      
      add_to_output(proposed)
    else
      # We have exhausted all 15 possible IDs, log a warning and do nothing
    end
  end
end

```

And when updating from a remote answer or offer:


```
# Params
# extension The URI of the extension we are updating
# id The id suggested for the extension we are updating
# typ the stream type i.e. audio or video

# We only consider extension we've said we support.
for local_extension in header_extensions
  if local_extension.uri != extension
    continue
  end
  
  negotiated_extension = find_negotiated_extension(
      extension, negotiated_header_extensions
  )
  
  if negotiated_extension
    # We already have a negotiated extension ID for this extension
    if id == negotiated_extension.id
      # All good, the peer suggested the same extension id that we had.
      mark_active_for_current_type(negotiated_extension)
    else
      # Log an error, the peer changed the id of an extension that we have already negotiated
    end
  else
    # This is either the response to an extension id we proposed or a mapping the peer is 
    # suggesting. Accept it if we can
    prev_ext = negotiated_header_extensions[id]
    
    if prev_ext
      if prev_ext.uri != extension
        # This ID was already negotiated, log  warning
      end
    else
      # Accept the peer's suggestion
      mark_negotiated(id, extension, typ, negotiated_header_extensions)
    end
  end
  
  # Clear any previous proposal for this id
  proposed_header_extensions[id] = nil
end
```