### PR TITLE
Fix current direction update when applying answer

### DIFF
--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -1464,7 +1464,7 @@ impl RTCPeerConnection {
                         }
 
                         if let Some(t) = find_by_mid(mid_value, &mut local_transceivers).await {
-                            let previous_direction = t.direction();
+                            let previous_direction = t.current_direction();
 
                             // 4.5.9.2.9
                             // Let direction be an RTCRtpTransceiverDirection value representing the direction


### PR DESCRIPTION
When applying an answer from the remote the value of
`current_direction`was correctly update, but the process to trigger any
side effect was incorrectly using `direction` instead of
`current_direction` to determine the previous direction.
