### PR TITLE
Add RTP Stats to stats report

### DIFF
--- a/interceptor/src/report/receiver/mod.rs
+++ b/interceptor/src/report/receiver/mod.rs
@@ -27,7 +27,7 @@ pub(crate) struct ReceiverReportRtcpReader {
 #[async_trait]
 impl RTCPReader for ReceiverReportRtcpReader {
     async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        let (n, attr) = { self.parent_rtcp_reader.read(buf, a).await? };
+        let (n, attr) = self.parent_rtcp_reader.read(buf, a).await?;
 
         let mut b = &buf[..n];
         let pkts = rtcp::packet::unmarshal(&mut b)?;

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -1,10 +1,20 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::hash::Hash;
 use std::sync::Arc;
+use std::time::SystemTime;
 
-use super::{RTPStats, RTPStatsReader};
+use super::{StatsContainer, StatsSnapshot, StreamStats};
 use async_trait::async_trait;
-use util::sync::Mutex;
+use rtcp::payload_feedbacks::full_intra_request::FullIntraRequest;
+use rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
+use rtcp::receiver_report::ReceiverReport;
+use rtcp::transport_feedbacks::transport_layer_nack::TransportLayerNack;
+use rtp::extension::abs_send_time_extension::unix2ntp;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Duration;
+
+use util::sync::{Mutex, RwLock};
 use util::{MarshalSize, Unmarshal};
 
 use crate::error::Result;
@@ -12,47 +22,196 @@ use crate::stream_info::StreamInfo;
 use crate::{Attributes, Interceptor, RTCPReader, RTCPWriter, RTPReader, RTPWriter};
 
 #[derive(Debug)]
+enum Message {
+    StatUpdate {
+        ssrc: u32,
+        update: StatsUpdate,
+    },
+    RequestSnapshot {
+        ssrcs: Vec<u32>,
+        chan: oneshot::Sender<Vec<Option<StatsSnapshot>>>,
+    },
+}
+
+#[derive(Debug)]
+enum StatsUpdate {
+    RecvRTP {
+        packets: u64,
+        header_bytes: u64,
+        payload_bytes: u64,
+        last_packet_timestamp: SystemTime,
+    },
+    WriteRTP {
+        packets: u64,
+        header_bytes: u64,
+        payload_bytes: u64,
+        last_packet_timestamp: SystemTime,
+    },
+    RecvRTCP {
+        rtt_ms: Option<f64>,
+        loss: Option<u8>,
+        fir_count: Option<u64>,
+        pli_count: Option<u64>,
+        nack_count: Option<u64>,
+    },
+    WriteRTCP {
+        rtt_ms: Option<f64>,
+        loss: Option<u8>,
+        fir_count: Option<u64>,
+        pli_count: Option<u64>,
+        nack_count: Option<u64>,
+    },
+}
+
 pub struct StatsInterceptor {
+    // Wrapped RTP streams
     recv_streams: Mutex<HashMap<u32, Arc<RTPReadRecorder>>>,
     send_streams: Mutex<HashMap<u32, Arc<RTPWriteRecorder>>>,
+
+    tx: mpsc::Sender<Message>,
+
     id: String,
+    now_gen: Option<Arc<dyn Fn() -> SystemTime + Send + Sync>>,
 }
 
 impl StatsInterceptor {
     pub fn new(id: String) -> Self {
+        let (tx, rx) = mpsc::channel(100);
+
+        tokio::spawn(run_stats_reducer(rx));
+
         Self {
             id,
             recv_streams: Default::default(),
             send_streams: Default::default(),
+            tx,
+            now_gen: None,
         }
     }
 
-    pub fn recv_stats_reader(&self, ssrc: u32) -> Option<RTPStatsReader> {
-        self.recv_stats_readers([ssrc].iter().copied())
-            .into_iter()
-            .next()
+    fn with_time_gen<F>(id: String, now_gen: F) -> Self
+    where
+        F: Fn() -> SystemTime + Send + Sync + 'static,
+    {
+        let (tx, rx) = mpsc::channel(100);
+        tokio::spawn(run_stats_reducer(rx));
+
+        Self {
+            id,
+            recv_streams: Default::default(),
+            send_streams: Default::default(),
+            tx,
+            now_gen: Some(Arc::new(now_gen)),
+        }
     }
 
-    pub fn recv_stats_readers(&self, ssrcs: impl Iterator<Item = u32>) -> Vec<RTPStatsReader> {
-        let lock = self.recv_streams.lock();
+    pub async fn fetch_stats(&self, ssrcs: Vec<u32>) -> Vec<Option<StatsSnapshot>> {
+        let (tx, rx) = oneshot::channel();
 
-        ssrcs
-            .filter_map(|ssrc| lock.get(&ssrc).map(|r| r.reader()))
-            .collect()
+        if let Err(e) = self
+            .tx
+            .send(Message::RequestSnapshot { ssrcs, chan: tx })
+            .await
+        {
+            log::debug!(
+                "Failed to fetch RTP stream stats from stats task with error: {}",
+                e
+            );
+
+            return vec![];
+        }
+
+        rx.await.unwrap_or_default()
     }
+}
 
-    pub fn send_stats_reader(&self, ssrc: u32) -> Option<RTPStatsReader> {
-        self.send_stats_readers([ssrc].iter().copied())
-            .into_iter()
-            .next()
-    }
+async fn run_stats_reducer(mut rx: mpsc::Receiver<Message>) {
+    let mut ssrc_stats: StatsContainer = Default::default();
+    let mut cleanup_ticker = tokio::time::interval(Duration::from_secs(10));
 
-    pub fn send_stats_readers(&self, ssrcs: impl Iterator<Item = u32>) -> Vec<RTPStatsReader> {
-        let lock = self.send_streams.lock();
+    loop {
+        tokio::select! {
+            maybe_msg = rx.recv() => {
+                let msg = match maybe_msg {
+                    Some(m) => m,
+                    None => break,
+                };
+                match msg {
+                    Message::StatUpdate { ssrc, update } => {
+                        let stats = ssrc_stats.get_or_create_stream_stats(ssrc);
 
-        ssrcs
-            .filter_map(|ssrc| lock.get(&ssrc).map(|r| r.reader()))
-            .collect()
+                        match update {
+                            StatsUpdate::RecvRTP {
+                                packets,
+                                header_bytes,
+                                payload_bytes,
+                                last_packet_timestamp,
+                            }
+                            | StatsUpdate::WriteRTP {
+                                packets,
+                                header_bytes,
+                                payload_bytes,
+                                last_packet_timestamp,
+                            } => {
+                                if matches!(update, StatsUpdate::RecvRTP { .. }) {
+                                    stats.rtp_recv_stats.update(
+                                        header_bytes,
+                                        payload_bytes,
+                                        packets,
+                                        last_packet_timestamp,
+                                    );
+                                } else {
+                                    stats.rtp_write_stats.update(
+                                        header_bytes,
+                                        payload_bytes,
+                                        packets,
+                                        last_packet_timestamp,
+                                    );
+                                }
+                            }
+                            StatsUpdate::RecvRTCP {
+                                rtt_ms,
+                                loss,
+                                fir_count,
+                                pli_count,
+                                nack_count,
+                            }
+                            | StatsUpdate::WriteRTCP {
+                                rtt_ms,
+                                loss,
+                                fir_count,
+                                pli_count,
+                                nack_count,
+                            } => {
+                                if matches!(update, StatsUpdate::RecvRTCP { .. }) {
+                                    stats
+                                        .rtcp_recv_stats
+                                        .update(rtt_ms, loss, fir_count, pli_count, nack_count);
+                                } else {
+                                    stats
+                                        .rtcp_write_stats
+                                        .update(rtt_ms, loss, fir_count, pli_count, nack_count);
+                                }
+                            }
+                        }
+
+                        stats.mark_updated();
+                    }
+                    Message::RequestSnapshot { ssrcs, chan } => {
+                        let result = ssrcs
+                            .into_iter()
+                            .map(|ssrc| ssrc_stats.get(ssrc).map(StreamStats::snapshot))
+                            .collect();
+
+                        let _ = chan.send(result);
+                    }
+                }
+
+            }
+            _ = cleanup_ticker.tick() => {
+                ssrc_stats.remove_stale_entries();
+            }
+        }
     }
 }
 
@@ -69,7 +228,7 @@ impl Interceptor for StatsInterceptor {
 
         let e = lock
             .entry(info.ssrc)
-            .or_insert_with(|| Arc::new(RTPReadRecorder::new(reader)));
+            .or_insert_with(|| Arc::new(RTPReadRecorder::new(reader, self.tx.clone())));
 
         e.clone()
     }
@@ -92,7 +251,7 @@ impl Interceptor for StatsInterceptor {
 
         let e = lock
             .entry(info.ssrc)
-            .or_insert_with(|| Arc::new(RTPWriteRecorder::new(writer)));
+            .or_insert_with(|| Arc::new(RTPWriteRecorder::new(writer, self.tx.clone())));
 
         e.clone()
     }
@@ -114,8 +273,16 @@ impl Interceptor for StatsInterceptor {
         &self,
         writer: Arc<dyn RTCPWriter + Send + Sync>,
     ) -> Arc<dyn RTCPWriter + Send + Sync> {
-        // NOP
-        writer
+        let now = self
+            .now_gen
+            .clone()
+            .unwrap_or_else(|| Arc::new(SystemTime::now));
+
+        Arc::new(RTCPWriteInterceptor {
+            rtcp_writer: writer,
+            tx: self.tx.clone(),
+            now_gen: move || now(),
+        })
     }
 
     /// bind_rtcp_reader lets you modify any incoming RTCP packets. It is called once per sender/receiver, however this might
@@ -124,25 +291,206 @@ impl Interceptor for StatsInterceptor {
         &self,
         reader: Arc<dyn RTCPReader + Send + Sync>,
     ) -> Arc<dyn RTCPReader + Send + Sync> {
-        reader
+        let now = self
+            .now_gen
+            .clone()
+            .unwrap_or_else(|| Arc::new(SystemTime::now));
+
+        Arc::new(RTCPReadInterceptor {
+            rtcp_reader: reader,
+            tx: self.tx.clone(),
+            now_gen: move || now(),
+        })
+    }
+}
+
+pub struct RTCPReadInterceptor<F> {
+    rtcp_reader: Arc<dyn RTCPReader + Send + Sync>,
+    tx: mpsc::Sender<Message>,
+    now_gen: F,
+}
+
+#[async_trait]
+impl<F> RTCPReader for RTCPReadInterceptor<F>
+where
+    F: Fn() -> SystemTime + Send + Sync,
+{
+    /// read a batch of rtcp packets
+    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)> {
+        let (n, attributes) = self.rtcp_reader.read(buf, attributes).await?;
+
+        let mut b = &buf[..n];
+        let pkts = rtcp::packet::unmarshal(&mut b)?;
+        // Middle 32 bits
+        let now = (unix2ntp((self.now_gen)()) >> 16) as u32;
+
+        #[derive(Default, Debug)]
+        struct Entry {
+            rtt_ms: Option<f64>,
+            loss: Option<u8>,
+            fir_count: Option<u64>,
+            pli_count: Option<u64>,
+            nack_count: Option<u64>,
+        }
+        let updates = pkts
+            .iter()
+            .fold(HashMap::<u32, Entry>::new(), |mut acc, p| {
+                if let Some(rr) = p.as_any().downcast_ref::<ReceiverReport>() {
+                    for recp in &rr.reports {
+                        let rtt_ms = calculate_rtt_ms(now, recp.delay, recp.last_sender_report);
+
+                        let e = acc.entry(recp.ssrc).or_default();
+                        e.rtt_ms = Some(rtt_ms);
+                        e.loss = Some(recp.fraction_lost);
+                    }
+                } else if let Some(fir) = p.as_any().downcast_ref::<FullIntraRequest>() {
+                    for fir_entry in &fir.fir {
+                        let e = acc.entry(fir_entry.ssrc).or_default();
+                        e.fir_count = e.fir_count.map(|v| v + 1).or(Some(1));
+                    }
+                } else if let Some(pli) = p.as_any().downcast_ref::<PictureLossIndication>() {
+                    let e = acc.entry(pli.media_ssrc).or_default();
+                    e.pli_count = e.pli_count.map(|v| v + 1).or(Some(1));
+                } else if let Some(nack) = p.as_any().downcast_ref::<TransportLayerNack>() {
+                    let count = nack.nacks.iter().flat_map(|p| p.into_iter()).count() as u64;
+
+                    let e = acc.entry(nack.media_ssrc).or_default();
+                    e.nack_count = e.nack_count.map(|v| v + count).or(Some(count));
+                }
+
+                acc
+            });
+
+        for (
+            ssrc,
+            Entry {
+                rtt_ms,
+                loss,
+                fir_count,
+                pli_count,
+                nack_count,
+            },
+        ) in updates.into_iter()
+        {
+            let _ = self
+                .tx
+                .send(Message::StatUpdate {
+                    ssrc,
+                    update: StatsUpdate::RecvRTCP {
+                        rtt_ms,
+                        loss,
+                        fir_count,
+                        pli_count,
+                        nack_count,
+                    },
+                })
+                .await;
+        }
+
+        Ok((n, attributes))
+    }
+}
+
+pub struct RTCPWriteInterceptor<F> {
+    rtcp_writer: Arc<dyn RTCPWriter + Send + Sync>,
+    tx: mpsc::Sender<Message>,
+    now_gen: F,
+}
+
+#[async_trait]
+impl<F> RTCPWriter for RTCPWriteInterceptor<F>
+where
+    F: Fn() -> SystemTime + Send + Sync,
+{
+    async fn write(
+        &self,
+        pkts: &[Box<dyn rtcp::packet::Packet + Send + Sync>],
+        attributes: &Attributes,
+    ) -> Result<usize> {
+        let now = (unix2ntp((self.now_gen)()) >> 16) as u32;
+
+        #[derive(Default, Debug)]
+        struct Entry {
+            rtt_ms: Option<f64>,
+            loss: Option<u8>,
+            fir_count: Option<u64>,
+            pli_count: Option<u64>,
+            nack_count: Option<u64>,
+        }
+        let updates = pkts
+            .iter()
+            .fold(HashMap::<u32, Entry>::new(), |mut acc, p| {
+                if let Some(rr) = p.as_any().downcast_ref::<ReceiverReport>() {
+                    for recp in &rr.reports {
+                        let rtt_ms = calculate_rtt_ms(now, recp.delay, recp.last_sender_report);
+
+                        let e = acc.entry(recp.ssrc).or_default();
+                        e.rtt_ms = Some(rtt_ms);
+                        e.loss = Some(recp.fraction_lost);
+                    }
+                } else if let Some(fir) = p.as_any().downcast_ref::<FullIntraRequest>() {
+                    for fir_entry in &fir.fir {
+                        let e = acc.entry(fir_entry.ssrc).or_default();
+                        e.fir_count = e.fir_count.map(|v| v + 1).or(Some(1));
+                    }
+                } else if let Some(pli) = p.as_any().downcast_ref::<PictureLossIndication>() {
+                    let e = acc.entry(pli.media_ssrc).or_default();
+                    e.pli_count = e.pli_count.map(|v| v + 1).or(Some(1));
+                } else if let Some(nack) = p.as_any().downcast_ref::<TransportLayerNack>() {
+                    let count = nack.nacks.iter().flat_map(|p| p.into_iter()).count() as u64;
+
+                    let e = acc.entry(nack.media_ssrc).or_default();
+                    e.nack_count = e.nack_count.map(|v| v + count).or(Some(count));
+                }
+
+                acc
+            });
+
+        dbg!(&updates);
+        for (
+            ssrc,
+            Entry {
+                rtt_ms,
+                loss,
+                fir_count,
+                pli_count,
+                nack_count,
+            },
+        ) in updates.into_iter()
+        {
+            let _ = self
+                .tx
+                .send(Message::StatUpdate {
+                    ssrc,
+                    update: StatsUpdate::WriteRTCP {
+                        rtt_ms,
+                        loss,
+                        fir_count,
+                        pli_count,
+                        nack_count,
+                    },
+                })
+                .await;
+        }
+
+        self.rtcp_writer.write(pkts, attributes).await
     }
 }
 
 pub struct RTPReadRecorder {
     rtp_reader: Arc<dyn RTPReader + Send + Sync>,
-    stats: RTPStats,
+    tx: mpsc::Sender<Message>,
 }
 
 impl RTPReadRecorder {
-    fn new(rtp_reader: Arc<dyn RTPReader + Send + Sync>) -> Self {
-        Self {
-            rtp_reader,
-            stats: Default::default(),
-        }
+    fn new(rtp_reader: Arc<dyn RTPReader + Send + Sync>, tx: mpsc::Sender<Message>) -> Self {
+        Self { rtp_reader, tx }
     }
+}
 
-    fn reader(&self) -> RTPStatsReader {
-        self.stats.reader()
+impl fmt::Debug for RTPReadRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RTPReadRecorder").finish()
     }
 }
 
@@ -155,39 +503,37 @@ impl RTPReader for RTPReadRecorder {
         let mut b = &buf[..bytes_read];
         let packet = rtp::packet::Packet::unmarshal(&mut b)?;
 
-        self.stats.update(
-            (bytes_read - packet.payload.len()) as u64,
-            packet.payload.len() as u64,
-            1,
-        );
+        let _ = self
+            .tx
+            .send(Message::StatUpdate {
+                ssrc: packet.header.ssrc,
+                update: StatsUpdate::RecvRTP {
+                    packets: 1,
+                    header_bytes: (bytes_read - packet.payload.len()) as u64,
+                    payload_bytes: packet.payload.len() as u64,
+                    last_packet_timestamp: SystemTime::now(),
+                },
+            })
+            .await;
 
         Ok((bytes_read, attributes))
     }
 }
 
-impl fmt::Debug for RTPReadRecorder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RTPReadRecorder")
-            .field("stats", &self.stats)
-            .finish()
-    }
-}
-
 pub struct RTPWriteRecorder {
     rtp_writer: Arc<dyn RTPWriter + Send + Sync>,
-    stats: RTPStats,
+    tx: mpsc::Sender<Message>,
 }
 
 impl RTPWriteRecorder {
-    fn new(rtp_writer: Arc<dyn RTPWriter + Send + Sync>) -> Self {
-        Self {
-            rtp_writer,
-            stats: Default::default(),
-        }
+    fn new(rtp_writer: Arc<dyn RTPWriter + Send + Sync>, tx: mpsc::Sender<Message>) -> Self {
+        Self { rtp_writer, tx }
     }
+}
 
-    fn reader(&self) -> RTPStatsReader {
-        self.stats.reader()
+impl fmt::Debug for RTPWriteRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RTPWriteRecorder").finish()
     }
 }
 
