### PR TITLE
Promote create_agent lock to top of function, to avoid race condition

### DIFF
--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).
 * Incresed serde's minimum version to 1.0.102 [#243 Fixes for cargo minimal-versions](https://github.com/webrtc-rs/webrtc/pull/243) contributed by [algesten](https://github.com/algesten)
+* Promote agent lock in ice_gather.rs create_agent() to top level of the function to avoid a race condition. [#290 Promote create_agent lock to top of function, to avoid race condition](https://github.com/webrtc-rs/webrtc/pull/290) contributed by [efer-ms](https://github.com/efer-ms)
 
 
 ## Prior to 0.8.0

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -1,12 +1,12 @@
 # webrtc-ice changelog
 
 ## Unreleased
+* Promote agent lock in ice_gather.rs create_agent() to top level of the function to avoid a race condition. [#290 Promote create_agent lock to top of function, to avoid race condition](https://github.com/webrtc-rs/webrtc/pull/290) contributed by [efer-ms](https://github.com/efer-ms)
 
 ### v0.8.0
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).
 * Incresed serde's minimum version to 1.0.102 [#243 Fixes for cargo minimal-versions](https://github.com/webrtc-rs/webrtc/pull/243) contributed by [algesten](https://github.com/algesten)
-* Promote agent lock in ice_gather.rs create_agent() to top level of the function to avoid a race condition. [#290 Promote create_agent lock to top of function, to avoid race condition](https://github.com/webrtc-rs/webrtc/pull/290) contributed by [efer-ms](https://github.com/efer-ms)
 
 
 ## Prior to 0.8.0

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -79,6 +79,11 @@ impl RTCIceGatherer {
     }
 
     pub(crate) async fn create_agent(&self) -> Result<()> {
+        // NOTE: A lock is held for the duration of this function in order to
+        // avoid potential double-agent creations. Care should be taken to
+        // ensure we do not do anything expensive other than the actual agent
+        // creation in this function.
+
         let mut agent = self.agent.lock().await;
         if agent.is_some() || self.state() != RTCIceGathererState::New {
             return Ok(());

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -79,11 +79,9 @@ impl RTCIceGatherer {
     }
 
     pub(crate) async fn create_agent(&self) -> Result<()> {
-        {
-            let agent = self.agent.lock().await;
-            if agent.is_some() || self.state() != RTCIceGathererState::New {
-                return Ok(());
-            }
+        let mut agent = self.agent.lock().await;
+        if agent.is_some() || self.state() != RTCIceGathererState::New {
+            return Ok(());
         }
 
         let mut candidate_types = vec![];
@@ -145,10 +143,7 @@ impl RTCIceGatherer {
 
         config.network_types.extend(requested_network_types);
 
-        {
-            let mut agent = self.agent.lock().await;
-            *agent = Some(Arc::new(ice::agent::Agent::new(config).await?));
-        }
+        *agent = Some(Arc::new(ice::agent::Agent::new(config).await?));
 
         Ok(())
     }


### PR DESCRIPTION
create_agent is called multiple times from multiple threads, however, it is not locked properly.

The code as written before:
1) Acquire lock
2) Check for early exit if agent is already in a usable state
3) Release lock
4) Build agent config
5) Acquire lock
6) Create agent and update value stored
7) Release lock

The issue is that two threads can get to step 4 at the same time, and hence the second one to complete step 6, obliterates the agent of the other.

Since building the agent config is cheap, it is cleaner to simply acquire the lock, and not release it until the function completes. So:

1) Acquire lock
2) Check for early exit if agent is already in a usable state
3) Build agent config
4) Create agent and update value stored
5) Release lock

---

An alternative is to do the early exit check once again after step 5, as:
1) Acquire lock
2) Check for early exit if agent is already in a usable state
3) Release lock
4) Build agent config
5) Acquire lock
6) Check for early exit if agent is already in a usable state
7) Create agent and update value stored
8) Release lock

But simply promoting the lock seems like a cleaner, less error prone choice.

---

We were seeing this race condition trigger about 0.1% of the time on certain setups.
