### PR TITLE
Simplify OnBufferedAmountLowFn callback API

### DIFF
--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -345,7 +345,7 @@ impl DataChannel {
 
     /// OnBufferedAmountLow sets the callback handler which would be called when the
     /// number of bytes of outgoing data buffered is lower than the threshold.
-    pub async fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
+    pub async fn on_buffered_amount_low(&self, f: Box<dyn OnBufferedAmountLowFn>) {
         self.stream.on_buffered_amount_low(f).await
     }
 

--- a/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
+++ b/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
@@ -117,12 +117,12 @@ async fn create_offerer() -> Result<Arc<RTCPeerConnection>> {
         .await;
 
     // This callback is made when the current bufferedAmount becomes lower than the threshold
-    dc.on_buffered_amount_low(Box::new(move || {
+    dc.on_buffered_amount_low(move || {
         let send_more_ch_tx2 = Arc::clone(&send_more_ch_tx);
-        Box::pin(async move {
+        async move {
             let _ = send_more_ch_tx2.send(()).await;
-        })
-    }))
+        }
+    })
     .await;
 
     Ok(pc)

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#293 Simplify OnBufferedAmountLowFn callback API](https://github.com/webrtc-rs/webrtc/pull/293) by [@llacqie](https://github.com/llacqie).
+
 ## v0.6.1
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).
 * [#245 Fix incorrect chunk type Display for CWR](https://github.com/webrtc-rs/webrtc/pull/245) by [@k0nserv](https://github.com/k0nserv).
-* [#293 Simplify OnBufferedAmountLowFn callback API](https://github.com/webrtc-rs/webrtc/pull/293) by [@llacqie](https://github.com/llacqie).
 
 ## Prior to 0.6.1
 

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).
 * [#245 Fix incorrect chunk type Display for CWR](https://github.com/webrtc-rs/webrtc/pull/245) by [@k0nserv](https://github.com/k0nserv).
+* [#293 Simplify OnBufferedAmountLowFn callback API](https://github.com/webrtc-rs/webrtc/pull/293) by [@llacqie](https://github.com/llacqie).
 
 ## Prior to 0.6.1
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changes
+
+#### Breaking changes
+
+* API for passing callbacks has changed. Now you should pass just `|| async {}` as callback. [#293 Simplify OnBufferedAmountLowFn callback API](https://github.com/webrtc-rs/webrtc/pull/293) contributed by [llacqie](https://github.com/llacqie).
+
 ## 0.5.0
 
 ### Changes


### PR DESCRIPTION
With this minor changes, you can now provide `|| async {}` as OnBufferedAmountLowFn callback instead of 
`Box::new(|| Box::pin(async {}))`. Other callback APIs can be refactored like this one easily.