### PR TITLE
Fix recent clippy lints

### DIFF
--- a/src/data_channel/data_channel_state.rs
+++ b/src/data_channel/data_channel_state.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::fmt;
 
 /// DataChannelState indicates the state of a data channel.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum RTCDataChannelState {
     #[serde(rename = "unspecified")]
     Unspecified = 0,

--- a/src/dtls_transport/dtls_role.rs
+++ b/src/dtls_transport/dtls_role.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// DtlsRole indicates the role of the DTLS transport.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DTLSRole {
     Unspecified = 0,
 

--- a/src/dtls_transport/dtls_transport_state.rs
+++ b/src/dtls_transport/dtls_transport_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// DTLSTransportState indicates the DTLS transport establishment state.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCDtlsTransportState {
     Unspecified = 0,
 

--- a/src/ice_transport/ice_candidate.rs
+++ b/src/ice_transport/ice_candidate.rs
@@ -14,7 +14,7 @@ use crate::ice_transport::ice_candidate_type::RTCIceCandidateType;
 use crate::ice_transport::ice_protocol::RTCIceProtocol;
 
 /// ICECandidate represents a ice candidate
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RTCIceCandidate {
     pub stats_id: String,
     pub foundation: String,
@@ -166,7 +166,7 @@ impl fmt::Display for RTCIceCandidate {
 }
 
 /// ICECandidateInit is used to serialize ice candidates
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RTCIceCandidateInit {
     pub candidate: String,

--- a/src/ice_transport/ice_candidate_pair.rs
+++ b/src/ice_transport/ice_candidate_pair.rs
@@ -3,7 +3,7 @@ use crate::ice_transport::ice_candidate::*;
 use std::fmt;
 
 /// ICECandidatePair represents an ICE Candidate pair
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCIceCandidatePair {
     stats_id: String,
     local: RTCIceCandidate,

--- a/src/ice_transport/ice_candidate_type.rs
+++ b/src/ice_transport/ice_candidate_type.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// ICECandidateType represents the type of the ICE candidate used.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RTCIceCandidateType {
     Unspecified,
 

--- a/src/ice_transport/ice_connection_state.rs
+++ b/src/ice_transport/ice_connection_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// RTCIceConnectionState indicates signaling state of the ICE Connection.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceConnectionState {
     Unspecified,
 

--- a/src/ice_transport/ice_credential_type.rs
+++ b/src/ice_transport/ice_credential_type.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 /// ICECredentialType indicates the type of credentials used to connect to
 /// an ICE server.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceCredentialType {
     Unspecified,
 

--- a/src/ice_transport/ice_gatherer_state.rs
+++ b/src/ice_transport/ice_gatherer_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// ICEGathererState represents the current state of the ICE gatherer.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceGathererState {
     Unspecified,
 

--- a/src/ice_transport/ice_gathering_state.rs
+++ b/src/ice_transport/ice_gathering_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// ICEGatheringState describes the state of the candidate gathering process.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceGatheringState {
     Unspecified,
 

--- a/src/ice_transport/ice_parameters.rs
+++ b/src/ice_transport/ice_parameters.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// ICEParameters includes the ICE username fragment
 /// and password and other ICE-related parameters.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RTCIceParameters {
     pub username_fragment: String,
     pub password: String,

--- a/src/ice_transport/ice_protocol.rs
+++ b/src/ice_transport/ice_protocol.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// ICEProtocol indicates the transport protocol type that is used in the
 /// ice.URL structure.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RTCIceProtocol {
     Unspecified,
 

--- a/src/ice_transport/ice_role.rs
+++ b/src/ice_transport/ice_role.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 /// ICERole describes the role ice.Agent is playing in selecting the
 /// preferred the candidate pair.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceRole {
     Unspecified,
 

--- a/src/ice_transport/ice_transport_state.rs
+++ b/src/ice_transport/ice_transport_state.rs
@@ -2,7 +2,7 @@ use ice::state::ConnectionState;
 use std::fmt;
 
 /// ICETransportState represents the current state of the ICE transport.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceTransportState {
     Unspecified,
 

--- a/src/peer_connection/offer_answer_options.rs
+++ b/src/peer_connection/offer_answer_options.rs
@@ -1,6 +1,6 @@
 /// AnswerOptions structure describes the options used to control the answer
 /// creation process.
-#[derive(Default, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct RTCAnswerOptions {
     /// voice_activity_detection allows the application to provide information
     /// about whether it wishes voice detection feature to be enabled or disabled.
@@ -9,7 +9,7 @@ pub struct RTCAnswerOptions {
 
 /// OfferOptions structure describes the options used to control the offer
 /// creation process
-#[derive(Default, Debug, PartialEq, Copy, Clone)]
+#[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct RTCOfferOptions {
     /// voice_activity_detection allows the application to provide information
     /// about whether it wishes voice detection feature to be enabled or disabled.

--- a/src/peer_connection/peer_connection_state.rs
+++ b/src/peer_connection/peer_connection_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// PeerConnectionState indicates the state of the PeerConnection.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCPeerConnectionState {
     Unspecified,
 

--- a/src/peer_connection/policy/bundle_policy.rs
+++ b/src/peer_connection/policy/bundle_policy.rs
@@ -5,7 +5,7 @@ use std::fmt;
 /// endpoint is not bundle-aware, and what ICE candidates are gathered. If the
 /// remote endpoint is bundle-aware, all media tracks and data channels are
 /// bundled onto the same transport.
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCBundlePolicy {
     Unspecified = 0,
 

--- a/src/peer_connection/policy/ice_transport_policy.rs
+++ b/src/peer_connection/policy/ice_transport_policy.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// ICETransportPolicy defines the ICE candidate policy surface the
 /// permitted candidates. Only these candidates are used for connectivity checks.
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCIceTransportPolicy {
     Unspecified = 0,
 

--- a/src/peer_connection/policy/rtcp_mux_policy.rs
+++ b/src/peer_connection/policy/rtcp_mux_policy.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// RTCPMuxPolicy affects what ICE candidates are gathered to support
 /// non-multiplexed RTCP.
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCRtcpMuxPolicy {
     Unspecified = 0,
 

--- a/src/peer_connection/policy/sdp_semantics.rs
+++ b/src/peer_connection/policy/sdp_semantics.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// SDPSemantics determines which style of SDP offers and answers
 /// can be used
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCSdpSemantics {
     Unspecified = 0,
 

--- a/src/peer_connection/sdp/sdp_type.rs
+++ b/src/peer_connection/sdp/sdp_type.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// SDPType describes the type of an SessionDescription.
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCSdpType {
     Unspecified = 0,
 

--- a/src/peer_connection/signaling_state.rs
+++ b/src/peer_connection/signaling_state.rs
@@ -26,7 +26,7 @@ impl fmt::Display for StateChangeOp {
 }
 
 /// SignalingState indicates the signaling state of the offer/answer process.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCSignalingState {
     Unspecified = 0,
 

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -61,7 +61,7 @@ pub const TYPE_RTCP_FB_NACK: &str = "nack";
 
 /// rtcpfeedback signals the connection to use additional RTCP packet types.
 /// <https://draft.ortc.org/#dom-rtcrtcpfeedback>
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCPFeedback {
     /// Type is the type of feedback.
     /// see: <https://draft.ortc.org/#dom-rtcrtcpfeedback>
@@ -240,7 +240,7 @@ impl RTCRtpTransceiver {
     /// Codecs returns list of supported codecs
     pub(crate) async fn get_codecs(&self) -> Vec<RTCRtpCodecParameters> {
         let mut codecs = self.codecs.lock().await;
-        RTPReceiverInternal::get_codecs(&mut *codecs, self.kind, &self.media_engine).await
+        RTPReceiverInternal::get_codecs(&mut codecs, self.kind, &self.media_engine).await
     }
 
     /// sender returns the RTPTransceiver's RTPSender if it has one

--- a/src/rtp_transceiver/rtp_codec.rs
+++ b/src/rtp_transceiver/rtp_codec.rs
@@ -6,7 +6,7 @@ use crate::rtp_transceiver::fmtp;
 use std::fmt;
 
 /// RTPCodecType determines the type of a codec
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTPCodecType {
     Unspecified = 0,
 
@@ -56,7 +56,7 @@ impl fmt::Display for RTPCodecType {
 
 /// RTPCodecCapability provides information about codec capabilities.
 /// <https://w3c.github.io/webrtc-pc/#dictionary-rtcrtpcodeccapability-members>
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCRtpCodecCapability {
     pub mime_type: String,
     pub clock_rate: u32,
@@ -100,7 +100,7 @@ pub struct RTCRtpHeaderExtensionCapability {
 
 /// RTPHeaderExtensionParameter represents a negotiated RFC5285 RTP header extension.
 /// <https://w3c.github.io/webrtc-pc/#dictionary-rtcrtpheaderextensionparameters-members>
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCRtpHeaderExtensionParameters {
     pub uri: String,
     pub id: isize,
@@ -110,7 +110,7 @@ pub struct RTCRtpHeaderExtensionParameters {
 /// will choose from, as well as entries for RTX, RED and FEC mechanisms. This also
 /// includes the PayloadType that has been negotiated
 /// <https://w3c.github.io/webrtc-pc/#rtcrtpcodecparameters>
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCRtpCodecParameters {
     pub capability: RTCRtpCodecCapability,
     pub payload_type: PayloadType,

--- a/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -173,9 +173,7 @@ impl RTPReceiverInternal {
                 loop {
                     tokio::select! {
                         res = State::error_on_close(&mut state_watch_rx) => {
-                            if let Err(e) = res {
-                                return Err(e);
-                            }
+                            res?
                         }
                         result = rtcp_interceptor.read(b, &a) => {
                             return Ok(result?)
@@ -207,9 +205,7 @@ impl RTPReceiverInternal {
                     loop {
                         tokio::select! {
                             res = State::error_on_close(&mut state_watch_rx) => {
-                                if let Err(e) = res {
-                                    return Err(e);
-                                }
+                                res?
                             }
                             result = rtcp_interceptor.read(b, &a) => {
                                 return Ok(result?);
@@ -323,7 +319,7 @@ impl RTPReceiverInternal {
         if let Some(codecs) = &*transceiver_codecs {
             let mut c = codecs.lock().await;
             parameters.codecs =
-                RTPReceiverInternal::get_codecs(&mut *c, self.kind, &self.media_engine).await;
+                RTPReceiverInternal::get_codecs(&mut c, self.kind, &self.media_engine).await;
         }
 
         parameters

--- a/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/src/rtp_transceiver/rtp_sender/mod.rs
@@ -296,7 +296,7 @@ impl RTCRtpSender {
             };
             if let Some(t) = t {
                 let context = self.context.lock().await;
-                t.unbind(&*context).await?;
+                t.unbind(&context).await?;
             }
         }
 
@@ -444,7 +444,7 @@ impl RTCRtpSender {
 
         {
             let stream_info = self.stream_info.lock().await;
-            self.interceptor.unbind_local_stream(&*stream_info).await;
+            self.interceptor.unbind_local_stream(&stream_info).await;
         }
 
         self.srtp_stream.close().await

--- a/src/rtp_transceiver/rtp_transceiver_direction.rs
+++ b/src/rtp_transceiver/rtp_transceiver_direction.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// RTPTransceiverDirection indicates the direction of the RTPTransceiver.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCRtpTransceiverDirection {
     Unspecified,
 

--- a/src/sctp_transport/sctp_transport_capabilities.rs
+++ b/src/sctp_transport/sctp_transport_capabilities.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// SCTPTransportCapabilities indicates the capabilities of the SCTPTransport.
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub struct SCTPTransportCapabilities {
     pub max_message_size: u32,
 }

--- a/src/sctp_transport/sctp_transport_state.rs
+++ b/src/sctp_transport/sctp_transport_state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// SCTPTransportState indicates the state of the SCTP transport.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RTCSctpTransportState {
     Unspecified,


### PR DESCRIPTION
Rust 1.63.0 introduces new clippy lints that were failing CI, this fixes
them.
