### PR TITLE
move profile to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ members = [
     "util",
     "webrtc",
 ]
+
+[profile.dev]
+opt-level = 0

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -53,6 +53,3 @@ time = "~0.3.1"
 [dev-dependencies]
 tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 env_logger = "0.9.0"
-
-[profile.dev]
-opt-level = 0


### PR DESCRIPTION
This will fix the:

cargo build
**warning: profiles for the non root package will be ignored, specify profiles at the workspace root:**
package:   C:\git\xnorpx\webrtc\webrtc\Cargo.toml
workspace: C:\git\xnorpx\webrtc\Cargo.toml