### PR TITLE
Correct msid handling for RtpSender

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,6 +132,11 @@ pub enum Error {
     #[error("RtpSender not created by this PeerConnection")]
     ErrSenderNotCreatedByConnection,
 
+    /// ErrSenderInitialTrackIdAlreadySet indicates a second call to
+    /// [`RtpSender::set_initial_track_id`] which is not allowed.
+    #[error("RtpSender's initial_track_id has already been set")]
+    ErrSenderInitialTrackIdAlreadySet,
+
     /// ErrSessionDescriptionNoFingerprint indicates set_remote_description was called with a SessionDescription that has no
     /// fingerprint
     #[error("set_remote_description called with no fingerprint")]

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1767,11 +1767,11 @@ impl RTCPeerConnection {
         }
 
         if let Some(t) = transceiver {
-            if sender.stop().await.is_ok() && t.set_sending_track(None).await.is_ok() {
-                t.set_direction_internal(RTCRtpTransceiverDirection::from_send_recv(
-                    false,
-                    t.direction().has_recv(),
-                ));
+            let sender_result = sender.stop().await;
+            // This also updates direction
+            let sending_track_result = t.set_sending_track(None).await;
+
+            if sender_result.is_ok() && sending_track_result.is_ok() {
                 self.internal.trigger_negotiation_needed().await;
             }
             Ok(())

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -394,8 +394,10 @@ impl RTCRtpTransceiver {
 
         let current_direction = self.current_direction();
         if previous_direction != current_direction {
+            let mid = self.mid().await;
             trace!(
-                "Processing transceiver direction change from {} to {}",
+                "Processing transceiver({}) direction change from {} to {}",
+                mid,
                 previous_direction,
                 current_direction
             );

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -370,11 +370,14 @@ impl RTCRtpTransceiver {
             .current_direction
             .swap(d as u8, Ordering::SeqCst)
             .into();
-        trace!(
-            "Changing current direction of transceiver from {} to {}",
-            previous,
-            d,
-        );
+
+        if d != previous {
+            trace!(
+                "Changing current direction of transceiver from {} to {}",
+                previous,
+                d,
+            );
+        }
     }
 
     /// Perform any subsequent actions after altering the transceiver's direction.
@@ -390,11 +393,13 @@ impl RTCRtpTransceiver {
         }
 
         let current_direction = self.current_direction();
-        trace!(
-            "Processing transceiver direction change from {} to {}",
-            previous_direction,
-            current_direction
-        );
+        if previous_direction != current_direction {
+            trace!(
+                "Processing transceiver direction change from {} to {}",
+                previous_direction,
+                current_direction
+            );
+        }
 
         match (previous_direction, current_direction) {
             (a, b) if a == b => {
@@ -462,26 +467,13 @@ impl RTCRtpTransceiver {
         }
 
         let direction = self.direction();
-        if !track_is_none && direction == RTCRtpTransceiverDirection::Recvonly {
-            self.set_direction_internal(RTCRtpTransceiverDirection::Sendrecv);
-        } else if !track_is_none && direction == RTCRtpTransceiverDirection::Inactive {
-            self.set_direction_internal(RTCRtpTransceiverDirection::Sendonly);
-        } else if track_is_none && direction == RTCRtpTransceiverDirection::Sendrecv {
-            self.set_direction_internal(RTCRtpTransceiverDirection::Recvonly);
-        } else if !track_is_none
-            && (direction == RTCRtpTransceiverDirection::Sendonly
-                || direction == RTCRtpTransceiverDirection::Sendrecv)
-        {
-            // Handle the case where a sendonly transceiver was added by a negotiation
-            // initiated by remote peer. For example a remote peer added a transceiver
-            // with direction recvonly.
-            //} else if !track_is_none && self.direction == RTPTransceiverDirection::Sendrecv {
-            // Similar to above, but for sendrecv transceiver.
-        } else if track_is_none && direction == RTCRtpTransceiverDirection::Sendonly {
-            self.set_direction_internal(RTCRtpTransceiverDirection::Inactive);
-        } else {
-            return Err(Error::ErrRTPTransceiverSetSendingInvalidState);
-        }
+        let should_send = !track_is_none;
+        let should_recv = direction.has_recv();
+        self.set_direction_internal(RTCRtpTransceiverDirection::from_send_recv(
+            should_send,
+            should_recv,
+        ));
+
         Ok(())
     }
 }

--- a/src/rtp_transceiver/rtp_transceiver_direction.rs
+++ b/src/rtp_transceiver/rtp_transceiver_direction.rs
@@ -97,11 +97,11 @@ impl RTCRtpTransceiverDirection {
         }
     }
 
-    fn has_send(&self) -> bool {
+    pub fn has_send(&self) -> bool {
         matches!(self, Self::Sendrecv | Self::Sendonly)
     }
 
-    fn has_recv(&self) -> bool {
+    pub fn has_recv(&self) -> bool {
         matches!(self, Self::Sendrecv | Self::Recvonly)
     }
 }


### PR DESCRIPTION
The previous logic would put negotiation into an endless loop after
running `remove_track` due to incorrectly implementing the negotiation
check and handling of stream ids.

Upon calling `remove_track` the following steps were carried out:

1. Find the transceiver the sender passed to `remove_track` is associated with
2. Stop the sender and set its track to `None`.

There were three problems with this:

1. The `remove_track` implementation is mostly correct, but it didn't always update the transceivers direction.
2. When checking if negotiation is needed the logic wasn't quite correct.
3. When offering the offered msid attribute didn't comply with the specification, in particular the msid line(s) should stay the same regardless of changes to the track or the transceivers direction. 

In total this meant that when removing a track, at least some times, we'd end up in an endless negotiation loop where the check if negotiation was needed was always returning true, even after negotiating with the peer.