@@ -197,29 +543,92 @@ impl RTPWriter for RTPWriteRecorder {
     async fn write(&self, pkt: &rtp::packet::Packet, attributes: &Attributes) -> Result<usize> {
         let n = self.rtp_writer.write(pkt, attributes).await?;
 
-        self.stats.update(
-            pkt.header.marshal_size() as u64,
-            pkt.payload.len() as u64,
-            1,
-        );
+        let _ = self
+            .tx
+            .send(Message::StatUpdate {
+                ssrc: pkt.header.ssrc,
+                update: StatsUpdate::WriteRTP {
+                    packets: 1,
+                    header_bytes: pkt.header.marshal_size() as u64,
+                    payload_bytes: pkt.payload.len() as u64,
+                    last_packet_timestamp: SystemTime::now(),
+                },
+            })
+            .await;
 
         Ok(n)
     }
 }
 
-impl fmt::Debug for RTPWriteRecorder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RTPWriteRecorder")
-            .field("stats", &self.stats)
-            .finish()
+trait GetOrCreateAtomic<T, U> {
+    fn get_or_create(&self, key: T) -> U;
+}
+
+impl<T, U> GetOrCreateAtomic<T, U> for RwLock<HashMap<T, U>>
+where
+    T: Hash + Eq,
+    U: Default + Clone,
+{
+    fn get_or_create(&self, key: T) -> U {
+        let lock = self.read();
+
+        if let Some(v) = lock.get(&key) {
+            v.clone()
+        } else {
+            // Upgrade lock to write
+            drop(lock);
+            let mut lock = self.write();
+
+            lock.entry(key).or_default().clone()
+        }
     }
+}
+
+/// Calculate the round trip time for a given peer as described in
+/// [RFC3550 6.4.1](https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1).
+///
+/// ## Params
+///
+/// - `now` the current middle 32 bits of an NTP timestamp for the current time.
+/// - `delay` the delay(`DLSR`) since last sender report expressed as fractions of a second in 32 bits.
+/// - `last_sender_report` the middle 32 bits of an NTP timestamp for the most recent sender report(LSR).
+fn calculate_rtt_ms(now: u32, delay: u32, last_sender_report: u32) -> f64 {
+    // [10 Nov 1995 11:33:25.125 UTC]       [10 Nov 1995 11:33:36.5 UTC]
+    // n                 SR(n)              A=b710:8000 (46864.500 s)
+    // ---------------------------------------------------------------->
+    //                    v                 ^
+    // ntp_sec =0xb44db705 v               ^ dlsr=0x0005:4000 (    5.250s)
+    // ntp_frac=0x20000000  v             ^  lsr =0xb705:2000 (46853.125s)
+    //   (3024992005.125 s)  v           ^
+    // r                      v         ^ RR(n)
+    // ---------------------------------------------------------------->
+    //                        |<-DLSR->|
+    //                         (5.250 s)
+    //
+    // A     0xb710:8000 (46864.500 s)
+    // DLSR -0x0005:4000 (    5.250 s)
+    // LSR  -0xb705:2000 (46853.125 s)
+    // -------------------------------
+    // delay 0x0006:2000 (    6.125 s)
+
+    let rtt = now - delay - last_sender_report;
+    let rtt_seconds = rtt >> 16;
+    let rtt_fraction = (rtt & (u16::MAX as u32)) as f64 / (u16::MAX as u32) as f64;
+
+    rtt_seconds as f64 * 1000.0 + (rtt_fraction as f64) * 1000.0
 }
 
 #[cfg(test)]
 mod test {
     use bytes::Bytes;
+    use rtcp::payload_feedbacks::full_intra_request::{FirEntry, FullIntraRequest};
+    use rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
+    use rtcp::receiver_report::ReceiverReport;
+    use rtcp::reception_report::ReceptionReport;
+    use rtcp::transport_feedbacks::transport_layer_nack::{NackPair, TransportLayerNack};
 
     use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
 
     use crate::error::Result;
     use crate::mock::mock_stream::MockStream;
@@ -228,7 +637,7 @@ mod test {
     use super::StatsInterceptor;
 
     #[tokio::test]
-    async fn test_stats_interceptor() -> Result<()> {
+    async fn test_stats_interceptor_rtp() -> Result<()> {
         let icpr: Arc<_> = Arc::new(StatsInterceptor::new("Hello".to_owned()));
 
         let recv_stream = MockStream::new(
@@ -249,17 +658,10 @@ mod test {
         )
         .await;
 
-        let recv_reader = icpr
-            .recv_stats_reader(123456)
-            .expect("After binding recv_stats_reader should return Some");
-
-        let send_reader = icpr
-            .send_stats_reader(234567)
-            .expect("After binding send_stats_reader should return Some");
-
         let _ = recv_stream
             .receive_rtp(rtp::packet::Packet {
                 header: rtp::header::Header {
+                    ssrc: 123456,
                     ..Default::default()
                 },
                 payload: Bytes::from_static(b"\xde\xad\xbe\xef"),
@@ -271,13 +673,10 @@ mod test {
             .await
             .expect("After calling receive_rtp read_rtp should return Some")?;
 
-        assert_eq!(recv_reader.packets(), 1);
-        assert_eq!(recv_reader.header_bytes(), 12);
-        assert_eq!(recv_reader.payload_bytes(), 4);
-
         let _ = send_stream
             .write_rtp(&rtp::packet::Packet {
                 header: rtp::header::Header {
+                    ssrc: 234567,
                     ..Default::default()
                 },
                 payload: Bytes::from_static(b"\xde\xad\xbe\xef\xde\xad\xbe\xef"),
@@ -287,15 +686,180 @@ mod test {
         let _ = send_stream
             .write_rtp(&rtp::packet::Packet {
                 header: rtp::header::Header {
+                    ssrc: 234567,
                     ..Default::default()
                 },
                 payload: Bytes::from_static(&[0x13, 0x37]),
             })
             .await;
 
-        assert_eq!(send_reader.packets(), 2);
-        assert_eq!(send_reader.header_bytes(), 24);
-        assert_eq!(send_reader.payload_bytes(), 10);
+        let snapshots = icpr.fetch_stats(vec![123456]).await;
+        let recv_snapshot = snapshots[0]
+            .as_ref()
+            .expect("Stats should exist for ssrc: 123456");
+        assert_eq!(recv_snapshot.rtp_recv_stats.packets(), 1);
+        assert_eq!(recv_snapshot.rtp_recv_stats.header_bytes(), 12);
+        assert_eq!(recv_snapshot.rtp_recv_stats.payload_bytes(), 4);
+
+        let snapshots = icpr.fetch_stats(vec![234567]).await;
+        let send_snapshot = snapshots[0]
+            .as_ref()
+            .expect("Stats should exist for ssrc: 234567");
+        assert_eq!(send_snapshot.rtp_write_stats.packets(), 2);
+        assert_eq!(send_snapshot.rtp_write_stats.header_bytes(), 24);
+        assert_eq!(send_snapshot.rtp_write_stats.payload_bytes(), 10);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stats_interceptor_rtcp() -> Result<()> {
+        let icpr: Arc<_> = Arc::new(StatsInterceptor::with_time_gen("Hello".to_owned(), || {
+            // 10 Nov 1995 11:33:36.5 UTC
+            SystemTime::UNIX_EPOCH + Duration::from_secs_f64(816003216.5)
+        }));
+
+        let recv_stream = MockStream::new(
+            &StreamInfo {
+                ssrc: 123456,
+                ..Default::default()
+            },
+            icpr.clone(),
+        )
+        .await;
+
+        let send_stream = MockStream::new(
+            &StreamInfo {
+                ssrc: 234567,
+                ..Default::default()
+            },
+            icpr.clone(),
+        )
+        .await;
+
+        send_stream
+            .receive_rtcp(vec![
+                Box::new(ReceiverReport {
+                    reports: vec![ReceptionReport {
+                        ssrc: 234567,
+                        last_sender_report: 0xb705_2000,
+                        delay: 0x0005_4000,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                Box::new(TransportLayerNack {
+                    sender_ssrc: 0,
+                    media_ssrc: 234567,
+                    nacks: vec![NackPair {
+                        packet_id: 5,
+                        lost_packets: 0b0011_0110,
+                    }],
+                }),
+                Box::new(TransportLayerNack {
+                    sender_ssrc: 0,
+                    // NB: Different SSRC
+                    media_ssrc: 999999,
+                    nacks: vec![NackPair {
+                        packet_id: 5,
+                        lost_packets: 0b0011_0110,
+                    }],
+                }),
+                Box::new(PictureLossIndication {
+                    sender_ssrc: 0,
+                    media_ssrc: 234567,
+                }),
+                Box::new(PictureLossIndication {
+                    sender_ssrc: 0,
+                    media_ssrc: 234567,
+                }),
+                Box::new(FullIntraRequest {
+                    sender_ssrc: 0,
+                    media_ssrc: 234567,
+                    fir: vec![
+                        FirEntry {
+                            ssrc: 234567,
+                            sequence_number: 132,
+                        },
+                        FirEntry {
+                            ssrc: 234567,
+                            sequence_number: 135,
+                        },
+                    ],
+                }),
+            ])
+            .await;
+
+        let _ = send_stream
+            .read_rtcp()
+            .await
+            .expect("After calling `receive_rtcp`, `read_rtcp` should return some packets");
+
+        recv_stream
+            .write_rtcp(&[
+                Box::new(TransportLayerNack {
+                    sender_ssrc: 0,
+                    media_ssrc: 123456,
+                    nacks: vec![NackPair {
+                        packet_id: 5,
+                        lost_packets: 0b0011_0111,
+                    }],
+                }),
+                Box::new(TransportLayerNack {
+                    sender_ssrc: 0,
+                    // NB: Different SSRC
+                    media_ssrc: 999999,
+                    nacks: vec![NackPair {
+                        packet_id: 5,
+                        lost_packets: 0b1111_0110,
+                    }],
+                }),
+                Box::new(PictureLossIndication {
+                    sender_ssrc: 0,
+                    media_ssrc: 123456,
+                }),
+                Box::new(PictureLossIndication {
+                    sender_ssrc: 0,
+                    media_ssrc: 123456,
+                }),
+                Box::new(PictureLossIndication {
+                    sender_ssrc: 0,
+                    media_ssrc: 123456,
+                }),
+                Box::new(FullIntraRequest {
+                    sender_ssrc: 0,
+                    media_ssrc: 123456,
+                    fir: vec![FirEntry {
+                        ssrc: 123456,
+                        sequence_number: 132,
+                    }],
+                }),
+            ])
+            .await
+            .expect("Failed to write RTCP packets for recv_stream");
+        let snapshots = icpr.fetch_stats(vec![234567]).await;
+
+        let send_snapshot = snapshots[0]
+            .as_ref()
+            .expect("Stats should exist for ssrc: 234567");
+        let rtt_ms = send_snapshot.rtcp_recv_stats.rtt_ms;
+        assert!(
+            rtt_ms > 6124.99 && rtt_ms < 6125.01,
+            "Expected rtt_ms to be about ~6125.0 it was {}",
+            rtt_ms
+        );
+
+        assert_eq!(send_snapshot.rtcp_recv_stats.nack_count(), 5);
+        assert_eq!(send_snapshot.rtcp_recv_stats.pli_count(), 2);
+        assert_eq!(send_snapshot.rtcp_recv_stats.fir_count(), 2);
+
+        let snapshots = icpr.fetch_stats(vec![123456]).await;
+        let recv_snapshot = snapshots[0]
+            .as_ref()
+            .expect("Stats should exist for ssrc: 123456");
+        assert_eq!(recv_snapshot.rtcp_write_stats.fir_count(), 1);
+        assert_eq!(recv_snapshot.rtcp_write_stats.nack_count(), 6);
+        assert_eq!(recv_snapshot.rtcp_write_stats.pli_count(), 3);
 
         Ok(())
     }

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -446,7 +446,6 @@ where
                 acc
             });
 
-        dbg!(&updates);
         for (
             ssrc,
             Entry {

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -70,7 +70,7 @@ pub struct StatsInterceptor {
     tx: mpsc::Sender<Message>,
 
     id: String,
-    now_gen: Option<Arc<dyn Fn() -> SystemTime + Send + Sync>>,
+    now_gen: Arc<dyn Fn() -> SystemTime + Send + Sync>,
 }
 
 impl StatsInterceptor {
@@ -84,7 +84,7 @@ impl StatsInterceptor {
             recv_streams: Default::default(),
             send_streams: Default::default(),
             tx,
-            now_gen: None,
+            now_gen: Arc::new(SystemTime::now),
         }
     }
 
@@ -100,7 +100,7 @@ impl StatsInterceptor {
             recv_streams: Default::default(),
             send_streams: Default::default(),
             tx,
-            now_gen: Some(Arc::new(now_gen)),
+            now_gen: Arc::new(now_gen),
         }
     }
 
@@ -273,10 +273,7 @@ impl Interceptor for StatsInterceptor {
         &self,
         writer: Arc<dyn RTCPWriter + Send + Sync>,
     ) -> Arc<dyn RTCPWriter + Send + Sync> {
-        let now = self
-            .now_gen
-            .clone()
-            .unwrap_or_else(|| Arc::new(SystemTime::now));
+        let now = self.now_gen.clone();
 
         Arc::new(RTCPWriteInterceptor {
             rtcp_writer: writer,
@@ -291,10 +288,7 @@ impl Interceptor for StatsInterceptor {
         &self,
         reader: Arc<dyn RTCPReader + Send + Sync>,
     ) -> Arc<dyn RTCPReader + Send + Sync> {
-        let now = self
-            .now_gen
-            .clone()
-            .unwrap_or_else(|| Arc::new(SystemTime::now));
+        let now = self.now_gen.clone();
 
         Arc::new(RTCPReadInterceptor {
             rtcp_reader: reader,

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -43,9 +43,7 @@ impl Iterator for NackIterator {
 
                 Some(self.packet_id)
             }
-            Some(id) if self.bitfield != 0 => {
-                let mut i = id;
-
+            Some(mut i) if self.bitfield != 0 => {
                 while self.bitfield != 0 {
                     if (self.bitfield & (1 << i)) != 0 {
                         self.bitfield &= !(1 << i);

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -16,7 +16,7 @@ type PacketBitmap = u16;
 
 /// NackPair is a wire-representation of a collection of
 /// Lost RTP packets
-#[derive(Debug, PartialEq, Eq, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub struct NackPair {
     /// ID of lost packets
     pub packet_id: u16,
@@ -27,40 +27,69 @@ pub struct NackPair {
 pub type RangeFn =
     Box<dyn (Fn(u16) -> Pin<Box<dyn Future<Output = bool> + Send + 'static>>) + Send + Sync>;
 
+pub struct NackIterator {
+    packet_id: u16,
+    bitfield: PacketBitmap,
+    index: Option<u16>,
+}
+
+impl Iterator for NackIterator {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.index {
+            None => {
+                self.index = Some(0);
+
+                Some(self.packet_id)
+            }
+            Some(id) if self.bitfield != 0 => {
+                let mut i = id;
+
+                while self.bitfield != 0 {
+                    if (self.bitfield & (1 << i)) != 0 {
+                        self.bitfield &= !(1 << i);
+                        self.index = Some(i + 1);
+
+                        return Some(self.packet_id.wrapping_add(i + 1));
+                    }
+
+                    i += 1;
+                }
+
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
 impl NackPair {
     /// PacketList returns a list of Nack'd packets that's referenced by a NackPair
     pub fn packet_list(&self) -> Vec<u16> {
-        let mut out = vec![self.packet_id];
-
-        let mut b = self.lost_packets;
-        let mut i = 0;
-
-        while b != 0 {
-            if (b & (1 << i)) != 0 {
-                b &= !(1 << i);
-                out.push(self.packet_id + i + 1);
-            }
-            i += 1;
-        }
-        out
+        self.into_iter().collect()
     }
 
     pub async fn range(&self, f: RangeFn) {
-        if !f(self.packet_id).await {
-            return;
-        }
-
-        let mut b = self.lost_packets;
-        let mut i = 0u16;
-        while b != 0 {
-            if (b & (1 << i)) != 0 {
-                b &= u16::MAX ^ (1 << i);
-                let (packet_id, _) = self.packet_id.overflowing_add(i + 1);
-                if !f(packet_id).await {
-                    return;
-                }
+        for packet_id in self.into_iter() {
+            if !f(packet_id).await {
+                return;
             }
-            i += 1;
+        }
+    }
+}
+
+/// Create an iterator over all the packet sequence numbers expressed by this NACK pair.
+impl IntoIterator for NackPair {
+    type Item = u16;
+
+    type IntoIter = NackIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        NackIterator {
+            packet_id: self.packet_id,
+            bitfield: self.lost_packets,
+            index: None,
         }
     }
 }
@@ -231,7 +260,7 @@ pub fn nack_pairs_from_sequence_numbers(seq_nos: &[u16]) -> Vec<NackPair> {
             continue;
         }
         if seq <= nack_pair.packet_id || seq > nack_pair.packet_id.saturating_add(16) {
-            pairs.push(nack_pair.clone());
+            pairs.push(nack_pair);
             nack_pair.packet_id = seq;
             continue;
         }

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
@@ -190,6 +190,15 @@ fn test_nack_pair() {
             lost_packets: 0x8000,
         },
     );
+
+    // Wrap around
+    test_nack(
+        vec![65534, 65535, 0, 1],
+        NackPair {
+            packet_id: 65534,
+            lost_packets: 0b0000_0111,
+        },
+    );
 }
 
 #[tokio::test]

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
@@ -199,6 +199,15 @@ fn test_nack_pair() {
             lost_packets: 0b0000_0111,
         },
     );
+
+    // Gap
+    test_nack(
+        vec![123, 125, 127, 129],
+        NackPair {
+            packet_id: 123,
+            lost_packets: 0b0010_1010,
+        },
+    );
 }
 
 #[tokio::test]

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -74,7 +74,7 @@ use ::ice::candidate::Candidate;
 use ::sdp::description::session::*;
 use ::sdp::util::ConnectionRole;
 use async_trait::async_trait;
-use interceptor::{Attributes, Interceptor, RTCPWriter};
+use interceptor::{stats, Attributes, Interceptor, RTCPWriter};
 use peer_connection_internal::*;
 use rand::{thread_rng, Rng};
 use rcgen::KeyPair;
@@ -221,9 +221,18 @@ impl RTCPeerConnection {
     pub(crate) async fn new(api: &API, mut configuration: RTCConfiguration) -> Result<Self> {
         RTCPeerConnection::init_configuration(&mut configuration)?;
 
-        let interceptor = api.interceptor_registry.build("")?;
+        let (interceptor, stats_interceptor): (Arc<dyn Interceptor + Send + Sync>, _) = {
+            let mut chain = api.interceptor_registry.build_chain("")?;
+            let stats_interceptor = stats::make_stats_interceptor("");
+            chain.add(stats_interceptor.clone());
+
+            (Arc::new(chain), stats_interceptor)
+        };
+
+        let weak_interceptor = Arc::downgrade(&interceptor);
         let (internal, configuration) =
-            PeerConnectionInternal::new(api, Arc::downgrade(&interceptor), configuration).await?;
+            PeerConnectionInternal::new(api, weak_interceptor, stats_interceptor, configuration)
+                .await?;
         let internal_rtcp_writer = Arc::clone(&internal) as Arc<dyn RTCPWriter + Send + Sync>;
         let interceptor_rtcp_writer = interceptor.bind_rtcp_writer(internal_rtcp_writer).await;
 

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -97,7 +97,13 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
 
     // Block Until packet with 0xAA has been seen
     tokio::spawn(async move {
-        send_video_until_done(seen_packet_a_rx, vec![track_a], Bytes::from_static(&[0xAA])).await;
+        send_video_until_done(
+            seen_packet_a_rx,
+            vec![track_a],
+            Bytes::from_static(&[0xAA]),
+            None,
+        )
+        .await;
     });
 
     rtp_sender
@@ -108,7 +114,13 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
 
     // Block Until packet with 0xBB has been seen
     tokio::spawn(async move {
-        send_video_until_done(seen_packet_b_rx, vec![track_b], Bytes::from_static(&[0xBB])).await;
+        send_video_until_done(
+            seen_packet_b_rx,
+            vec![track_b],
+            Bytes::from_static(&[0xBB]),
+            None,
+        )
+        .await;
     });
 
     close_pair_now(&sender, &receiver).await;
@@ -235,7 +247,13 @@ async fn test_rtp_sender_replace_track_invalid_track_kind_change() -> Result<()>
         .await;
 
     tokio::spawn(async move {
-        send_video_until_done(seen_packet_rx, vec![track_a], Bytes::from_static(&[0xAA])).await;
+        send_video_until_done(
+            seen_packet_rx,
+            vec![track_a],
+            Bytes::from_static(&[0xAA]),
+            None,
+        )
+        .await;
     });
 
     if let Err(err) = rtp_sender.replace_track(Some(track_b)).await {
@@ -315,7 +333,13 @@ async fn test_rtp_sender_replace_track_invalid_codec_change() -> Result<()> {
         .await;
 
     tokio::spawn(async move {
-        send_video_until_done(seen_packet_rx, vec![track_a], Bytes::from_static(&[0xAA])).await;
+        send_video_until_done(
+            seen_packet_rx,
+            vec![track_a],
+            Bytes::from_static(&[0xAA]),
+            None,
+        )
+        .await;
     });
 
     if let Err(err) = rtp_sender.replace_track(Some(track_b)).await {

--- a/webrtc/src/track/track_local/track_local_static_test.rs
+++ b/webrtc/src/track/track_local/track_local_static_test.rs
@@ -278,7 +278,13 @@ async fn test_track_local_static_payload_type() -> Result<()> {
 
     signal_pair(&mut offerer, &mut answerer).await?;
 
-    send_video_until_done(on_track_fired_rx, vec![track], Bytes::from_static(&[0x00])).await;
+    send_video_until_done(
+        on_track_fired_rx,
+        vec![track],
+        Bytes::from_static(&[0x00]),
+        None,
+    )
+    .await;
 
     close_pair_now(&offerer, &answerer).await;
 


### PR DESCRIPTION
This PR implements inbound and outbound RTP stats according to the 
[specification](https://www.w3.org/TR/webrtc-stats/), with some 
limitations. 

## Todo

- [x] Inbound RTP
- [x] Outbound RTP
- [x] Tests
