### PR TITLE
Revert "base id updating on whether it's been negotiated, not on its …

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -157,7 +157,7 @@ impl RTCDataChannel {
                 negotiated: self.negotiated,
             };
 
-            if !self.negotiated {
+            if self.id.load(Ordering::SeqCst) == 0 {
                 self.id.store(
                     sctp_transport
                         .generate_and_set_data_channel_id(


### PR DESCRIPTION
…value (#226)"

This reverts commit 823c3f80f13b40a7454efebc8f40ddbc04c24099.

As pointed out in [the original PR](https://github.com/webrtc-rs/webrtc/pull/226#issuecomment-1202028922), this commit broke the API guarantees we had before. I don't think I have time right now to fix this properly, but maybe @stuqdog does?