### PR TITLE
add RTCPeerConnection::get_remote_dtls_certificate

### DIFF
--- a/.github/workflows/webrtc.yml
+++ b/.github/workflows/webrtc.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.0
+          toolchain: 1.57.0
           profile: minimal
           components: clippy, rustfmt
           override: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ dtls = { package = "webrtc-dtls", version = "0.5.2" }
 rtp = "0.6.5"
 rtcp = "0.6.5"
 srtp = { package = "webrtc-srtp", version = "0.8.9" }
-sctp = { package = "webrtc-sctp", version = "0.4.3" }
-data = { package = "webrtc-data", version = "0.3.3" }
+sctp = { package = "webrtc-sctp", version = "0.5.0" }
+data = { package = "webrtc-data", version = "0.3.3", git = "https://github.com/webrtc-rs/data.git", rev = "f630dcd2b90ed8faf57d1b36c18ec5aa715325c0" }
 media = { package = "webrtc-media", version = "0.4.5" }
 interceptor = "0.7.6"
 tokio = { version = "1.15.0", features = ["full"] }
@@ -38,7 +38,7 @@ waitgroup = "0.1.2"
 regex = "1.5.4"
 url = "2.2.2"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"]}
-rcgen = { version = "0.8.14", features = ["pem", "x509-parser"]}
+rcgen = { version = "0.9.2", features = ["pem", "x509-parser"]}
 ring = "0.16.20"
 sha2 = "0.10.1"
 lazy_static = "1.4.0"

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -2127,10 +2127,15 @@ impl RTCPeerConnection {
 
     /// Returns the remote DTLS certificate bytes.
     ///
-    /// If DTLS has not been established yet, it returns empty bytes.
+    /// If DTLS has not been established yet, it returns `None`.
     ///
     /// See [`RTCDtlsTransport::get_remote_certificate`].
-    pub async fn get_remote_dtls_certificate(&self) -> Bytes {
-        return self.internal.dtls_transport.get_remote_certificate().await;
+    pub async fn get_remote_dtls_certificate(&self) -> Option<Bytes> {
+        let bytes = self.internal.dtls_transport.get_remote_certificate().await;
+        if bytes.len() == 0 {
+            None
+        } else {
+            Some(bytes)
+        }
     }
 }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -74,6 +74,7 @@ use ::ice::candidate::Candidate;
 use ::sdp::description::session::*;
 use ::sdp::util::ConnectionRole;
 use async_trait::async_trait;
+use bytes::Bytes;
 use interceptor::{Attributes, Interceptor, RTCPWriter};
 use peer_connection_internal::*;
 use rand::{thread_rng, Rng};
@@ -2122,5 +2123,14 @@ impl RTCPeerConnection {
         }
 
         gathering_complete_rx
+    }
+
+    /// Returns the remote DTLS certificate bytes.
+    ///
+    /// If DTLS has not been established yet, it returns empty bytes.
+    ///
+    /// See [`RTCDtlsTransport::get_remote_certificate`].
+    pub async fn get_remote_dtls_certificate(&self) -> Bytes {
+        return self.internal.dtls_transport.get_remote_certificate().await
     }
 }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -2131,6 +2131,6 @@ impl RTCPeerConnection {
     ///
     /// See [`RTCDtlsTransport::get_remote_certificate`].
     pub async fn get_remote_dtls_certificate(&self) -> Bytes {
-        return self.internal.dtls_transport.get_remote_certificate().await
+        return self.internal.dtls_transport.get_remote_certificate().await;
     }
 }


### PR DESCRIPTION
Previously it was not possible to get DTLS certificate of the remote peer from `RTCPeerConnection`. Neither it's possible in Pion. _(NOTE: I'm going to raise a similar issue there)_

Also, I had to always require / set remote certificate (even if certificate verification is disabled via settings). It's in line with Pion https://github.com/pion/webrtc/blob/7feac502862a6a8804179dbadb816654138f34e0/dtlstransport.go#L367-L373.

Refs https://github.com/libp2p/specs/pull/412#discussion_r912612288