### PR TITLE
[ice-restart example]: directory for index.html uses examples/examples

### DIFF
--- a/examples/examples/ice-restart/ice-restart.rs
+++ b/examples/examples/ice-restart/ice-restart.rs
@@ -27,7 +27,7 @@ lazy_static! {
         Arc::new(Mutex::new(None));
 }
 
-static INDEX: &str = "examples/ice-restart/index.html";
+static INDEX: &str = "examples/examples/ice-restart/index.html";
 static NOTFOUND: &[u8] = b"Not Found";
 
 /// HTTP status code 404


### PR DESCRIPTION
To fix a 404 not found error when running the example.