### PR TITLE
Make tests run clean on windows.

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -25,3 +25,7 @@ thiserror = "1.0"
 tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 env_logger = "0.9.0"
 chrono = "0.4.19"
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = {version = "0.39", features = ["Win32_Media"]}
+ctor = "0.1"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -55,6 +55,10 @@ chrono = "0.4.19"
 clap = "3.2.6"
 hub = {path = "examples/hub"}
 
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = {version = "0.39", features = ["Win32_Media"]}
+ctor = "0.1"
+
 [[example]]
 name = "dial_psk"
 path = "examples/dial/psk/dial_psk.rs"

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -26,3 +26,7 @@ log = "0.4.16"
 [dev-dependencies]
 tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 chrono = "0.4.19"
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = {version = "0.39", features = ["Win32_Media"]}
+ctor = "0.1"

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -29,6 +29,10 @@ env_logger = "0.9.0"
 chrono = "0.4.19"
 clap = "3.2.6"
 
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = {version = "0.39", features = ["Win32_Media"]}
+ctor = "0.1"
+
 [[example]]
 name = "ping"
 path = "examples/ping.rs"

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -13,6 +13,28 @@ use util::conn::conn_bridge::*;
 use util::conn::conn_pipe::pipe;
 use util::conn::*;
 
+#[cfg(target_os = "windows")]
+#[ctor::ctor]
+fn increase_timer_resolution() {
+    // by default windows timer resolution is 20ms to 
+    // increase resolution we need to set it to minimum available.
+    // https://docs.microsoft.com/en-us/windows/win32/multimedia/multimedia-timers
+    use windows::Win32::Media::timeGetDevCaps;
+    use windows::Win32::Media::timeBeginPeriod;
+    use windows::Win32::Media::TIMECAPS;
+    use std::mem;
+
+    let mut time_caps = TIMECAPS {
+        wPeriodMin: 0,
+        wPeriodMax: 0,
+    };
+    let time_caps_size = mem::size_of::<TIMECAPS>() as u32;
+    unsafe {
+        timeGetDevCaps(&mut time_caps as *mut TIMECAPS, time_caps_size);
+        timeBeginPeriod(time_caps.wPeriodMin);
+    }
+}
+
 async fn create_new_association_pair(
     br: &Arc<Bridge>,
     ca: Arc<dyn Conn + Send + Sync>,

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -53,3 +53,7 @@ time = "~0.3.1"
 [dev-dependencies]
 tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 env_logger = "0.9.0"
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = {version = "0.39", features = ["Win32_Media"]}
+ctor = "0.1"


### PR DESCRIPTION
Enable high resolution timer on windows but disable tests that could not run
reliable even with high resolution timers.