### PR TITLE
always start sctp

### DIFF
--- a/src/dtls_transport/mod.rs
+++ b/src/dtls_transport/mod.rs
@@ -415,32 +415,30 @@ impl RTCDtlsTransport {
             };
         }
 
-        if self
+        if !self
             .setting_engine
             .disable_certificate_fingerprint_verification
         {
-            return Ok(());
-        }
-
-        // Check the fingerprint if a certificate was exchanged
-        let remote_certs = &dtls_conn.connection_state().await.peer_certificates;
-        if remote_certs.is_empty() {
-            self.state_change(RTCDtlsTransportState::Failed).await;
-            return Err(Error::ErrNoRemoteCertificate);
-        }
-
-        {
-            let mut remote_certificate = self.remote_certificate.lock().await;
-            *remote_certificate = Bytes::from(remote_certs[0].clone());
-        }
-
-        if let Err(err) = self.validate_fingerprint(&remote_certs[0]).await {
-            if dtls_conn.close().await.is_err() {
-                log::error!("{}", err);
+            // Check the fingerprint if a certificate was exchanged
+            let remote_certs = &dtls_conn.connection_state().await.peer_certificates;
+            if remote_certs.is_empty() {
+                self.state_change(RTCDtlsTransportState::Failed).await;
+                return Err(Error::ErrNoRemoteCertificate);
             }
 
-            self.state_change(RTCDtlsTransportState::Failed).await;
-            return Err(err);
+            {
+                let mut remote_certificate = self.remote_certificate.lock().await;
+                *remote_certificate = Bytes::from(remote_certs[0].clone());
+            }
+
+            if let Err(err) = self.validate_fingerprint(&remote_certs[0]).await {
+                if dtls_conn.close().await.is_err() {
+                    log::error!("{}", err);
+                }
+
+                self.state_change(RTCDtlsTransportState::Failed).await;
+                return Err(err);
+            }
         }
 
         {


### PR DESCRIPTION
Fixes a bug where if you set
`disable_certificate_fingerprint_verification` to true via
`SettingEngine`, even though DTLS handshake is completed, SCTP does not
start. As you can see, this was due to the code returning `Ok(())`
without changing the state and starting the sctp.