### PR TITLE
Remove video/rtx codecs

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Improvements
-
 * Added more stats to `RemoteInboundRTPStats` and `RemoteOutboundRTPStats` [#282](https://github.com/webrtc-rs/webrtc/pull/282) by [@k0nserv](https://github.com/k0nserv).
+* Don't register `video/rtx` codecs in `MediaEngine::register_default_codecs`. These weren't actually support and prevented RTX in the existing RTP stream from being used. Long term we should support RTX via this method, this is tracked in [#295](https://github.com/webrtc-rs/webrtc/issues/295). [#294 Remove video/rtx codecs](https://github.com/webrtc-rs/webrtc/pull/294) contributed by [k0nserv](https://github.com/k0nserv)
+
 
 ## 0.5.1
 

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -167,17 +167,6 @@ impl MediaEngine {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=96".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 97,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_VP9.to_owned(),
                     clock_rate: 90000,
                     channels: 0,
@@ -189,17 +178,6 @@ impl MediaEngine {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=98".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 99,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_VP9.to_owned(),
                     clock_rate: 90000,
                     channels: 0,
@@ -207,17 +185,6 @@ impl MediaEngine {
                     rtcp_feedback: video_rtcp_feedback.clone(),
                 },
                 payload_type: 100,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=100".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 101,
                 ..Default::default()
             },
             RTCRtpCodecParameters {
@@ -235,17 +202,6 @@ impl MediaEngine {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=102".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 121,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_H264.to_owned(),
                     clock_rate: 90000,
                     channels: 0,
@@ -255,17 +211,6 @@ impl MediaEngine {
                     rtcp_feedback: video_rtcp_feedback.clone(),
                 },
                 payload_type: 127,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=127".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 120,
                 ..Default::default()
             },
             RTCRtpCodecParameters {
@@ -283,17 +228,6 @@ impl MediaEngine {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=125".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 107,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_H264.to_owned(),
                     clock_rate: 90000,
                     channels: 0,
@@ -303,17 +237,6 @@ impl MediaEngine {
                     rtcp_feedback: video_rtcp_feedback.clone(),
                 },
                 payload_type: 108,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=108".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 109,
                 ..Default::default()
             },
             RTCRtpCodecParameters {
@@ -331,17 +254,6 @@ impl MediaEngine {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=127".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 120,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_H264.to_owned(),
                     clock_rate: 90000,
                     channels: 0,
@@ -351,17 +263,6 @@ impl MediaEngine {
                     rtcp_feedback: video_rtcp_feedback,
                 },
                 payload_type: 123,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_owned(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=123".to_owned(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 118,
                 ..Default::default()
             },
             RTCRtpCodecParameters {

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -104,17 +104,6 @@ async fn test_rtp_transceiver_set_codec_preferences() -> Result<()> {
             },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_string(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=96".to_string(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 97,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_VP9.to_string(),
                     clock_rate: 90000,
                     channels: 0,
@@ -122,17 +111,6 @@ async fn test_rtp_transceiver_set_codec_preferences() -> Result<()> {
                     rtcp_feedback: vec![],
                 },
                 payload_type: 98,
-                ..Default::default()
-            },
-            RTCRtpCodecParameters {
-                capability: RTCRtpCodecCapability {
-                    mime_type: "video/rtx".to_string(),
-                    clock_rate: 90000,
-                    channels: 0,
-                    sdp_fmtp_line: "apt=98".to_string(),
-                    rtcp_feedback: vec![],
-                },
-                payload_type: 99,
                 ..Default::default()
             },
         ],


### PR DESCRIPTION
We don't actually support handling RTX on a distinct SSRC and declaring
these causes Chrome(and maybe others) to not sent retransmissions within
the existing RTP stream. This all means that even if we emit NACKs the
resulting retransmissions will simply be ignored.
