### PR TITLE
Support completely unreliable datachannels

### DIFF
--- a/src/data_channel/data_channel_parameters.rs
+++ b/src/data_channel/data_channel_parameters.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct DataChannelParameters {
     pub label: String,
     pub protocol: String,
-    pub id: u16,
+    pub id: Option<u16>,
     pub ordered: bool,
-    pub max_packet_life_time: u16,
-    pub max_retransmits: u16,
+    pub max_packet_life_time: Option<u16>,
+    pub max_retransmits: Option<u16>,
     pub negotiated: bool,
 }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1756,9 +1756,7 @@ impl RTCPeerConnection {
 
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #19)
         if let Some(options) = options {
-            if let Some(id) = options.id {
-                params.id = id;
-            }
+            params.id = options.id;
 
             // Ordered indicates if data is allowed to be delivered out of order. The
             // default value of true, guarantees that data will be delivered in order.
@@ -1768,14 +1766,10 @@ impl RTCPeerConnection {
             }
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #7)
-            if let Some(max_packet_life_time) = options.max_packet_life_time {
-                params.max_packet_life_time = max_packet_life_time;
-            }
+            params.max_packet_life_time = options.max_packet_life_time;
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #8)
-            if let Some(max_retransmits) = options.max_retransmits {
-                params.max_retransmits = max_retransmits;
-            }
+            params.max_retransmits = options.max_retransmits;
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #10)
             if let Some(protocol) = options.protocol {
@@ -1799,7 +1793,7 @@ impl RTCPeerConnection {
         ));
 
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #16)
-        if d.max_packet_lifetime != 0 && d.max_retransmits != 0 {
+        if d.max_packet_lifetime.is_some() && d.max_retransmits.is_some() {
             return Err(Error::ErrRetransmitsOrPacketLifeTime);
         }
 

--- a/src/sctp_transport/mod.rs
+++ b/src/sctp_transport/mod.rs
@@ -224,9 +224,9 @@ impl RTCSctpTransport {
                 }
             };
 
-            let mut max_retransmits = 0;
-            let mut max_packet_lifetime = 0;
-            let val = dc.config.reliability_parameter as u16;
+            let mut max_retransmits: Option<u16> = None;
+            let mut max_packet_lifetime: Option<u16> = None;
+            let val: Option<u16> = dc.config.reliability_parameter;
             let ordered;
 
             match dc.config.channel_type {
@@ -257,7 +257,7 @@ impl RTCSctpTransport {
             let id = dc.stream_identifier();
             let rtc_dc = Arc::new(RTCDataChannel::new(
                 DataChannelParameters {
-                    id,
+                    id: Some(id),
                     label: dc.config.label.clone(),
                     protocol: dc.config.protocol.clone(),
                     negotiated: dc.config.negotiated,


### PR DESCRIPTION
It appears that DataChannel parameters: `id` `maxRetransmits` & `maxPacketLifetime` were not translated completely from https://github.com/pion/webrtc/blob/master/datachannel.go#L26

These parameters are able to have a value of `nil` in Pion, which allows for setup of datachannels which are completely unordered & unreliable. There's a big difference between an `id` or `maxRetransmits` of `nil` vs `0`, which **webrtc-rs** currently conflates.

This will allow interop with https://github.com/triplehex/webrtc-unreliable .

This PR requires the usage of the following PRs to function correctly:
https://github.com/webrtc-rs/sctp/pull/10
https://github.com/webrtc-rs/data/pull/5