### PR TITLE
Rework almost all callbacks

### DIFF
--- a/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
+++ b/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
@@ -117,12 +117,12 @@ async fn create_offerer() -> Result<Arc<RTCPeerConnection>> {
         .await;
 
     // This callback is made when the current bufferedAmount becomes lower than the threshold
-    dc.on_buffered_amount_low(move || {
+    dc.on_buffered_amount_low(Box::new(move || {
         let send_more_ch_tx2 = Arc::clone(&send_more_ch_tx);
         async move {
             let _ = send_more_ch_tx2.send(()).await;
         }
-    })
+    }))
     .await;
 
     Ok(pc)

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -1073,7 +1073,7 @@ impl AgentInternal {
                     if let (Some(f), Some(p)) =
                         (&mut *on_selected_candidate_pair_change_hdlr, &selected_pair)
                     {
-                        f(&p.local, &p.remote).await;
+                        f(p.local.clone(), p.remote.clone()).await;
                     }
                 }
             }

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -35,7 +35,7 @@ pub struct AgentInternal {
     pub(crate) on_connection_state_change_hdlr:
         Mutex<Option<Box<dyn OnConnectionStateChangeHdlrFn>>>,
     pub(crate) on_selected_candidate_pair_change_hdlr:
-        Mutex<Option<OnSelectedCandidatePairChangeHdlrFn>>,
+        Mutex<Option<Box<dyn OnSelectedCandidatePairChangeHdlrFn>>>,
     pub(crate) on_candidate_hdlr: Mutex<Option<OnCandidateHdlrFn>>,
 
     pub(crate) tie_breaker: AtomicU64,
@@ -1074,7 +1074,7 @@ impl AgentInternal {
                     if let (Some(f), Some(p)) =
                         (&mut *on_selected_candidate_pair_change_hdlr, &selected_pair)
                     {
-                        f(p.local.clone(), p.remote.clone()).await;
+                        f.call(p.local.clone(), p.remote.clone()).await;
                     }
                 }
             }

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -2122,7 +2122,7 @@ async fn test_run_task_in_selected_candidate_pair_change_callback() -> Result<()
     let is_tested_tx = Arc::new(Mutex::new(Some(is_tested_tx)));
     a_agent
         .on_selected_candidate_pair_change(Box::new(
-            move |_: &Arc<dyn Candidate + Send + Sync>, _: &Arc<dyn Candidate + Send + Sync>| {
+            move |_: Arc<dyn Candidate + Send + Sync>, _: Arc<dyn Candidate + Send + Sync>| {
                 let is_tested_tx_clone = Arc::clone(&is_tested_tx);
                 Box::pin(async move {
                     let mut tx = is_tested_tx_clone.lock().await;

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -191,12 +191,12 @@ async fn test_on_selected_candidate_pair_change() -> Result<()> {
     let a = Agent::new(AgentConfig::default()).await?;
     let (callback_called_tx, mut callback_called_rx) = mpsc::channel::<()>(1);
     let callback_called_tx = Arc::new(Mutex::new(Some(callback_called_tx)));
-    let cb: OnSelectedCandidatePairChangeHdlrFn = Box::new(move |_, _| {
+    let cb = Box::new(move |_, _| {
         let callback_called_tx_clone = Arc::clone(&callback_called_tx);
-        Box::pin(async move {
+        async move {
             let mut tx = callback_called_tx_clone.lock().await;
             tx.take();
-        })
+        }
     });
     a.on_selected_candidate_pair_change(cb).await;
 

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -63,11 +63,14 @@ impl Default for BindingRequest {
     }
 }
 
+// TODO: Rework
 pub type OnConnectionStateChangeHdlrFn = Box<
     dyn (FnMut(ConnectionState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
+
+// TODO: Rework
 pub type OnSelectedCandidatePairChangeHdlrFn = Box<
     dyn (FnMut(
             Arc<dyn Candidate + Send + Sync>,
@@ -76,6 +79,8 @@ pub type OnSelectedCandidatePairChangeHdlrFn = Box<
         + Send
         + Sync,
 >;
+
+// TODO: Rework
 pub type OnCandidateHdlrFn = Box<
     dyn (FnMut(
             Option<Arc<dyn Candidate + Send + Sync>>,
@@ -83,6 +88,7 @@ pub type OnCandidateHdlrFn = Box<
         + Send
         + Sync,
 >;
+
 pub type GatherCandidateCancelFn = Box<dyn Fn() + Send + Sync>;
 
 struct ChanReceivers {

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -70,8 +70,8 @@ pub type OnConnectionStateChangeHdlrFn = Box<
 >;
 pub type OnSelectedCandidatePairChangeHdlrFn = Box<
     dyn (FnMut(
-            &Arc<dyn Candidate + Send + Sync>,
-            &Arc<dyn Candidate + Send + Sync>,
+            Arc<dyn Candidate + Send + Sync>,
+            Arc<dyn Candidate + Send + Sync>,
         ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -54,7 +54,7 @@ where
     }
 }
 
-// TODO: Rework
+// TODO: Decide what to do with FnOnce
 pub type OnOpenHdlrFn =
     Box<dyn (FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -569,16 +569,13 @@ impl RTCDataChannel {
     /// on_buffered_amount_low sets an event handler which is invoked when
     /// the number of bytes of outgoing data becomes lower than the
     /// buffered_amount_low_threshold.
-    pub async fn on_buffered_amount_low<F>(&self, f: F)
-    where
-        F: OnBufferedAmountLowFn + 'static,
-    {
+    pub async fn on_buffered_amount_low(&self, f: Box<dyn OnBufferedAmountLowFn>) {
         let data_channel = self.data_channel.lock().await;
         if let Some(dc) = &*data_channel {
-            dc.on_buffered_amount_low(Box::new(f)).await;
+            dc.on_buffered_amount_low(f).await;
         } else {
             let mut on_buffered_amount_low = self.on_buffered_amount_low.lock().await;
-            *on_buffered_amount_low = Some(Box::new(f));
+            *on_buffered_amount_low = Some(f);
         }
     }
 

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -31,15 +31,18 @@ use crate::stats::{DataChannelStats, StatsReportType};
 /// message size limit for Chromium
 const DATA_CHANNEL_BUFFER_SIZE: u16 = u16::MAX;
 
+// TODO: Rework
 pub type OnMessageHdlrFn = Box<
     dyn (FnMut(DataChannelMessage) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnOpenHdlrFn =
     Box<dyn (FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 
+// TODO: Rework
 pub type OnCloseHdlrFn =
     Box<dyn (FnMut() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -47,6 +47,7 @@ pub(crate) fn default_srtp_protection_profiles() -> Vec<SrtpProtectionProfile> {
     ]
 }
 
+// TODO: Rework
 pub type OnDTLSTransportStateChangeHdlrFn = Box<
     dyn (FnMut(RTCDtlsTransportState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/error.rs
+++ b/webrtc/src/error.rs
@@ -412,6 +412,7 @@ pub enum Error {
     new(String),
 }
 
+// TODO: Rework
 pub type OnErrorHdlrFn =
     Box<dyn (FnMut(Error) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -28,18 +28,21 @@ pub struct RTCIceGatherOptions {
     pub ice_gather_policy: RTCIceTransportPolicy,
 }
 
+// TODO: Rework
 pub type OnLocalCandidateHdlrFn = Box<
     dyn (FnMut(Option<RTCIceCandidate>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnICEGathererStateChangeHdlrFn = Box<
     dyn (FnMut(RTCIceGathererState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnGatheringCompleteHdlrFn =
     Box<dyn (FnMut() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -40,12 +40,14 @@ pub mod ice_role;
 pub mod ice_server;
 pub mod ice_transport_state;
 
+// TODO: Rework
 pub type OnConnectionStateChangeHdlrFn = Box<
     dyn (FnMut(RTCIceTransportState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnSelectedCandidatePairChangeHdlrFn = Box<
     dyn (FnMut(RTCIceCandidatePair) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -127,12 +127,12 @@ impl RTCIceTransport {
                 Arc::clone(&self.on_selected_candidate_pair_change_handler);
             agent
                 .on_selected_candidate_pair_change(Box::new(
-                    move |local: &Arc<dyn Candidate + Send + Sync>,
-                          remote: &Arc<dyn Candidate + Send + Sync>| {
+                    move |local: Arc<dyn Candidate + Send + Sync>,
+                          remote: Arc<dyn Candidate + Send + Sync>| {
                         let on_selected_candidate_pair_change_handler_clone =
                             Arc::clone(&on_selected_candidate_pair_change_handler);
-                        let local = RTCIceCandidate::from(local);
-                        let remote = RTCIceCandidate::from(remote);
+                        let local = RTCIceCandidate::from(&local);
+                        let remote = RTCIceCandidate::from(&remote);
                         Box::pin(async move {
                             let mut handler =
                                 on_selected_candidate_pair_change_handler_clone.lock().await;

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -40,7 +40,8 @@ pub mod ice_role;
 pub mod ice_server;
 pub mod ice_transport_state;
 
-// TODO: Rework
+// TODO: Can't be reworked due to the dynamically inferred return type in the callback, 
+//       that set in webrtc::peer_connection::peer_connection_internal::PeerConnectionInternal::create_ice_transport()
 pub type OnConnectionStateChangeHdlrFn = Box<
     dyn (FnMut(RTCIceTransportState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -113,30 +113,35 @@ pub fn math_rand_alpha(n: usize) -> String {
     rand_string
 }
 
+// TODO: Rework
 pub type OnSignalingStateChangeHdlrFn = Box<
     dyn (FnMut(RTCSignalingState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnICEConnectionStateChangeHdlrFn = Box<
     dyn (FnMut(RTCIceConnectionState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnPeerConnectionStateChangeHdlrFn = Box<
     dyn (FnMut(RTCPeerConnectionState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnDataChannelHdlrFn = Box<
     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnTrackHdlrFn = Box<
     dyn (FnMut(
             Option<Arc<TrackRemote>>,
@@ -146,6 +151,7 @@ pub type OnTrackHdlrFn = Box<
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnNegotiationNeededHdlrFn =
     Box<dyn (FnMut() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>;
 

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -583,7 +583,7 @@ impl RTCPeerConnection {
 
     /// on_ice_gathering_state_change sets an event handler which is invoked when the
     /// ICE candidate gathering state has changed.
-    pub async fn on_ice_gathering_state_change(&self, f: OnICEGathererStateChangeHdlrFn) {
+    pub async fn on_ice_gathering_state_change(&self, f: Box<dyn OnICEGathererStateChangeHdlrFn>) {
         self.internal.ice_gatherer.on_state_change(f).await
     }
 

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -179,7 +179,7 @@ where
     }
 }
 
-// TODO: Rework
+// TODO: Can't be reworked due to the dynamically inferred return type in callbacks
 pub type OnDataChannelHdlrFn = Box<
     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -577,7 +577,7 @@ impl RTCPeerConnection {
     /// candidate is found.
     /// Take note that the handler is gonna be called with a nil pointer when
     /// gathering is finished.
-    pub async fn on_ice_candidate(&self, f: OnLocalCandidateHdlrFn) {
+    pub async fn on_ice_candidate(&self, f: Box<dyn OnLocalCandidateHdlrFn>) {
         self.internal.ice_gatherer.on_local_candidate(f).await
     }
 

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -201,7 +201,8 @@ where
     }
 }
 
-// TODO: Rework
+// TODO: Can't be reworked due to the dynamically inferred return type in the callback, 
+//       that set in webrtc::peer_connection::peer_connection_test::test_get_stats()
 pub type OnTrackHdlrFn = Box<
     dyn (FnMut(
             Option<Arc<TrackRemote>>,

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -643,7 +643,7 @@ impl PeerConnectionInternal {
         }
     }
 
-    pub(super) async fn set_gather_complete_handler(&self, f: OnGatheringCompleteHdlrFn) {
+    pub(super) async fn set_gather_complete_handler(&self, f: Box<dyn OnGatheringCompleteHdlrFn>) {
         self.ice_gatherer.on_gathering_complete(f).await;
     }
 

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -36,7 +36,7 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) ice_transport: Arc<RTCIceTransport>,
     pub(super) dtls_transport: Arc<RTCDtlsTransport>,
     pub(super) on_peer_connection_state_change_handler:
-        Arc<Mutex<Option<OnPeerConnectionStateChangeHdlrFn>>>,
+        Arc<Mutex<Option<Box<dyn OnPeerConnectionStateChangeHdlrFn>>>>,
     pub(super) peer_connection_state: Arc<AtomicU8>,
     pub(super) ice_connection_state: Arc<AtomicU8>,
 

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -48,7 +48,7 @@ pub(crate) struct PeerConnectionInternal {
         Arc<Mutex<Option<Box<dyn OnSignalingStateChangeHdlrFn>>>>,
     pub(super) on_ice_connection_state_change_handler:
         Arc<Mutex<Option<Box<dyn OnICEConnectionStateChangeHdlrFn>>>>,
-    pub(super) on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
+    pub(super) on_data_channel_handler: Arc<Mutex<Option<Box<dyn OnDataChannelHdlrFn>>>>,
 
     pub(super) ice_gatherer: Arc<RTCIceGatherer>,
 
@@ -135,7 +135,7 @@ impl PeerConnectionInternal {
                 Box::pin(async move {
                     let mut handler = on_data_channel_handler2.lock().await;
                     if let Some(f) = &mut *handler {
-                        f(d).await;
+                        f.call(d).await;
                     }
                 })
             }))

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -47,7 +47,7 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) on_signaling_state_change_handler:
         Arc<Mutex<Option<Box<dyn OnSignalingStateChangeHdlrFn>>>>,
     pub(super) on_ice_connection_state_change_handler:
-        Arc<Mutex<Option<OnICEConnectionStateChangeHdlrFn>>>,
+        Arc<Mutex<Option<Box<dyn OnICEConnectionStateChangeHdlrFn>>>>,
     pub(super) on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
 
     pub(super) ice_gatherer: Arc<RTCIceGatherer>,

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -22,7 +22,8 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) last_offer: Mutex<String>,
     pub(super) last_answer: Mutex<String>,
 
-    pub(super) on_negotiation_needed_handler: Arc<Mutex<Option<OnNegotiationNeededHdlrFn>>>,
+    pub(super) on_negotiation_needed_handler:
+        Arc<Mutex<Option<Box<dyn OnNegotiationNeededHdlrFn>>>>,
     pub(super) is_closed: Arc<AtomicBool>,
 
     /// ops is an operations queue which will ensure the enqueued actions are

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -49,7 +49,7 @@ pub(crate) struct PeerConnectionInternal {
         Arc<Mutex<Option<Box<dyn OnSignalingStateChangeHdlrFn>>>>,
     pub(super) on_ice_connection_state_change_handler:
         Arc<Mutex<Option<Box<dyn OnICEConnectionStateChangeHdlrFn>>>>,
-    pub(super) on_data_channel_handler: Arc<Mutex<Option<Box<dyn OnDataChannelHdlrFn>>>>,
+    pub(super) on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
 
     pub(super) ice_gatherer: Arc<RTCIceGatherer>,
 
@@ -136,7 +136,7 @@ impl PeerConnectionInternal {
                 Box::pin(async move {
                     let mut handler = on_data_channel_handler2.lock().await;
                     if let Some(f) = &mut *handler {
-                        f.call(d).await;
+                        f(d).await;
                     }
                 })
             }))

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -44,7 +44,8 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) rtp_transceivers: Arc<Mutex<Vec<Arc<RTCRtpTransceiver>>>>,
 
     pub(super) on_track_handler: Arc<Mutex<Option<OnTrackHdlrFn>>>,
-    pub(super) on_signaling_state_change_handler: Arc<Mutex<Option<OnSignalingStateChangeHdlrFn>>>,
+    pub(super) on_signaling_state_change_handler:
+        Arc<Mutex<Option<Box<dyn OnSignalingStateChangeHdlrFn>>>>,
     pub(super) on_ice_connection_state_change_handler:
         Arc<Mutex<Option<OnICEConnectionStateChangeHdlrFn>>>,
     pub(super) on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -34,7 +34,7 @@ use util::Conn;
 
 const SCTP_MAX_CHANNELS: u16 = u16::MAX;
 
-// TODO: Rework
+// TODO: Can't be reworked due to the dynamically inferred return type in callbacks
 pub type OnDataChannelHdlrFn = Box<
     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -4,6 +4,7 @@ mod sctp_transport_test;
 pub mod sctp_transport_capabilities;
 pub mod sctp_transport_state;
 
+use async_trait::async_trait;
 use sctp_transport_state::RTCSctpTransportState;
 use std::collections::HashSet;
 
@@ -41,12 +42,27 @@ pub type OnDataChannelHdlrFn = Box<
         + Sync,
 >;
 
-// TODO: Rework
-pub type OnDataChannelOpenedHdlrFn = Box<
-    dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
-        + Send
-        + Sync,
->;
+// pub type OnDataChannelOpenedHdlrFn = Box<
+//     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
+//         + Send
+//         + Sync,
+// >;
+
+#[async_trait]
+pub trait OnDataChannelOpenedHdlrFn: Send + Sync {
+    async fn call(&mut self, c: Arc<RTCDataChannel>);
+}
+
+#[async_trait]
+impl<T, F> OnDataChannelOpenedHdlrFn for F
+where
+    F: FnMut(Arc<RTCDataChannel>) -> T + Send + Sync,
+    T: Future<Output = ()> + Send,
+{
+    async fn call(&mut self, c: Arc<RTCDataChannel>) {
+        (*self)(c).await
+    }
+}
 
 struct AcceptDataChannelParams {
     notify_rx: Arc<Notify>,
@@ -54,7 +70,7 @@ struct AcceptDataChannelParams {
     data_channels: Arc<Mutex<Vec<Arc<RTCDataChannel>>>>,
     on_error_handler: Arc<Mutex<Option<Box<dyn OnErrorHdlrFn>>>>,
     on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
-    on_data_channel_opened_handler: Arc<Mutex<Option<OnDataChannelOpenedHdlrFn>>>,
+    on_data_channel_opened_handler: Arc<Mutex<Option<Box<dyn OnDataChannelOpenedHdlrFn>>>>,
     data_channels_opened: Arc<AtomicU32>,
     data_channels_accepted: Arc<AtomicU32>,
     setting_engine: Arc<SettingEngine>,
@@ -84,7 +100,7 @@ pub struct RTCSctpTransport {
 
     on_error_handler: Arc<Mutex<Option<Box<dyn OnErrorHdlrFn>>>>,
     on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
-    on_data_channel_opened_handler: Arc<Mutex<Option<OnDataChannelOpenedHdlrFn>>>,
+    on_data_channel_opened_handler: Arc<Mutex<Option<Box<dyn OnDataChannelOpenedHdlrFn>>>>,
 
     // DataChannels
     pub(crate) data_channels: Arc<Mutex<Vec<Arc<RTCDataChannel>>>>,
@@ -310,7 +326,7 @@ impl RTCSctpTransport {
             {
                 let mut handler = param.on_data_channel_opened_handler.lock().await;
                 if let Some(f) = &mut *handler {
-                    f(rtc_dc).await;
+                    f.call(rtc_dc).await;
                     param.data_channels_opened.fetch_add(1, Ordering::SeqCst);
                 }
             }
@@ -333,7 +349,7 @@ impl RTCSctpTransport {
 
     /// on_data_channel_opened sets an event handler which is invoked when a data
     /// channel is opened
-    pub async fn on_data_channel_opened(&self, f: OnDataChannelOpenedHdlrFn) {
+    pub async fn on_data_channel_opened(&self, f: Box<dyn OnDataChannelOpenedHdlrFn>) {
         let mut handler = self.on_data_channel_opened_handler.lock().await;
         *handler = Some(f);
     }

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -34,12 +34,14 @@ use util::Conn;
 
 const SCTP_MAX_CHANNELS: u16 = u16::MAX;
 
+// TODO: Rework
 pub type OnDataChannelHdlrFn = Box<
     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send
         + Sync,
 >;
 
+// TODO: Rework
 pub type OnDataChannelOpenedHdlrFn = Box<
     dyn (FnMut(Arc<RTCDataChannel>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
         + Send

--- a/webrtc/src/track/track_remote/mod.rs
+++ b/webrtc/src/track/track_remote/mod.rs
@@ -19,6 +19,8 @@ use util::Unmarshal;
 lazy_static! {
     static ref TRACK_REMOTE_UNIQUE_ID: AtomicUsize = AtomicUsize::new(0);
 }
+
+// TODO: Rework
 pub type OnMuteHdlrFn = Box<
     dyn (FnMut() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync + 'static,
 >;


### PR DESCRIPTION
Almost all callbacks, whose name matches On*Fn pattern, reworked, except for those that were skipped with a comment why (check commits "Skip <callback_name>").
Callback representation reverted to `Box::new(|| async {})` because of `webrtc_ice::agent::agent_vnet_test::on_connected()` that returns boxed closure (we can't return non boxed closure).