### PR TITLE
Get stats from peer connection

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -26,8 +26,8 @@ use data_channel_state::RTCDataChannelState;
 use crate::api::setting_engine::SettingEngine;
 use crate::error::{Error, OnErrorHdlrFn, Result};
 use crate::sctp_transport::RTCSctpTransport;
-use crate::stats::{StatsReportType, DataChannelStats};
 use crate::stats::stats_collector::StatsCollector;
+use crate::stats::{DataChannelStats, StatsReportType};
 
 /// message size limit for Chromium
 const DATA_CHANNEL_BUFFER_SIZE: u16 = u16::MAX;

--- a/src/ice_transport/ice_gatherer.rs
+++ b/src/ice_transport/ice_gatherer.rs
@@ -7,6 +7,7 @@ use crate::ice_transport::ice_parameters::RTCIceParameters;
 use crate::ice_transport::ice_server::RTCIceServer;
 use crate::peer_connection::policy::ice_transport_policy::RTCIceTransportPolicy;
 use crate::stats::stats_collector::StatsCollector;
+use crate::stats::SourceStatsType::*;
 use crate::stats::StatsReportType;
 
 use ice::agent::Agent;
@@ -316,15 +317,15 @@ impl RTCIceGatherer {
                 let mut reports = vec![];
 
                 for stats in agent.get_candidate_pairs_stats().await {
-                    reports.push(StatsReportType::from(stats));
+                    reports.push(StatsReportType::from(CandidatePair(stats)));
                 }
 
                 for stats in agent.get_local_candidates_stats().await {
-                    reports.push(StatsReportType::from(stats));
+                    reports.push(StatsReportType::from(LocalCandidate(stats)));
                 }
 
                 for stats in agent.get_remote_candidates_stats().await {
-                    reports.push(StatsReportType::from(stats));
+                    reports.push(StatsReportType::from(RemoteCandidate(stats)));
                 }
 
                 let mut lock = collector.try_lock().unwrap();

--- a/src/ice_transport/ice_gatherer.rs
+++ b/src/ice_transport/ice_gatherer.rs
@@ -6,6 +6,7 @@ use crate::ice_transport::ice_gatherer_state::RTCIceGathererState;
 use crate::ice_transport::ice_parameters::RTCIceParameters;
 use crate::ice_transport::ice_server::RTCIceServer;
 use crate::peer_connection::policy::ice_transport_policy::RTCIceTransportPolicy;
+use crate::stats::stats_collector::StatsCollector;
 
 use ice::agent::Agent;
 use ice::candidate::{Candidate, CandidateType};
@@ -16,6 +17,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use waitgroup::Worker;
 
 /// ICEGatherOptions provides options relating to the gathering of ICE candidates.
 #[derive(Default, Debug, Clone)]
@@ -302,6 +304,11 @@ impl RTCIceGatherer {
         agent.clone()
     }
 
+    pub(crate) fn collect_stats(&self, collector: &Arc<Mutex<StatsCollector>>, worker: Worker) {
+        tokio::spawn(async move {
+            drop(worker);
+        });
+    }
     /*TODO:func (g *ICEGatherer) collectStats(collector *statsReportCollector) {
 
         agent := g.getAgent()

--- a/src/ice_transport/mod.rs
+++ b/src/ice_transport/mod.rs
@@ -334,7 +334,7 @@ impl RTCIceTransport {
         let mut internal = self.internal.lock().await;
         if let Some(_conn) = internal.conn.take() {
             let collector = collector.clone();
-            let stats = ICETransportStats::new();
+            let stats = ICETransportStats::new("ice_transport".to_owned());
             // TODO: get bytes out of Conn.
             // bytes_received: conn.bytes_received,
             // bytes_sent: conn.bytes_sent,

--- a/src/ice_transport/mod.rs
+++ b/src/ice_transport/mod.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use ice::candidate::Candidate;
 use ice::state::ConnectionState;
 use tokio::sync::{mpsc, Mutex};
-use tokio::time::Instant;
 use util::Conn;
 
 use ice_candidate::RTCIceCandidate;
@@ -335,13 +334,10 @@ impl RTCIceTransport {
         let mut internal = self.internal.lock().await;
         if let Some(_conn) = internal.conn.take() {
             let collector = collector.clone();
-            let stats = ICETransportStats {
-                timestamp: Instant::now(),
-                id: "ice_transport".to_owned(),
-                // TODO: get bytes out of Conn.
-                // bytes_received: conn.bytes_received,
-                // bytes_sent: conn.bytes_sent,
-            };
+            let stats = ICETransportStats::new();
+            // TODO: get bytes out of Conn.
+            // bytes_received: conn.bytes_received,
+            // bytes_sent: conn.bytes_sent,
 
             let mut lock = collector.try_lock().unwrap();
             lock.push(Transport(stats));

--- a/src/peer_connection/certificate.rs
+++ b/src/peer_connection/certificate.rs
@@ -1,14 +1,13 @@
 use crate::dtls_transport::dtls_fingerprint::RTCDtlsFingerprint;
 use crate::error::{Error, Result};
 use crate::peer_connection::math_rand_alpha;
-use crate::stats::{CertificateStats, StatsReportType};
 use crate::stats::stats_collector::StatsCollector;
+use crate::stats::{CertificateStats, StatsReportType};
 
 use dtls::crypto::{CryptoPrivateKey, CryptoPrivateKeyKind};
 use rcgen::{CertificateParams, KeyPair, RcgenError};
 use ring::signature::{EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 use sha2::{Digest, Sha256};
-use tokio::time::Instant;
 use std::ops::Add;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -167,29 +166,6 @@ impl RTCCertificate {
         RTCCertificate::from_params(params)
     }
 
-    pub(crate) async fn collect_stats(
-        &self,
-        collector: &Arc<Mutex<StatsCollector>>,
-        worker: Worker,
-    ) {
-        let fingerprints = self.get_fingerprints().unwrap();
-        if let Some(fingerprint) = fingerprints.into_iter().nth(0) {
-            let stats = CertificateStats {
-                timestamp: Instant::now(),
-                id: self.stats_id.clone(),
-                // base64_certificate
-                fingerprint: fingerprint.value,
-                fingerprint_algorithm: fingerprint.algorithm,
-                // issuer_certificate_id
-
-            };
-            let mut lock = collector.try_lock().unwrap();
-            lock.push(StatsReportType::CertificateStats(stats));
-
-            drop(worker);
-        }
-    }
-
     /*TODO:
     // CertificateFromX509 creates a new WebRTC Certificate from a given PrivateKey and Certificate
     //
@@ -197,7 +173,24 @@ impl RTCCertificate {
     func CertificateFromX509(privateKey crypto.PrivateKey, certificate *x509.Certificate) Certificate {
         return Certificate{privateKey, certificate, fmt.Sprintf("certificate-%d", time.Now().UnixNano())}
     }
+    */
 
+    pub(crate) async fn collect_stats(
+        &self,
+        collector: &Arc<Mutex<StatsCollector>>,
+        worker: Worker,
+    ) {
+        let fingerprints = self.get_fingerprints().unwrap();
+        if let Some(fingerprint) = fingerprints.into_iter().nth(0) {
+            let stats = CertificateStats::new(self, fingerprint);
+            let mut lock = collector.try_lock().unwrap();
+            lock.push(StatsReportType::CertificateStats(stats));
+
+            drop(worker);
+        }
+    }
+
+    /*
     func (c Certificate) collectStats(report *statsReportCollector) error {
         report.Collecting()
 

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1986,7 +1986,10 @@ impl RTCPeerConnection {
     }
 
     pub async fn get_stats(&self) -> StatsReport {
-        self.internal.get_stats(self.get_stats_id().to_owned()).await.into()
+        self.internal
+            .get_stats(self.get_stats_id().to_owned())
+            .await
+            .into()
     }
     // GetStats return data providing statistics about the overall connection
     /*TODO: func (pc *PeerConnection) GetStats() StatsReport {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1986,7 +1986,7 @@ impl RTCPeerConnection {
     }
 
     pub async fn get_stats(&self) -> StatsReport {
-        self.internal.get_stats().await.into()
+        self.internal.get_stats(self.get_stats_id().to_owned()).await.into()
     }
     // GetStats return data providing statistics about the overall connection
     /*TODO: func (pc *PeerConnection) GetStats() StatsReport {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -64,6 +64,7 @@ use crate::rtp_transceiver::{RTCRtpTransceiverInit, SSRC};
 use crate::sctp_transport::sctp_transport_capabilities::SCTPTransportCapabilities;
 use crate::sctp_transport::sctp_transport_state::RTCSctpTransportState;
 use crate::sctp_transport::RTCSctpTransport;
+use crate::stats::StatsReport;
 use crate::track::track_local::track_local_static_sample::TrackLocalStaticSample;
 use crate::track::track_local::TrackLocal;
 use crate::track::track_remote::TrackRemote;
@@ -1984,6 +1985,9 @@ impl RTCPeerConnection {
             .into()
     }
 
+    pub async fn get_stats(&self) -> StatsReport {
+        self.internal.get_stats().await.into()
+    }
     // GetStats return data providing statistics about the overall connection
     /*TODO: func (pc *PeerConnection) GetStats() StatsReport {
         var (

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1327,6 +1327,9 @@ impl PeerConnectionInternal {
             self.ice_gatherer.collect_stats(&collector, wg.worker()),
             self.ice_transport.collect_stats(&collector, wg.worker()),
             self.sctp_transport.collect_stats(&collector, wg.worker()),
+            self.dtls_transport.collect_stats(&collector, wg.worker()),
+            // TODO: data channels
+            // TODO: media engine
         );
 
         wg.wait().await;

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1328,7 +1328,6 @@ impl PeerConnectionInternal {
             self.ice_transport.collect_stats(&collector, wg.worker()),
             self.sctp_transport.collect_stats(&collector, wg.worker()),
             self.dtls_transport.collect_stats(&collector, wg.worker()),
-            // TODO: data channels
             self.media_engine.collect_stats(&collector, wg.worker()),
         );
 

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1320,10 +1320,14 @@ impl PeerConnectionInternal {
     }
 
     pub(super) async fn get_stats(&self) -> Arc<Mutex<StatsCollector>> {
-        let mut collector = Arc::new(Mutex::new(StatsCollector::new()));
+        let collector = Arc::new(Mutex::new(StatsCollector::new()));
         let wg = WaitGroup::new();
 
-        tokio::join!(self.ice_gatherer.collect_stats(&mut collector, wg.worker()));
+        tokio::join!(
+            self.ice_gatherer.collect_stats(&collector, wg.worker()),
+            self.ice_transport
+                .collect_stats(&collector, wg.worker()),
+        );
 
         wg.wait().await;
         collector

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1326,7 +1326,8 @@ impl PeerConnectionInternal {
         tokio::join!(
             self.ice_gatherer.collect_stats(&collector, wg.worker()),
             self.ice_transport.collect_stats(&collector, wg.worker()),
-            self.sctp_transport.collect_stats(&collector, wg.worker(), stats_id),
+            self.sctp_transport
+                .collect_stats(&collector, wg.worker(), stats_id),
             self.dtls_transport.collect_stats(&collector, wg.worker()),
             self.media_engine.collect_stats(&collector, wg.worker()),
         );

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1323,7 +1323,7 @@ impl PeerConnectionInternal {
         let mut collector = Arc::new(Mutex::new(StatsCollector::new()));
         let wg = WaitGroup::new();
 
-        self.ice_gatherer.collect_stats(&mut collector, wg.worker());
+        tokio::join!(self.ice_gatherer.collect_stats(&mut collector, wg.worker()));
 
         wg.wait().await;
         collector

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1329,7 +1329,7 @@ impl PeerConnectionInternal {
             self.sctp_transport.collect_stats(&collector, wg.worker()),
             self.dtls_transport.collect_stats(&collector, wg.worker()),
             // TODO: data channels
-            // TODO: media engine
+            self.media_engine.collect_stats(&collector, wg.worker()),
         );
 
         wg.wait().await;

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1325,8 +1325,8 @@ impl PeerConnectionInternal {
 
         tokio::join!(
             self.ice_gatherer.collect_stats(&collector, wg.worker()),
-            self.ice_transport
-                .collect_stats(&collector, wg.worker()),
+            self.ice_transport.collect_stats(&collector, wg.worker()),
+            self.sctp_transport.collect_stats(&collector, wg.worker()),
         );
 
         wg.wait().await;

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -1319,14 +1319,14 @@ impl PeerConnectionInternal {
         false
     }
 
-    pub(super) async fn get_stats(&self) -> Arc<Mutex<StatsCollector>> {
+    pub(super) async fn get_stats(&self, stats_id: String) -> Arc<Mutex<StatsCollector>> {
         let collector = Arc::new(Mutex::new(StatsCollector::new()));
         let wg = WaitGroup::new();
 
         tokio::join!(
             self.ice_gatherer.collect_stats(&collector, wg.worker()),
             self.ice_transport.collect_stats(&collector, wg.worker()),
-            self.sctp_transport.collect_stats(&collector, wg.worker()),
+            self.sctp_transport.collect_stats(&collector, wg.worker(), stats_id),
             self.dtls_transport.collect_stats(&collector, wg.worker()),
             self.media_engine.collect_stats(&collector, wg.worker()),
         );

--- a/src/sctp_transport/mod.rs
+++ b/src/sctp_transport/mod.rs
@@ -16,8 +16,8 @@ use crate::dtls_transport::*;
 use crate::error::*;
 use crate::sctp_transport::sctp_transport_capabilities::SCTPTransportCapabilities;
 use crate::stats::stats_collector::StatsCollector;
-use crate::stats::{ICETransportStats, PeerConnectionStats};
 use crate::stats::StatsReportType::{PeerConnection, SCTPTransport};
+use crate::stats::{ICETransportStats, PeerConnectionStats};
 
 use data::message::message_channel_open::ChannelType;
 use sctp::association::Association;
@@ -364,7 +364,11 @@ impl RTCSctpTransport {
         }
 
         let mut reports = vec![];
-        reports.push(PeerConnection(PeerConnectionStats::new(self, peer_connection_id, data_channels_closed)));
+        reports.push(PeerConnection(PeerConnectionStats::new(
+            self,
+            peer_connection_id,
+            data_channels_closed,
+        )));
 
         // conn
         if let Some(_net_conn) = dtls_transport.conn().await {

--- a/src/sctp_transport/mod.rs
+++ b/src/sctp_transport/mod.rs
@@ -342,6 +342,7 @@ impl RTCSctpTransport {
         &self,
         collector: &Arc<Mutex<StatsCollector>>,
         worker: Worker,
+        peer_connection_id: String,
     ) {
         let dtls_transport = self.transport();
 
@@ -363,7 +364,7 @@ impl RTCSctpTransport {
         }
 
         let mut reports = vec![];
-        reports.push(PeerConnection(PeerConnectionStats::new(self, data_channels_closed)));
+        reports.push(PeerConnection(PeerConnectionStats::new(self, peer_connection_id, data_channels_closed)));
 
         // conn
         if let Some(_net_conn) = dtls_transport.conn().await {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -43,7 +43,7 @@ impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
 
 pub struct ICECandidatePairStats {
     timestamp: Instant,
-    // id: String,
+    id: String,
     local_candidate_id: String,
     remote_candidate_id: String,
     state: CandidatePairState,
@@ -74,6 +74,7 @@ impl From<CandidatePairStats> for ICECandidatePairStats {
     fn from(stats: CandidatePairStats) -> Self {
         ICECandidatePairStats {
             timestamp: stats.timestamp,
+            id: format!("{}-{}", stats.local_candidate_id, stats.remote_candidate_id),
             local_candidate_id: stats.local_candidate_id,
             remote_candidate_id: stats.remote_candidate_id,
             state: stats.state,
@@ -104,7 +105,7 @@ impl From<CandidatePairStats> for ICECandidatePairStats {
 
 pub struct ICECandidateStats {
     timestamp: Instant,
-    // id: String,
+    id: String,
     candidate_type: CandidateType,
     deleted: bool,
     ip: String,
@@ -119,7 +120,7 @@ impl From<CandidateStats> for ICECandidateStats {
     fn from(stats: CandidateStats) -> Self {
         ICECandidateStats {
             timestamp: stats.timestamp,
-            // id: String,
+            id: stats.id,
             network_type: stats.network_type,
             ip: stats.ip,
             port: stats.port,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -262,7 +262,7 @@ impl From<&RTCDataChannel> for DataChannelStats {
 
 pub struct PeerConnectionStats {
     timestamp: Instant,
-    // id: String,
+    id: String,
     data_channels_accepted: u32,
     data_channels_closed: u32,
     data_channels_opened: u32,
@@ -270,10 +270,10 @@ pub struct PeerConnectionStats {
 }
 
 impl PeerConnectionStats {
-    pub fn new(transport: &RTCSctpTransport, data_channels_closed: u32) -> Self {
+    pub fn new(transport: &RTCSctpTransport, stats_id: String, data_channels_closed: u32) -> Self {
         PeerConnectionStats {
             timestamp: Instant::now(),
-            // id: transport.stats_id.clone(), // TODO: pass this into sctp_transport.collect_stats ?
+            id: stats_id,
             data_channels_accepted: transport.data_channels_accepted(),
             data_channels_opened: transport.data_channels_opened(),
             data_channels_requested: transport.data_channels_requested(),

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,3 +1,6 @@
+use crate::dtls_transport::dtls_fingerprint::RTCDtlsFingerprint;
+use crate::peer_connection::certificate::RTCCertificate;
+
 use ice::agent::agent_stats::{CandidatePairStats, CandidateStats};
 use ice::candidate::{CandidatePairState, CandidateType};
 use ice::network_type::NetworkType;
@@ -158,11 +161,23 @@ impl ICETransportStats {
 }
 
 pub struct CertificateStats {
-    pub timestamp: Instant,
-    pub id: String,
+    timestamp: Instant,
+    id: String,
     // base64_certificate: String,
-    pub fingerprint: String,
-    pub fingerprint_algorithm: String,
+    fingerprint: String,
+    fingerprint_algorithm: String,
     // issuer_certificate_id: String,
 }
 
+impl CertificateStats {
+    pub(crate) fn new(cert: &RTCCertificate, fingerprint: RTCDtlsFingerprint) -> Self {
+        CertificateStats {
+            timestamp: Instant::now(),
+            id: cert.stats_id.clone(),
+            // TODO: base64_certificate
+            fingerprint: fingerprint.value,
+            fingerprint_algorithm: fingerprint.algorithm,
+            // TODO: issuer_certificate_id
+        }
+    }
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,3 +1,4 @@
+use ice::agent::agent_stats::{CandidatePairStats, CandidateStats};
 use stats_collector::StatsCollector;
 
 use std::sync::Arc;
@@ -25,6 +26,22 @@ pub enum StatsType {
     Transport,
 }
 
+pub enum StatsReportType {
+  StatsType(ICECandidatePairStats),
+}
+
+impl From<CandidatePairStats> for StatsReportType {
+    fn from(stats: CandidatePairStats) -> Self {
+       StatsReportType::StatsType(stats.into())
+    }
+}
+
+impl From<CandidateStats> for StatsReportType {
+    fn from(stats: CandidateStats) -> Self {
+       StatsReportType::StatsType(stats.into())
+    }
+}
+
 pub struct StatsReport {}
 
 impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
@@ -33,3 +50,16 @@ impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
     }
 }
 
+pub struct ICECandidatePairStats {}
+
+impl From<CandidatePairStats> for ICECandidatePairStats {
+    fn from(_stats: CandidatePairStats) -> Self {
+        ICECandidatePairStats {}
+    }
+}
+
+impl From<CandidateStats> for ICECandidatePairStats {
+    fn from(_stats: CandidateStats) -> Self {
+        ICECandidatePairStats {}
+    }
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -135,8 +135,17 @@ impl From<CandidateStats> for ICECandidateStats {
 }
 
 pub struct ICETransportStats {
-    pub timestamp: Instant,
-    pub id: String,
+    timestamp: Instant,
+    id: String,
     // bytes_received: u64,
     // bytes_sent: u64,
+}
+
+impl ICETransportStats {
+    pub(crate) fn new() -> Self {
+        ICETransportStats {
+            timestamp: Instant::now(),
+            id: "ice_transport".to_owned(),
+        }
+    }
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -19,6 +19,7 @@ pub enum StatsReportType {
     CandidatePair(ICECandidatePairStats),
     LocalCandidate(ICECandidateStats),
     RemoteCandidate(ICECandidateStats),
+    SCTPTransport(ICETransportStats),
     Transport(ICETransportStats),
 }
 
@@ -42,8 +43,13 @@ impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
     }
 }
 
+// TODO: should timestamps be cast here, or during serialization?
+// func statsTimestampFrom(t time.Time) StatsTimestamp {
+// 	return StatsTimestamp(t.UnixNano() / int64(time.Millisecond))
+// }
+
 pub struct ICECandidatePairStats {
-    timestamp: Instant,
+    timestamp: Instant, // StatsTimestamp
     id: String,
     local_candidate_id: String,
     remote_candidate_id: String,
@@ -53,10 +59,10 @@ pub struct ICECandidatePairStats {
     packets_received: u32,
     bytes_sent: u64,
     bytes_received: u64,
-    last_packet_sent_timestamp: Instant,
-    last_packet_received_timstamp: Instant,
-    first_request_timestamp: Instant,
-    last_request_timestamp: Instant,
+    last_packet_sent_timestamp: Instant,    // statsTimestampFrom
+    last_packet_received_timstamp: Instant, // statsTimestampFrom
+    first_request_timestamp: Instant,       // statsTimestampFrom
+    last_request_timestamp: Instant,        // statsTimestampFrom
     total_round_trip_time: f64,
     current_round_trip_time: f64,
     available_outgoing_bitrate: f64,
@@ -68,7 +74,7 @@ pub struct ICECandidatePairStats {
     responses_sent: u64,
     retransmissions_sent: u64,
     consent_requests_sent: u64,
-    consent_expired_timestamp: Instant,
+    consent_expired_timestamp: Instant, // statsTimestampFrom
 }
 
 impl From<CandidatePairStats> for ICECandidatePairStats {
@@ -142,10 +148,10 @@ pub struct ICETransportStats {
 }
 
 impl ICETransportStats {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(id: String) -> Self {
         ICETransportStats {
             timestamp: Instant::now(),
-            id: "ice_transport".to_owned(),
+            id: id,
         }
     }
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -49,8 +49,9 @@ impl From<SourceStatsType> for StatsReportType {
 }
 
 // TODO: should this be some form of String-indexed HashMap?
+#[derive(Debug)]
 pub struct StatsReport {
-    reports: Vec<StatsReportType>,
+    pub(crate) reports: Vec<StatsReportType>,
 }
 
 impl From<Arc<Mutex<StatsCollector>>> for StatsReport {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -17,6 +17,7 @@ pub enum SourceStatsType {
 
 pub enum StatsReportType {
     CandidatePair(ICECandidatePairStats),
+    CertificateStats(CertificateStats),
     LocalCandidate(ICECandidateStats),
     RemoteCandidate(ICECandidateStats),
     SCTPTransport(ICETransportStats),
@@ -150,8 +151,18 @@ pub struct ICETransportStats {
 impl ICETransportStats {
     pub(crate) fn new(id: String) -> Self {
         ICETransportStats {
+            id,
             timestamp: Instant::now(),
-            id: id,
         }
     }
 }
+
+pub struct CertificateStats {
+    pub timestamp: Instant,
+    pub id: String,
+    // base64_certificate: String,
+    pub fingerprint: String,
+    pub fingerprint_algorithm: String,
+    // issuer_certificate_id: String,
+}
+

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,5 +1,7 @@
 use crate::dtls_transport::dtls_fingerprint::RTCDtlsFingerprint;
 use crate::peer_connection::certificate::RTCCertificate;
+use crate::rtp_transceiver::PayloadType;
+use crate::rtp_transceiver::rtp_codec::RTCRtpCodecParameters;
 
 use ice::agent::agent_stats::{CandidatePairStats, CandidateStats};
 use ice::candidate::{CandidatePairState, CandidateType};
@@ -21,6 +23,7 @@ pub enum SourceStatsType {
 pub enum StatsReportType {
     CandidatePair(ICECandidatePairStats),
     CertificateStats(CertificateStats),
+    Codec(CodecStats),
     LocalCandidate(ICECandidateStats),
     RemoteCandidate(ICECandidateStats),
     SCTPTransport(ICETransportStats),
@@ -179,5 +182,30 @@ impl CertificateStats {
             fingerprint_algorithm: fingerprint.algorithm,
             // TODO: issuer_certificate_id
         }
+    }
+}
+
+pub struct CodecStats {
+    timestamp: Instant,
+    id: String,
+    payload_type: PayloadType,
+    mime_type: String,
+    clock_rate: u32,
+    channels: u16,
+    sdp_fmtp_line: String,
+}
+
+impl From<&RTCRtpCodecParameters> for CodecStats {
+    fn from(codec: &RTCRtpCodecParameters) -> Self {
+        CodecStats {
+            timestamp: Instant::now(),
+            id: codec.stats_id.clone(),
+            payload_type: codec.payload_type,
+            mime_type: codec.capability.mime_type.clone(),
+            clock_rate: codec.capability.clock_rate,
+            channels: codec.capability.channels,
+            sdp_fmtp_line: codec.capability.sdp_fmtp_line.clone(),
+        }
+
     }
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -48,7 +48,7 @@ impl From<SourceStatsType> for StatsReportType {
     }
 }
 
-// TODO: should this be some form of String-indexed map?
+// TODO: should this be some form of String-indexed HashMap?
 pub struct StatsReport {
     reports: Vec<StatsReportType>,
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -19,6 +19,7 @@ pub enum StatsReportType {
     CandidatePair(ICECandidatePairStats),
     LocalCandidate(ICECandidateStats),
     RemoteCandidate(ICECandidateStats),
+    Transport(ICETransportStats),
 }
 
 impl From<SourceStatsType> for StatsReportType {
@@ -131,4 +132,11 @@ impl From<CandidateStats> for ICECandidateStats {
             deleted: stats.deleted,
         }
     }
+}
+
+pub struct ICETransportStats {
+    pub timestamp: Instant,
+    pub id: String,
+    // bytes_received: u64,
+    // bytes_sent: u64,
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,44 +1,35 @@
 use ice::agent::agent_stats::{CandidatePairStats, CandidateStats};
+use ice::candidate::{CandidatePairState, CandidateType};
+use ice::network_type::NetworkType;
 use stats_collector::StatsCollector;
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 
 pub mod stats_collector;
 
-pub enum StatsType {
-    CSRC,
-    CandidatePair,
-    Certificate,
-    Codec,
-    DataChannel,
-    InboundRTP,
-    LocalCandidate,
-    OutboundRTP,
-    PeerConnection,
-    Receiver,
-    RemoteCandidate,
-    RemoteInboundRTP,
-    RemoteOutboundRTP,
-    Sender,
-    Stream,
-    Track,
-    Transport,
+pub enum SourceStatsType {
+    CandidatePair(CandidatePairStats),
+    LocalCandidate(CandidateStats),
+    RemoteCandidate(CandidateStats),
 }
 
 pub enum StatsReportType {
-  StatsType(ICECandidatePairStats),
+    CandidatePair(ICECandidatePairStats),
+    LocalCandidate(ICECandidateStats),
+    RemoteCandidate(ICECandidateStats),
 }
 
-impl From<CandidatePairStats> for StatsReportType {
-    fn from(stats: CandidatePairStats) -> Self {
-       StatsReportType::StatsType(stats.into())
-    }
-}
-
-impl From<CandidateStats> for StatsReportType {
-    fn from(stats: CandidateStats) -> Self {
-       StatsReportType::StatsType(stats.into())
+impl From<SourceStatsType> for StatsReportType {
+    fn from(stats: SourceStatsType) -> Self {
+        match stats {
+            SourceStatsType::CandidatePair(stats) => StatsReportType::CandidatePair(stats.into()),
+            SourceStatsType::LocalCandidate(stats) => StatsReportType::LocalCandidate(stats.into()),
+            SourceStatsType::RemoteCandidate(stats) => {
+                StatsReportType::RemoteCandidate(stats.into())
+            }
+        }
     }
 }
 
@@ -50,16 +41,93 @@ impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
     }
 }
 
-pub struct ICECandidatePairStats {}
+pub struct ICECandidatePairStats {
+    timestamp: Instant,
+    // id: String,
+    local_candidate_id: String,
+    remote_candidate_id: String,
+    state: CandidatePairState,
+    nominated: bool,
+    packets_sent: u32,
+    packets_received: u32,
+    bytes_sent: u64,
+    bytes_received: u64,
+    last_packet_sent_timestamp: Instant,
+    last_packet_received_timstamp: Instant,
+    first_request_timestamp: Instant,
+    last_request_timestamp: Instant,
+    total_round_trip_time: f64,
+    current_round_trip_time: f64,
+    available_outgoing_bitrate: f64,
+    available_incoming_bitrate: f64,
+    circuit_breaker_trigger_count: u32,
+    requests_received: u64,
+    requests_sent: u64,
+    responses_received: u64,
+    responses_sent: u64,
+    retransmissions_sent: u64,
+    consent_requests_sent: u64,
+    consent_expired_timestamp: Instant,
+}
 
 impl From<CandidatePairStats> for ICECandidatePairStats {
-    fn from(_stats: CandidatePairStats) -> Self {
-        ICECandidatePairStats {}
+    fn from(stats: CandidatePairStats) -> Self {
+        ICECandidatePairStats {
+            timestamp: stats.timestamp,
+            local_candidate_id: stats.local_candidate_id,
+            remote_candidate_id: stats.remote_candidate_id,
+            state: stats.state,
+            nominated: stats.nominated,
+            packets_sent: stats.packets_sent,
+            packets_received: stats.packets_received,
+            bytes_sent: stats.bytes_sent,
+            bytes_received: stats.bytes_received,
+            last_packet_sent_timestamp: stats.last_packet_sent_timestamp,
+            last_packet_received_timstamp: stats.last_packet_received_timestamp,
+            first_request_timestamp: stats.first_request_timestamp,
+            last_request_timestamp: stats.last_request_timestamp,
+            total_round_trip_time: stats.total_round_trip_time,
+            current_round_trip_time: stats.current_round_trip_time,
+            available_outgoing_bitrate: stats.available_outgoing_bitrate,
+            available_incoming_bitrate: stats.available_incoming_bitrate,
+            circuit_breaker_trigger_count: stats.circuit_breaker_trigger_count,
+            requests_received: stats.requests_received,
+            requests_sent: stats.requests_sent,
+            responses_received: stats.responses_received,
+            responses_sent: stats.responses_sent,
+            retransmissions_sent: stats.retransmissions_sent,
+            consent_requests_sent: stats.consent_requests_sent,
+            consent_expired_timestamp: stats.consent_expired_timestamp,
+        }
     }
 }
 
-impl From<CandidateStats> for ICECandidatePairStats {
-    fn from(_stats: CandidateStats) -> Self {
-        ICECandidatePairStats {}
+pub struct ICECandidateStats {
+    timestamp: Instant,
+    // id: String,
+    candidate_type: CandidateType,
+    deleted: bool,
+    ip: String,
+    network_type: NetworkType,
+    port: u16,
+    priority: u32,
+    relay_protocol: String,
+    url: String,
+}
+
+impl From<CandidateStats> for ICECandidateStats {
+    fn from(stats: CandidateStats) -> Self {
+        ICECandidateStats {
+            timestamp: stats.timestamp,
+            // id: String,
+            network_type: stats.network_type,
+            ip: stats.ip,
+            port: stats.port,
+            candidate_type: stats.candidate_type,
+            priority: stats.priority,
+            url: stats.url,
+            relay_protocol: stats.relay_protocol,
+            deleted: stats.deleted,
+        }
     }
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,1 +1,35 @@
+use stats_collector::StatsCollector;
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub mod stats_collector;
+
+pub enum StatsType {
+    CSRC,
+    CandidatePair,
+    Certificate,
+    Codec,
+    DataChannel,
+    InboundRTP,
+    LocalCandidate,
+    OutboundRTP,
+    PeerConnection,
+    Receiver,
+    RemoteCandidate,
+    RemoteInboundRTP,
+    RemoteOutboundRTP,
+    Sender,
+    Stream,
+    Track,
+    Transport,
+}
+
+pub struct StatsReport {}
+
+impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
+    fn from(_collector: Arc<Mutex<StatsCollector>>) -> Self {
+        StatsReport {}
+    }
+}
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -23,6 +23,7 @@ pub enum SourceStatsType {
     RemoteCandidate(CandidateStats),
 }
 
+#[derive(Debug)]
 pub enum StatsReportType {
     CandidatePair(ICECandidatePairStats),
     CertificateStats(CertificateStats),
@@ -47,11 +48,19 @@ impl From<SourceStatsType> for StatsReportType {
     }
 }
 
-pub struct StatsReport {}
+// TODO: should this be some form of String-indexed map?
+pub struct StatsReport {
+    reports: Vec<StatsReportType>,
+}
 
 impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
-    fn from(_collector: Arc<Mutex<StatsCollector>>) -> Self {
-        StatsReport {}
+    fn from(collector: Arc<Mutex<StatsCollector>>) -> Self {
+        let lock = Arc::try_unwrap(collector).unwrap();
+        let collector = lock.into_inner();
+
+        StatsReport {
+            reports: collector.reports,
+        }
     }
 }
 
@@ -60,6 +69,7 @@ impl From<Arc<Mutex<StatsCollector>>> for StatsReport {
 // 	return StatsTimestamp(t.UnixNano() / int64(time.Millisecond))
 // }
 
+#[derive(Debug)]
 pub struct ICECandidatePairStats {
     timestamp: Instant, // StatsTimestamp
     id: String,
@@ -122,6 +132,7 @@ impl From<CandidatePairStats> for ICECandidatePairStats {
     }
 }
 
+#[derive(Debug)]
 pub struct ICECandidateStats {
     timestamp: Instant,
     id: String,
@@ -152,6 +163,7 @@ impl From<CandidateStats> for ICECandidateStats {
     }
 }
 
+#[derive(Debug)]
 pub struct ICETransportStats {
     timestamp: Instant,
     id: String,
@@ -168,6 +180,7 @@ impl ICETransportStats {
     }
 }
 
+#[derive(Debug)]
 pub struct CertificateStats {
     timestamp: Instant,
     id: String,
@@ -190,6 +203,7 @@ impl CertificateStats {
     }
 }
 
+#[derive(Debug)]
 pub struct CodecStats {
     timestamp: Instant,
     id: String,
@@ -214,6 +228,7 @@ impl From<&RTCRtpCodecParameters> for CodecStats {
     }
 }
 
+#[derive(Debug)]
 pub struct DataChannelStats {
     timestamp: Instant,
     id: String,
@@ -260,6 +275,7 @@ impl From<&RTCDataChannel> for DataChannelStats {
     }
 }
 
+#[derive(Debug)]
 pub struct PeerConnectionStats {
     timestamp: Instant,
     id: String,

--- a/src/stats/stats_collector.rs
+++ b/src/stats/stats_collector.rs
@@ -1,5 +1,6 @@
 use super::StatsReportType;
 
+#[derive(Default)]
 pub struct StatsCollector {
     reports: Vec<StatsReportType>,
 }
@@ -7,7 +8,7 @@ pub struct StatsCollector {
 impl StatsCollector {
     pub(crate) fn new() -> Self {
         StatsCollector {
-            reports: vec![]
+            ..Default::default()
         }
     }
 

--- a/src/stats/stats_collector.rs
+++ b/src/stats/stats_collector.rs
@@ -13,12 +13,10 @@ impl StatsCollector {
     }
 
     pub(crate) fn append(&mut self, stats: &mut Vec<StatsReportType>) {
-        // TODO increase capacity when needed
         self.reports.append(stats);
     }
 
     pub(crate) fn push(&mut self, stats: StatsReportType) {
-        // TODO increase capacity when needed
         self.reports.push(stats);
     }
 }

--- a/src/stats/stats_collector.rs
+++ b/src/stats/stats_collector.rs
@@ -1,8 +1,8 @@
 use super::StatsReportType;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct StatsCollector {
-    reports: Vec<StatsReportType>,
+    pub(crate) reports: Vec<StatsReportType>,
 }
 
 impl StatsCollector {

--- a/src/stats/stats_collector.rs
+++ b/src/stats/stats_collector.rs
@@ -1,7 +1,23 @@
-pub struct StatsCollector {}
+use super::StatsReportType;
+
+pub struct StatsCollector {
+    reports: Vec<StatsReportType>,
+}
 
 impl StatsCollector {
     pub(crate) fn new() -> Self {
-        StatsCollector {}
+        StatsCollector {
+            reports: vec![]
+        }
+    }
+
+    pub(crate) fn append(&mut self, stats: &mut Vec<StatsReportType>) {
+        // TODO increase capacity when needed
+        self.reports.append(stats);
+    }
+
+    pub(crate) fn push(&mut self, stats: StatsReportType) {
+        // TODO increase capacity when needed
+        self.reports.push(stats);
     }
 }

--- a/src/stats/stats_collector.rs
+++ b/src/stats/stats_collector.rs
@@ -1,0 +1,7 @@
+pub struct StatsCollector {}
+
+impl StatsCollector {
+    pub(crate) fn new() -> Self {
+        StatsCollector {}
+    }
+}


### PR DESCRIPTION
This is obviously not finished, but I was hoping to get some feedback on a few points.

* I don't see a way of getting `bytes_received` or `bytes_sent` out of things that implement `Conn`. I was hoping that I was just missing some connecting thing.
* Do you have any hints on getting `base64_certificate` and `issuer_certificate_id` from an `RTCCertificate`?
* Serialization and casting... I was thinking that it might make sense to keep things close to the raw types (enums, Instants, etc), and delay transformations up until someone serialized types to something else like JSON. Any thoughts?
* `StatsReport`... in golang, this is a map. I was assuming this would be a struct that could be serialized, but wanted to ask if there was a preference.

I've left the existing commented-out golang functions for now, for references, but was going to delete them later.