### PR TITLE
Handle inactive transceivers more correctly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use std::string::FromUtf8Error;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError as MpscSendError;
 
+use crate::peer_connection::sdp::sdp_type::RTCSdpType;
+use crate::peer_connection::signaling_state::RTCSignalingState;
 use crate::rtp_transceiver::rtp_receiver;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -336,8 +338,17 @@ pub enum Error {
     ErrSettingEngineSetAnsweringDTLSRole,
     #[error("can't rollback from stable state")]
     ErrSignalingStateCannotRollback,
-    #[error("invalid proposed signaling state transition")]
-    ErrSignalingStateProposedTransitionInvalid,
+    #[error(
+        "invalid proposed signaling state transition from {} applying {} {}", 
+        from, 
+        if *is_local { "local" } else {  "remote" }, 
+        applying
+    )]
+    ErrSignalingStateProposedTransitionInvalid {
+        from: RTCSignalingState,
+        applying: RTCSdpType,
+        is_local: bool,
+    },
     #[error("cannot convert to StatsICECandidatePairStateSucceeded invalid ice candidate state")]
     ErrStatsICECandidateStateInvalid,
     #[error("ICETransport can only be called in ICETransportStateNew")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use std::string::FromUtf8Error;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError as MpscSendError;
 
+use crate::rtp_transceiver::rtp_receiver;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug, PartialEq)]
@@ -299,6 +301,11 @@ pub enum Error {
     ErrRTPReceiverForSSRCTrackStreamNotFound,
     #[error("no trackStreams found for RID")]
     ErrRTPReceiverForRIDTrackStreamNotFound,
+    #[error("invalid RTP Receiver transition from {from} to {to}")]
+    ErrRTPReceiverStateChangeInvalid {
+        from: rtp_receiver::State,
+        to: rtp_receiver::State,
+    },
     #[error("Track must not be nil")]
     ErrRTPSenderTrackNil,
     #[error("RTPSender must not be nil")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -340,8 +340,8 @@ pub enum Error {
     ErrSignalingStateCannotRollback,
     #[error(
         "invalid proposed signaling state transition from {} applying {} {}", 
-        from, 
-        if *is_local { "local" } else {  "remote" }, 
+        from,
+        if *is_local { "local" } else {  "remote" },
         applying
     )]
     ErrSignalingStateProposedTransitionInvalid {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1346,7 +1346,7 @@ impl RTCPeerConnection {
                                         t.set_mid(mid_value.to_owned()).await?;
                                     }
 
-                                    t.process_new_direection(previous_direction).await?;
+                                    t.process_new_direction(previous_direction).await?;
                                 } else {
                                     let receiver = Arc::new(RTCRtpReceiver::new(
                                         self.internal.setting_engine.get_receive_mtu(),

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -142,7 +142,7 @@ impl PeerConnectionInternal {
         sdp_semantics: RTCSdpSemantics,
     ) -> Result<()> {
         let mut track_details = if let Some(parsed) = &remote_desc.parsed {
-            track_details_from_sdp(parsed)
+            track_details_from_sdp(parsed, true)
         } else {
             vec![]
         };
@@ -189,6 +189,7 @@ impl PeerConnectionInternal {
                         continue;
                     }
 
+                    log::info!("Stopping receiver {:?}", receiver);
                     if let Err(err) = receiver.stop().await {
                         log::warn!("Failed to stop RtpReceiver: {}", err);
                         continue;
@@ -726,7 +727,15 @@ impl PeerConnectionInternal {
         } else {
             {
                 for t in &local_transceivers {
+                    if t.stopped.load(Ordering::SeqCst) {
+                        // An "m=" section is generated for each
+                        // RtpTransceiver that has been added to the PeerConnection, excluding
+                        // any stopped RtpTransceivers;
+                        continue;
+                    }
+
                     if let Some(sender) = t.sender().await {
+                        // TODO: This is dubious because of rollbacks.
                         sender.set_negotiated();
                     }
                     media_sections.push(MediaSection {

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -142,7 +142,7 @@ impl PeerConnectionInternal {
         sdp_semantics: RTCSdpSemantics,
     ) -> Result<()> {
         let mut track_details = if let Some(parsed) = &remote_desc.parsed {
-            track_details_from_sdp(parsed, true)
+            track_details_from_sdp(parsed, false)
         } else {
             vec![]
         };

--- a/src/peer_connection/sdp/mod.rs
+++ b/src/peer_connection/sdp/mod.rs
@@ -65,7 +65,10 @@ pub(crate) fn filter_track_with_ssrc(incoming_tracks: &mut Vec<TrackDetails>, ss
 }
 
 /// extract all TrackDetails from an SDP.
-pub(crate) fn track_details_from_sdp(s: &SessionDescription) -> Vec<TrackDetails> {
+pub(crate) fn track_details_from_sdp(
+    s: &SessionDescription,
+    include_inactive: bool,
+) -> Vec<TrackDetails> {
     let mut incoming_tracks = vec![];
 
     for media in &s.media_descriptions {
@@ -78,7 +81,7 @@ pub(crate) fn track_details_from_sdp(s: &SessionDescription) -> Vec<TrackDetails
 
         // If media section is recvonly or inactive skip
         if media.attribute(ATTR_KEY_RECV_ONLY).is_some()
-            || media.attribute(ATTR_KEY_INACTIVE).is_some()
+            || (!include_inactive && media.attribute(ATTR_KEY_INACTIVE).is_some())
         {
             continue;
         }
@@ -134,11 +137,15 @@ pub(crate) fn track_details_from_sdp(s: &SessionDescription) -> Vec<TrackDetails
                 // figure this out automatically when an ontrack event is emitted on RTCPeerConnection.
                 ATTR_KEY_MSID => {
                     if let Some(value) = &attr.value {
-                        let split: Vec<&str> = value.split(' ').collect();
-                        if split.len() == 2 {
-                            stream_id = split[0];
-                            track_id = split[1];
-                        }
+                        let mut split = value.split(' ');
+
+                        match (split.next(), split.next(), split.next()) {
+                            (Some(sid), Some(tid), None) => {
+                                stream_id = sid;
+                                track_id = tid;
+                            }
+                            _ => {}
+                        };
                     }
                 }
 

--- a/src/peer_connection/sdp/mod.rs
+++ b/src/peer_connection/sdp/mod.rs
@@ -67,7 +67,7 @@ pub(crate) fn filter_track_with_ssrc(incoming_tracks: &mut Vec<TrackDetails>, ss
 /// extract all TrackDetails from an SDP.
 pub(crate) fn track_details_from_sdp(
     s: &SessionDescription,
-    include_inactive: bool,
+    exclude_inactive: bool,
 ) -> Vec<TrackDetails> {
     let mut incoming_tracks = vec![];
 
@@ -81,7 +81,7 @@ pub(crate) fn track_details_from_sdp(
 
         // If media section is recvonly or inactive skip
         if media.attribute(ATTR_KEY_RECV_ONLY).is_some()
-            || (!include_inactive && media.attribute(ATTR_KEY_INACTIVE).is_some())
+            || (exclude_inactive && media.attribute(ATTR_KEY_INACTIVE).is_some())
         {
             continue;
         }

--- a/src/peer_connection/sdp/sdp_test.rs
+++ b/src/peer_connection/sdp/sdp_test.rs
@@ -378,7 +378,7 @@ fn test_track_details_from_sdp() -> Result<()> {
             ..Default::default()
         };
 
-        let tracks = track_details_from_sdp(&s, false);
+        let tracks = track_details_from_sdp(&s, true);
         assert_eq!(3, tracks.len());
         if track_details_for_ssrc(&tracks, 1000).is_some() {
             assert!(
@@ -466,13 +466,13 @@ fn test_track_details_from_sdp() -> Result<()> {
         };
         assert_eq!(
             0,
-            track_details_from_sdp(&s, false).len(),
-            "inactive and recvonly tracks should be ignored when passing include_inactive: false"
+            track_details_from_sdp(&s, true).len(),
+            "inactive and recvonly tracks should be ignored when passing exclude_inactive: true"
         );
         assert_eq!(
             1,
-            track_details_from_sdp(&s, true).len(),
-            "Inactive tracks should not be ignored when passing include_inactive: true"
+            track_details_from_sdp(&s, false).len(),
+            "Inactive tracks should not be ignored when passing exclude_inactive: false"
         );
     }
 

--- a/src/peer_connection/sdp/sdp_test.rs
+++ b/src/peer_connection/sdp/sdp_test.rs
@@ -378,7 +378,7 @@ fn test_track_details_from_sdp() -> Result<()> {
             ..Default::default()
         };
 
-        let tracks = track_details_from_sdp(&s);
+        let tracks = track_details_from_sdp(&s, false);
         assert_eq!(3, tracks.len());
         if track_details_for_ssrc(&tracks, 1000).is_some() {
             assert!(
@@ -416,7 +416,6 @@ fn test_track_details_from_sdp() -> Result<()> {
         }
     }
 
-    //"inactive and recvonly tracks ignored"
     {
         let s = SessionDescription {
             media_descriptions: vec![
@@ -426,6 +425,10 @@ fn test_track_details_from_sdp() -> Result<()> {
                         ..Default::default()
                     },
                     attributes: vec![
+                        Attribute {
+                            key: "mid".to_owned(),
+                            value: Some("1".to_owned()),
+                        },
                         Attribute {
                             key: "inactive".to_owned(),
                             value: None,
@@ -444,6 +447,10 @@ fn test_track_details_from_sdp() -> Result<()> {
                     },
                     attributes: vec![
                         Attribute {
+                            key: "mid".to_owned(),
+                            value: Some("1".to_owned()),
+                        },
+                        Attribute {
                             key: "recvonly".to_owned(),
                             value: None,
                         },
@@ -457,7 +464,16 @@ fn test_track_details_from_sdp() -> Result<()> {
             ],
             ..Default::default()
         };
-        assert_eq!(0, track_details_from_sdp(&s).len());
+        assert_eq!(
+            0,
+            track_details_from_sdp(&s, false).len(),
+            "inactive and recvonly tracks should be ignored when passing include_inactive: false"
+        );
+        assert_eq!(
+            1,
+            track_details_from_sdp(&s, true).len(),
+            "Inactive tracks should not be ignored when passing include_inactive: true"
+        );
     }
 
     Ok(())

--- a/src/peer_connection/signaling_state.rs
+++ b/src/peer_connection/signaling_state.rs
@@ -204,11 +204,19 @@ pub(crate) fn check_next_signaling_state(
             }
         }
         _ => {
-            return Err(Error::ErrSignalingStateProposedTransitionInvalid);
+            return Err(Error::ErrSignalingStateProposedTransitionInvalid {
+                from: cur,
+                applying: sdp_type,
+                is_local: op == StateChangeOp::SetLocal,
+            });
         }
     };
 
-    Err(Error::ErrSignalingStateProposedTransitionInvalid)
+    Err(Error::ErrSignalingStateProposedTransitionInvalid {
+        from: cur,
+        is_local: op == StateChangeOp::SetLocal,
+        applying: sdp_type,
+    })
 }
 
 #[cfg(test)]
@@ -328,7 +336,11 @@ mod test {
                 RTCSignalingState::HaveRemotePranswer,
                 StateChangeOp::SetRemote,
                 RTCSdpType::Pranswer,
-                Some(Error::ErrSignalingStateProposedTransitionInvalid),
+                Some(Error::ErrSignalingStateProposedTransitionInvalid {
+                    from: RTCSignalingState::Stable,
+                    is_local: false,
+                    applying: RTCSdpType::Pranswer,
+                }),
             ),
             (
                 "(invalid) stable->SetRemote(rollback)->have-local-offer",

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -313,7 +313,7 @@ impl RTCRtpTransceiver {
         self.direction.store(d as u8, Ordering::SeqCst);
     }
 
-    pub(crate) async fn process_new_direection(
+    pub(crate) async fn process_new_direction(
         &self,
         previous_direction: RTCRtpTransceiverDirection,
     ) -> Result<()> {

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -334,12 +334,12 @@ impl RTCRtpTransceiver {
             // All others imply a change
             (_, RTCRtpTransceiverDirection::Inactive | RTCRtpTransceiverDirection::Sendonly) => {
                 if let Some(receiver) = &*self.receiver.lock().await {
-                    receiver.pause()?;
+                    receiver.pause().await?;
                 }
             }
             (_, RTCRtpTransceiverDirection::Recvonly | RTCRtpTransceiverDirection::Sendrecv) => {
                 if let Some(receiver) = &*self.receiver.lock().await {
-                    receiver.resume()?;
+                    receiver.resume().await?;
                 }
             }
             // TODO: Senders

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -313,6 +313,10 @@ impl RTCRtpTransceiver {
         self.direction.store(d as u8, Ordering::SeqCst);
     }
 
+    /// Perform any subsequent actions after altering the transceiver's direction.
+    ///
+    /// After changing the transceiver's direction this method should be called to perform any
+    /// side-effects that results from the new direction, such as pausing/resuming the RTP receiver.
     pub(crate) async fn process_new_direction(
         &self,
         previous_direction: RTCRtpTransceiverDirection,
@@ -335,7 +339,7 @@ impl RTCRtpTransceiver {
             }
             (_, RTCRtpTransceiverDirection::Recvonly | RTCRtpTransceiverDirection::Sendrecv) => {
                 if let Some(receiver) = &*self.receiver.lock().await {
-                    receiver.unpause()?;
+                    receiver.resume()?;
                 }
             }
             // TODO: Senders

--- a/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -137,7 +137,7 @@ pub struct RTPReceiverInternal {
 impl RTPReceiverInternal {
     /// read reads incoming RTCP for this RTPReceiver
     async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
-        let mut state_watch_rx = self.state_rx.clone();
+        let mut state_watch_rx = self.state_tx.subscribe();
         // Ensure we are running or paused. When paused we still receive RTCP even if RTP traffic
         // isn't flowing.
         State::wait_for(&mut state_watch_rx, &[State::Running, State::Paused]).await?;
@@ -168,7 +168,7 @@ impl RTPReceiverInternal {
 
     /// read_simulcast reads incoming RTCP for this RTPReceiver for given rid
     async fn read_simulcast(&self, b: &mut [u8], rid: &str) -> Result<(usize, Attributes)> {
-        let mut state_watch_rx = self.state_rx.clone();
+        let mut state_watch_rx = self.state_tx.subscribe();
 
         // Ensure we are running or paused. When paused we still recevie RTCP even if RTP traffic
         // isn't flowing.
@@ -231,7 +231,7 @@ impl RTPReceiverInternal {
     }
 
     pub(crate) async fn read_rtp(&self, b: &mut [u8], tid: usize) -> Result<(usize, Attributes)> {
-        let mut state_watch_rx = self.state_rx.clone();
+        let mut state_watch_rx = self.state_tx.subscribe();
 
         // Ensure we are running.
         State::wait_for(&mut state_watch_rx, &[State::Running]).await?;
@@ -330,7 +330,7 @@ impl RTPReceiverInternal {
 
     /// Get the current state and a receiver for the next state change.
     pub(crate) fn current_state(&self) -> State {
-        *self.state_tx.borrow()
+        *self.state_rx.borrow()
     }
 
     pub(crate) fn start(&self) -> Result<()> {

--- a/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -18,14 +18,114 @@ use crate::track::{TrackStream, TrackStreams};
 
 use interceptor::stream_info::RTPHeaderExtension;
 use interceptor::{Attributes, Interceptor};
+use std::fmt;
+
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex, Notify, RwLock};
+use tokio::sync::{watch, Mutex, RwLock};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum State {
+    Initial = 0,
+    Running = 1,
+    Paused = 2,
+    Closed = 3,
+}
+
+impl From<u8> for State {
+    fn from(value: u8) -> Self {
+        match value {
+            v if v == State::Initial as u8 => State::Initial,
+            v if v == State::Running as u8 => State::Running,
+            v if v == State::Paused as u8 => State::Paused,
+            v if v == State::Closed as u8 => State::Closed,
+            _ => unreachable!(
+                "Invalid serialization of {}: {}",
+                std::any::type_name::<Self>(),
+                value
+            ),
+        }
+    }
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Initial => write!(f, "Initial"),
+            State::Running => write!(f, "Running"),
+            State::Paused => write!(f, "Paused"),
+            State::Closed => write!(f, "Closed"),
+        }
+    }
+}
+
+impl State {
+    fn transition(to: Self, tx: &watch::Sender<State>) -> Result<()> {
+        let current = *tx.borrow();
+        if current == to {
+            // Already in this state
+            return Ok(());
+        }
+
+        match current {
+            Self::Initial if matches!(to, Self::Running | Self::Paused | Self::Closed) => {
+                let _ = tx.send(to);
+                return Ok(());
+            }
+            State::Running if matches!(to, Self::Paused | Self::Closed) => {
+                let _ = tx.send(to);
+                return Ok(());
+            }
+            State::Paused if matches!(to, Self::Running | Self::Closed) => {
+                let _ = tx.send(to);
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        Err(Error::ErrRTPReceiverStateChangeInvalid { from: current, to })
+    }
+
+    async fn wait_for(rx: &mut watch::Receiver<State>, states: &[State]) -> Result<()> {
+        loop {
+            let state = *rx.borrow();
+
+            match state {
+                _ if states.contains(&state) => return Ok(()),
+                State::Closed => {
+                    return Err(Error::ErrClosedPipe);
+                }
+                _ => {}
+            }
+
+            if let Err(_) = rx.changed().await {
+                return Err(Error::ErrClosedPipe);
+            }
+        }
+    }
+
+    async fn error_on_close(rx: &mut watch::Receiver<State>) -> Result<()> {
+        if let Err(_) = rx.changed().await {
+            return Err(Error::ErrClosedPipe);
+        }
+
+        let state = *rx.borrow();
+        if state == State::Closed {
+            return Err(Error::ErrClosedPipe);
+        }
+
+        Ok(())
+    }
+}
 
 pub struct RTPReceiverInternal {
     pub(crate) kind: RTPCodecType,
+
+    // State is stored within the channel
+    state_tx: watch::Sender<State>,
+    state_rx: watch::Receiver<State>,
+
     tracks: RwLock<Vec<TrackStreams>>,
-    closed_rx: Arc<Notify>,
-    received_rx: Mutex<mpsc::Receiver<()>>,
 
     transceiver_codecs: Mutex<Option<Arc<Mutex<Vec<RTCRtpCodecParameters>>>>>,
 
@@ -37,28 +137,25 @@ pub struct RTPReceiverInternal {
 impl RTPReceiverInternal {
     /// read reads incoming RTCP for this RTPReceiver
     async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
-        {
-            let mut received_rx = self.received_rx.lock().await;
-            tokio::select! {
-                _ = received_rx.recv() =>{
-                    // Drop into the below code and don't hold this lock any longer
-                }
-                _ = self.closed_rx.notified() => {
-                    return Err(Error::ErrClosedPipe);
-                }
-            }
-        }
+        let mut state_watch_rx = self.state_rx.clone();
+        // Ensure we are running or paused. When paused we still recevie RTCP even if RTP traffic
+        // isn't flowing.
+        State::wait_for(&mut state_watch_rx, &[State::Running, State::Paused]).await?;
 
         let tracks = self.tracks.read().await;
         if let Some(t) = tracks.first() {
             if let Some(rtcp_interceptor) = &t.stream.rtcp_interceptor {
                 let a = Attributes::new();
-                tokio::select! {
-                    _ = self.closed_rx.notified() => {
-                        Err(Error::ErrClosedPipe)
-                    }
-                    result = rtcp_interceptor.read(b, &a) => {
-                        Ok(result?)
+                loop {
+                    tokio::select! {
+                        res = State::error_on_close(&mut state_watch_rx) => {
+                            if let Err(e) = res {
+                                return Err(e);
+                            }
+                        }
+                        result = rtcp_interceptor.read(b, &a) => {
+                            return Ok(result?)
+                        }
                     }
                 }
             } else {
@@ -71,29 +168,28 @@ impl RTPReceiverInternal {
 
     /// read_simulcast reads incoming RTCP for this RTPReceiver for given rid
     async fn read_simulcast(&self, b: &mut [u8], rid: &str) -> Result<(usize, Attributes)> {
-        {
-            let mut received_rx = self.received_rx.lock().await;
-            tokio::select! {
-                _ = received_rx.recv() =>{
-                    // Drop into the below code and don't hold this lock any longer
-                }
-                _ = self.closed_rx.notified() => {
-                    return Err(Error::ErrClosedPipe);
-                }
-            }
-        }
+        let mut state_watch_rx = self.state_rx.clone();
+
+        // Ensure we are running or paused. When paused we still recevie RTCP even if RTP traffic
+        // isn't flowing.
+        State::wait_for(&mut state_watch_rx, &[State::Running, State::Paused]).await?;
 
         let tracks = self.tracks.read().await;
         for t in &*tracks {
             if t.track.rid() == rid {
                 if let Some(rtcp_interceptor) = &t.stream.rtcp_interceptor {
                     let a = Attributes::new();
-                    tokio::select! {
-                        _ = self.closed_rx.notified() => {
-                            return Err(Error::ErrClosedPipe);
-                        }
-                        result = rtcp_interceptor.read(b, &a) => {
-                            return Ok(result?);
+
+                    loop {
+                        tokio::select! {
+                            res = State::error_on_close(&mut state_watch_rx) => {
+                                if let Err(e) = res {
+                                    return Err(e);
+                                }
+                            }
+                            result = rtcp_interceptor.read(b, &a) => {
+                                return Ok(result?);
+                            }
                         }
                     }
                 } else {
@@ -135,10 +231,10 @@ impl RTPReceiverInternal {
     }
 
     pub(crate) async fn read_rtp(&self, b: &mut [u8], tid: usize) -> Result<(usize, Attributes)> {
-        {
-            let mut received_rx = self.received_rx.lock().await;
-            let _ = received_rx.recv().await;
-        }
+        let mut state_watch_rx = self.state_rx.clone();
+
+        // Ensure we are running.
+        State::wait_for(&mut state_watch_rx, &[State::Running]).await?;
 
         //log::debug!("read_rtp enter tracks tid {}", tid);
         let mut rtp_interceptor = None;
@@ -165,12 +261,24 @@ impl RTPReceiverInternal {
             //    "read_rtp rtp_interceptor.read enter with tid {} ssrc {}",
             //    tid, ssrc
             //);
-            tokio::select! {
-                _ = self.closed_rx.notified() => {
-                    Err(Error::ErrClosedPipe)
-                }
-                result = rtp_interceptor.read(b, &a) => {
-                    Ok(result?)
+            loop {
+                tokio::select! {
+                    _ = state_watch_rx.changed() => {
+                        let new_state = *state_watch_rx.borrow();
+
+                        match new_state {
+                            State::Paused => {
+                                return Ok((0, Default::default()));
+                            },
+                            State::Closed => {
+                                return Err(Error::ErrClosedPipe);
+                            },
+                            _ => {},
+                        }
+                    }
+                    result = rtp_interceptor.read(b, &a) => {
+                        return Ok(result?);
+                    }
                 }
             }
         } else {
@@ -217,6 +325,29 @@ impl RTPReceiverInternal {
 
         filtered_codecs
     }
+
+    // State
+
+    /// Get the current state and a receiver for the next state change.
+    pub(crate) fn current_state(&self) -> State {
+        *self.state_tx.borrow()
+    }
+
+    pub(crate) fn start(&self) -> Result<()> {
+        State::transition(State::Running, &self.state_tx)
+    }
+
+    pub(crate) fn pause(&self) -> Result<()> {
+        State::transition(State::Paused, &self.state_tx)
+    }
+
+    pub(crate) fn unpause(&self) -> Result<()> {
+        State::transition(State::Running, &self.state_tx)
+    }
+
+    pub(crate) fn close(&self) -> Result<()> {
+        State::transition(State::Closed, &self.state_tx)
+    }
 }
 
 /// RTPReceiver allows an application to inspect the receipt of a TrackRemote
@@ -224,8 +355,6 @@ pub struct RTCRtpReceiver {
     receive_mtu: usize,
     kind: RTPCodecType,
     transport: Arc<RTCDtlsTransport>,
-    closed_tx: Arc<Notify>,
-    received_tx: Mutex<Option<mpsc::Sender<()>>>,
 
     pub internal: Arc<RTPReceiverInternal>,
 }
@@ -246,16 +375,12 @@ impl RTCRtpReceiver {
         media_engine: Arc<MediaEngine>,
         interceptor: Arc<dyn Interceptor + Send + Sync>,
     ) -> Self {
-        let closed_tx = Arc::new(Notify::new());
-        let closed_rx = closed_tx.clone();
-        let (received_tx, received_rx) = mpsc::channel(1);
+        let (state_tx, state_rx) = watch::channel(State::Initial);
 
         RTCRtpReceiver {
             receive_mtu,
             kind,
             transport: Arc::clone(&transport),
-            closed_tx,
-            received_tx: Mutex::new(Some(received_tx)),
 
             internal: Arc::new(RTPReceiverInternal {
                 kind,
@@ -265,8 +390,8 @@ impl RTCRtpReceiver {
                 media_engine,
                 interceptor,
 
-                closed_rx,
-                received_rx: Mutex::new(received_rx),
+                state_tx,
+                state_rx,
 
                 transceiver_codecs: Mutex::new(None),
             }),
@@ -344,13 +469,10 @@ impl RTCRtpReceiver {
     pub async fn receive(&self, parameters: &RTCRtpReceiveParameters) -> Result<()> {
         let receiver = Arc::downgrade(&self.internal);
 
-        let _d = {
-            let mut received_tx = self.received_tx.lock().await;
-            if received_tx.is_none() {
-                return Err(Error::ErrRTPReceiverReceiveAlreadyCalled);
-            }
-            received_tx.take()
-        };
+        if self.internal.current_state() != State::Initial {
+            return Err(Error::ErrRTPReceiverReceiveAlreadyCalled);
+        }
+        self.internal.start()?;
 
         let (global_params, interceptor, media_engine) = {
             (
@@ -485,8 +607,7 @@ impl RTCRtpReceiver {
     }
 
     pub(crate) async fn have_received(&self) -> bool {
-        let received_tx = self.received_tx.lock().await;
-        received_tx.is_none()
+        self.internal.current_state() != State::Initial
     }
 
     pub(crate) async fn start(&self, incoming: &TrackDetails) {
@@ -522,15 +643,11 @@ impl RTCRtpReceiver {
 
     /// Stop irreversibly stops the RTPReceiver
     pub async fn stop(&self) -> Result<()> {
-        self.closed_tx.notify_waiters();
-
-        let received_tx_is_none = {
-            let received_tx = self.received_tx.lock().await;
-            received_tx.is_none()
-        };
+        let previous_state = self.internal.current_state();
+        self.internal.close()?;
 
         let mut errs = vec![];
-        if received_tx_is_none {
+        if previous_state != State::Initial {
             let tracks = self.internal.tracks.write().await;
             for t in &*tracks {
                 if let Some(rtcp_read_stream) = &t.stream.rtcp_read_stream {
@@ -641,5 +758,19 @@ impl RTCRtpReceiver {
         }
 
         Err(Error::ErrRTPReceiverForRIDTrackStreamNotFound)
+    }
+
+    // State
+
+    pub(crate) fn current_state(&self) -> State {
+        self.internal.current_state()
+    }
+
+    pub(crate) fn pause(&self) -> Result<()> {
+        self.internal.pause()
+    }
+
+    pub(crate) fn unpause(&self) -> Result<()> {
+        self.internal.unpause()
     }
 }

--- a/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -138,7 +138,7 @@ impl RTPReceiverInternal {
     /// read reads incoming RTCP for this RTPReceiver
     async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
         let mut state_watch_rx = self.state_rx.clone();
-        // Ensure we are running or paused. When paused we still recevie RTCP even if RTP traffic
+        // Ensure we are running or paused. When paused we still receive RTCP even if RTP traffic
         // isn't flowing.
         State::wait_for(&mut state_watch_rx, &[State::Running, State::Paused]).await?;
 
@@ -341,7 +341,7 @@ impl RTPReceiverInternal {
         State::transition(State::Paused, &self.state_tx)
     }
 
-    pub(crate) fn unpause(&self) -> Result<()> {
+    pub(crate) fn resume(&self) -> Result<()> {
         State::transition(State::Running, &self.state_tx)
     }
 
@@ -770,7 +770,7 @@ impl RTCRtpReceiver {
         self.internal.pause()
     }
 
-    pub(crate) fn unpause(&self) -> Result<()> {
-        self.internal.unpause()
+    pub(crate) fn resume(&self) -> Result<()> {
+        self.internal.resume()
     }
 }

--- a/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
+++ b/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
@@ -11,6 +11,7 @@ use crate::track::track_local::track_local_static_sample::TrackLocalStaticSample
 use crate::track::track_local::TrackLocal;
 use bytes::Bytes;
 use media::Sample;
+use tokio::sync::mpsc;
 use tokio::time::Duration;
 use waitgroup::WaitGroup;
 

--- a/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::api::media_engine::{MIME_TYPE_OPUS, MIME_TYPE_VP8, MIME_TYPE_VP9};
 use crate::api::APIBuilder;
 use crate::peer_connection::configuration::RTCConfiguration;
-use crate::peer_connection::peer_connection_test::close_pair_now;
+use crate::peer_connection::peer_connection_test::{close_pair_now, create_vnet_pair};
+use crate::peer_connection::signaling_state::RTCSignalingState;
 
 #[tokio::test]
 async fn test_rtp_transceiver_set_codec_preferences() -> Result<()> {
@@ -212,6 +213,46 @@ async fn test_rtp_transceiver_set_codec_preferences_payload_type() -> Result<()>
 
     // test_codec is ignored since offerer doesn't support
     assert!(!answer.sdp.contains("test_codec"));
+
+    close_pair_now(&offer_pc, &answer_pc).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rtp_transceiver_direction_change() -> Result<()> {
+    let (offer_pc, answer_pc, _) = create_vnet_pair().await?;
+
+    let offer_transceiver = offer_pc
+        .add_transceiver_from_kind(RTPCodecType::Video, &[])
+        .await?;
+
+    let answer_transceiver = answer_pc
+        .add_transceiver_from_kind(RTPCodecType::Video, &[])
+        .await?;
+
+    let offer = offer_pc.create_offer(None).await?;
+
+    offer_pc.set_local_description(offer.clone()).await?;
+    answer_pc.set_remote_description(offer).await?;
+
+    let answer = answer_pc.create_answer(None).await?;
+    assert!(answer.sdp.contains("a=sendrecv"),);
+    answer_pc.set_local_description(answer.clone()).await?;
+    offer_pc.set_remote_description(answer).await?;
+
+    offer_transceiver.set_direction(RTCRtpTransceiverDirection::Inactive);
+
+    let offer = offer_pc.create_offer(None).await?;
+    assert!(offer.sdp.contains("a=inactive"),);
+
+    offer_pc.set_local_description(offer.clone()).await?;
+    answer_pc.set_remote_description(offer).await?;
+
+    let answer = answer_pc.create_answer(None).await?;
+    dbg!(&answer);
+    assert!(answer.sdp.contains("a=inactive"),);
+    // offer_pc.set_remote_description(answer).await?;
 
     close_pair_now(&offer_pc, &answer_pc).await;
 

--- a/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -250,9 +250,8 @@ async fn test_rtp_transceiver_direction_change() -> Result<()> {
     answer_pc.set_remote_description(offer).await?;
 
     let answer = answer_pc.create_answer(None).await?;
-    dbg!(&answer);
     assert!(answer.sdp.contains("a=inactive"),);
-    // offer_pc.set_remote_description(answer).await?;
+    offer_pc.set_remote_description(answer).await?;
 
     close_pair_now(&offer_pc, &answer_pc).await;
 


### PR DESCRIPTION
Instead of stopping transceivers when a media section transitions to
inactive we keep them active, then if they become active again we resume receiving.