### PR TITLE
Specify both path and version in crate deps

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/webrtc-rs/data"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "marshal"]  }
-sctp = { path = "../sctp", package = "webrtc-sctp" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "marshal"]  }
+sctp = { version = "0.6.0", path = "../sctp", package = "webrtc-sctp" }
 
 tokio = { version = "1.19", features = ["full"] }
 bytes = "1"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/webrtc-rs/dtls"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
 byteorder = "1"
 rand_core = "0.6.3"

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/webrtc-rs/ice"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet", "sync"] }
-turn = { path = "../turn" }
-stun = { path = "../stun" }
-mdns = { path = "../mdns", package = "webrtc-mdns" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet", "sync"] }
+turn = { version = "0.5.4", path = "../turn" }
+stun = { version = "0.4.2", path = "../stun" }
+mdns = { version = "0.4.3", path = "../mdns", package = "webrtc-mdns" }
 
 async-trait = "0.1.56"
 crc = "3.0"

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/interceptor"
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
-rtp = { path = "../rtp" }
-rtcp = { path = "../rtcp" }
-srtp = { path = "../srtp", package = "webrtc-srtp" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal", "sync"] }
+rtp = { version = "0.6.6", path = "../rtp" }
+rtcp = { version = "0.6.6", path = "../rtcp" }
+srtp = { version = "0.8.9", path = "../srtp", package = "webrtc-srtp" }
 
 tokio = { version = "1.19", features = ["sync", "time"] }
 async-trait = "0.1.56"

--- a/mdns/Cargo.toml
+++ b/mdns/Cargo.toml
@@ -16,7 +16,7 @@ default = [ "reuse_port" ]
 reuse_port = []
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["ifaces"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["ifaces"] }
 
 tokio = { version = "1.19", features = ["full"] }
 socket2 = { version = "0.4.4", features = ["all"] }

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/webrtc-rs/media"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
-rtp = { path = "../rtp" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
+rtp = { version = "0.6.6", path = "../rtp" }
 
 byteorder = "1"
 bytes = "1"

--- a/rtcp/Cargo.toml
+++ b/rtcp/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/rtcp"
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
 
 bytes = "1"
 thiserror = "1.0"

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/rtp"
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
 
 bytes = "1"
 rand = "0.8.5"

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/webrtc-rs/sctp"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
 tokio = { version = "1.19", features = ["full"] }
 bytes = "1"

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -10,13 +10,13 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/srtp"
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = [
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = [
     "conn",
     "buffer",
     "marshal",
 ] }
-rtp = { path = "../rtp" }
-rtcp = { path = "../rtcp" }
+rtp = { version = "0.6.6", path = "../rtp" }
+rtcp = { version = "0.6.6", path = "../rtcp" }
 
 byteorder = "1"
 bytes = "1"

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 bench = []
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
 tokio = { version = "1.19", features = ["full"] }
 lazy_static = "1.4"

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/webrtc-rs/turn"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet"] }
-stun = { path = "../stun" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet"] }
+stun = { version = "0.4.2", path = "../stun" }
 
 tokio = { version = "1.19", features = ["full"] }
 async-trait = "0.1.56"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -12,20 +12,20 @@ repository = "https://github.com/webrtc-rs/webrtc"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-data = { path = "../data", package = "webrtc-data" }
-dtls = { path = "../dtls", package = "webrtc-dtls" }
-ice = { path = "../ice", package = "webrtc-ice" }
-interceptor = { path = "../interceptor" }
-mdns = { path = "../mdns", package = "webrtc-mdns" }
-media = { path = "../media", package = "webrtc-media" }
-rtcp = { path = "../rtcp" }
-rtp = { path = "../rtp" }
-sctp = { path = "../sctp", package = "webrtc-sctp" }
-sdp = { path = "../sdp" }
-srtp = { path = "../srtp", package = "webrtc-srtp" }
-stun = { path = "../stun" }
-turn = { path = "../turn" }
-util = { path = "../util", package = "webrtc-util" }
+data = { version = "0.4.0", path = "../data", package = "webrtc-data" }
+dtls = { version = "0.5.4", path = "../dtls", package = "webrtc-dtls" }
+ice = { version = "0.7.1", path = "../ice", package = "webrtc-ice" }
+interceptor = { version = "0.7.7", path = "../interceptor" }
+mdns = { version = "0.4.3", path = "../mdns", package = "webrtc-mdns" }
+media = { version = "0.4.6", path = "../media", package = "webrtc-media" }
+rtcp = { version = "0.6.6", path = "../rtcp" }
+rtp = { version = "0.6.6", path = "../rtp" }
+sctp = { version = "0.6.0", path = "../sctp", package = "webrtc-sctp" }
+sdp = { version = "0.5.1", path = "../sdp" }
+srtp = { version = "0.8.9", path = "../srtp", package = "webrtc-srtp" }
+stun = { version = "0.4.2", path = "../stun" }
+turn = { version = "0.5.4", path = "../turn" }
+util = { version = "0.5.4", path = "../util", package = "webrtc-util" }
 
 tokio = { version = "1.19", features = ["full"] }
 log = "0.4"


### PR DESCRIPTION
Cargo allows specifying both a `path` and `version` for dependencies,
doing this makes publishing easier.

> It is possible to specify both a registry version and a git or path
> location. The git or path dependency will be used locally (in which
> case the version is checked against the local copy), and when
> published to a registry like crates.io, it will use the registry
> version. Other combinations are not allowed.

_From [The Cargo Book][0]_

[0]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
