### PR TITLE
Remove reliance on part tail for sampler builder

### DIFF
--- a/media/src/io/sample_builder/mod.rs
+++ b/media/src/io/sample_builder/mod.rs
@@ -227,14 +227,6 @@ impl<T: Depacketizer> SampleBuilder<T> {
             if self.active.compare(i) == Comparison::After {
                 break;
             }
-            if self
-                .depacketizer
-                .is_partition_tail(packet.header.marker, &packet.payload)
-            {
-                consume.head = self.active.head;
-                consume.tail = i.wrapping_add(1);
-                break;
-            }
             if let Some(head_timestamp) = self.fetch_timestamp(&self.active) {
                 if packet.header.timestamp != head_timestamp {
                     consume.head = self.active.head;


### PR DESCRIPTION
This reliance caused problems where Sample's would incorrectly report
dropped packets because Chrome sends empty packets with the same
timestamp after the packet with the RTP marker.

By only relying on timestamp we correctly merge these empty packets into
the Sample and don't report dropped packets when none were dropped. We
also guarantee that we can always calculate a duration for a Sample.
