### PR TITLE
relax regex version requirement

### DIFF
--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -31,7 +31,7 @@ waitgroup = "0.1.2"
 
 [dev-dependencies]
 tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
-regex = "1.6"
+regex = "1"
 env_logger = "0.9.0"
 chrono = "0.4.19"
 ipnet = "2.5.0"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.8.5"
 bytes = "1"
 thiserror = "1.0"
 waitgroup = "0.1.2"
-regex = "1.6"
+regex = "1"
 url = "2.2"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"]}
 rcgen = { version = "0.9.2", features = ["pem", "x509-parser"]}


### PR DESCRIPTION
some projects like https://github.com/bheisler/criterion.rs depend on regex: `1.3`. I don't see why 1.6 have to be a requirement.