### PR TITLE
Pause RTP writing if direction indicates it

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -164,6 +164,7 @@ impl API {
             transport,
             Arc::clone(&self.media_engine),
             interceptor,
+            false,
         )
         .await
     }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1718,6 +1718,7 @@ impl RTCPeerConnection {
                             Arc::clone(&self.internal.dtls_transport),
                             Arc::clone(&self.internal.media_engine),
                             Arc::clone(&self.interceptor),
+                            false, // adding a track sets a send direction.
                         )
                         .await,
                     );

--- a/src/peer_connection/peer_connection_internal.rs
+++ b/src/peer_connection/peer_connection_internal.rs
@@ -542,6 +542,7 @@ impl PeerConnectionInternal {
                         Arc::clone(&self.dtls_transport),
                         Arc::clone(&self.media_engine),
                         Arc::clone(&interceptor),
+                        false,
                     )
                     .await,
                 ));
@@ -555,6 +556,7 @@ impl PeerConnectionInternal {
                         Arc::clone(&self.dtls_transport),
                         Arc::clone(&self.media_engine),
                         Arc::clone(&interceptor),
+                        false,
                     )
                     .await,
                 ));

--- a/src/peer_connection/sdp/sdp_test.rs
+++ b/src/peer_connection/sdp/sdp_test.rs
@@ -637,6 +637,7 @@ async fn test_media_description_fingerprints() -> Result<()> {
                     Arc::new(RTCDtlsTransport::default()),
                     Arc::clone(&api.media_engine),
                     Arc::clone(&interceptor),
+                    false,
                 )
                 .await,
             )))

--- a/src/rtp_transceiver/mod.rs
+++ b/src/rtp_transceiver/mod.rs
@@ -400,27 +400,25 @@ impl RTCRtpTransceiver {
                 previous_direction,
                 current_direction
             );
+        } else {
+            // no change.
+            return Ok(());
         }
 
-        match (previous_direction, current_direction) {
-            (a, b) if a == b => {
-                // No change, do nothing
+        if let Some(receiver) = &*self.receiver.lock().await {
+            let pause_receiver = !current_direction.has_recv();
+
+            if pause_receiver {
+                receiver.pause().await?;
+            } else {
+                receiver.resume().await?;
             }
-            // All others imply a change
-            (_, RTCRtpTransceiverDirection::Inactive | RTCRtpTransceiverDirection::Sendonly) => {
-                if let Some(receiver) = &*self.receiver.lock().await {
-                    trace!("Pausing receiver {:?}", receiver);
-                    receiver.pause().await?;
-                }
-            }
-            (_, RTCRtpTransceiverDirection::Recvonly | RTCRtpTransceiverDirection::Sendrecv) => {
-                if let Some(receiver) = &*self.receiver.lock().await {
-                    trace!("Unpausing receiver {:?}", receiver);
-                    receiver.resume().await?;
-                }
-            }
-            // TODO: Senders
-            (_, _) => {}
+        }
+
+        if let Some(sender) = &*self.sender.lock().await {
+            let pause_sender = !current_direction.has_send();
+
+            sender.set_paused(pause_sender);
         }
 
         Ok(())


### PR DESCRIPTION
Currently if `RTCRtpTransceiver::direction` is set to a valueq which
doesn't allow sending data, we happily keep sending data if the user
does `write_sample` or `write_rtp`.

This changes so that any writes are just dropped as long as the
direction doesn't permit sending.