### PR TITLE
update call to DataChannel::accept as per data pr #14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ dtls = { package = "webrtc-dtls", version = "0.5.2" }
 rtp = "0.6.5"
 rtcp = "0.6.5"
 srtp = { package = "webrtc-srtp", version = "0.8.9" }
-sctp = { package = "webrtc-sctp", version = "0.4.3" }
-data = { package = "webrtc-data", version = "0.3.3" }
+sctp = { package = "webrtc-sctp", version = "0.5.0" }
+data = { package = "webrtc-data", version = "0.4.0" }
 media = { package = "webrtc-media", version = "0.4.5" }
 interceptor = "0.7.6"
 tokio = { version = "1.19", features = ["full"] }

--- a/src/sctp_transport/mod.rs
+++ b/src/sctp_transport/mod.rs
@@ -212,12 +212,22 @@ impl RTCSctpTransport {
     }
 
     async fn accept_data_channels(param: AcceptDataChannelParams) {
+        let dcs = param.data_channels.lock().await;
+        let mut existing_data_channels = Vec::new();
+        for dc in dcs.iter() {
+            if let Some(dc) = dc.data_channel.lock().await.clone() {
+                existing_data_channels.push(dc);
+            }
+        }
+        drop(dcs);
+
         loop {
             let dc = tokio::select! {
                 _ = param.notify_rx.notified() => break,
                 result = DataChannel::accept(
                     &param.sctp_association,
                     data::data_channel::Config::default(),
+                    &existing_data_channels,
                 ) => {
                     match result {
                         Ok(dc) => dc,


### PR DESCRIPTION
Allows for acceptance of already created data channels. Duplicates logic
already existing in pion at
https://github.com/pion/webrtc/blob/master/sctptransport.go#L162.

Refs https://github.com/webrtc-rs/data/pull/14
Replaces https://github.com/webrtc-rs/webrtc/pull/219

Co-authored-by: stuqdog <ethanrodkin@protonmail.com>