### PR TITLE
Handle empty RTP packets in Sample Builder

### DIFF
--- a/media/src/io/sample_builder/sample_sequence_location_test.rs
+++ b/media/src/io/sample_builder/sample_sequence_location_test.rs
@@ -22,3 +22,24 @@ fn test_sample_sequence_location_compare() {
     assert_eq!(Comparison::After, s2.compare(32));
     assert_eq!(Comparison::After, s2.compare(128));
 }
+
+#[test]
+fn test_sample_sequence_location_range() {
+    let mut data: Vec<Option<u16>> = vec![None; u16::MAX as usize + 1];
+
+    data[65533] = Some(65533);
+    data[65535] = Some(65535);
+    data[0] = Some(0);
+    data[2] = Some(2);
+
+    let s = SampleSequenceLocation {
+        head: 65533,
+        tail: 3,
+    };
+    let reconstructed: Vec<_> = s.range(&data).map(|x| x.cloned()).collect();
+
+    assert_eq!(
+        reconstructed,
+        [Some(65533), None, Some(65535), Some(0), None, Some(2)]
+    );
+}

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Sample {
     /// These packets don't carry media and aren't useful for building samples.
     ///
     /// This field can be combined with [`Sample::prev_dropped_packets`] to determine if any
-    /// dropped packets have are likely to have detrimental impact on the steadiness of the RTP stream.
+    /// dropped packets are likely to have detrimental impact on the steadiness of the RTP stream.
     ///
     /// ## Example adjustment
     ///

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -51,7 +51,9 @@ pub struct Sample {
     /// ## Example adjustment
     ///
     /// ```rust
-    /// # use crate::Sample;
+    /// # use bytes::Bytes;
+    /// # use std::time::{SystemTime, Duration};
+    /// # use webrtc_media::Sample;
     /// # let sample = Sample {
     /// #   data: Bytes::new(),
     /// #   timestamp: SystemTime::now(),
@@ -62,7 +64,7 @@ pub struct Sample {
     /// # };
     /// #
     /// let adjusted_dropped =
-    /// sample.prev_dropped_packets.saturating_sub(sample.pre_padding_packets);
+    /// sample.prev_dropped_packets.saturating_sub(sample.prev_padding_packets);
     /// ```
     pub prev_padding_packets: u16,
 }

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -15,11 +15,56 @@ use std::time::{Duration, SystemTime};
 /// A Sample contains encoded media and timing information
 #[derive(Debug)]
 pub struct Sample {
+    /// The assembled data in the sample, as a bitstream.
+    ///
+    /// The format is Codec dependant, but is always a bitstream format
+    /// rather than the packetized format used when carried over RTP.
+    ///
+    /// See: [`rtp::packetizer::Depacketizer`] and implementations of it for more details.
     pub data: Bytes,
+
+    /// The wallclock time when this sample was generated.
     pub timestamp: SystemTime,
+
+    /// The duration of this sample
     pub duration: Duration,
+
+    /// The RTP packet timestamp of this sample.
+    ///
+    /// For all RTP packets that contributed to a single sample the timestamp is the same.
     pub packet_timestamp: u32,
+
+    /// The number of packets that were dropped prior to building this sample.
+    ///
+    /// Packets being dropped doesn't necessarily indicate something wrong, e.g., packets are sometimes
+    /// dropped because they aren't relevant for sample building.
     pub prev_dropped_packets: u16,
+
+    /// The number of packets that were identified as padding prior to building this sample.
+    ///
+    /// Some implementations, notably libWebRTC, send padding packets to keep the send rate steady.
+    /// These packets don't carry media and aren't useful for building samples.
+    ///
+    /// This field can be combined with [`Sample::prev_dropped_packets`] to determine if any
+    /// dropped packets have are likely to have detrimental impact on the steadiness of the RTP stream.
+    ///
+    /// ## Example adjustment
+    ///
+    /// ```rust
+    /// # use crate::Sample;
+    /// # let sample = Sample {
+    /// #   data: Bytes::new(),
+    /// #   timestamp: SystemTime::now(),
+    /// #   duration: Duration::from_secs(0),
+    /// #   packet_timestamp: 0,
+    /// #   prev_dropped_packets: 10,
+    /// #   prev_padding_packets: 15
+    /// # };
+    /// #
+    /// let adjusted_dropped =
+    /// sample.prev_dropped_packets.saturating_sub(sample.pre_padding_packets);
+    /// ```
+    pub prev_padding_packets: u16,
 }
 
 impl Default for Sample {
@@ -30,6 +75,7 @@ impl Default for Sample {
             duration: Duration::from_secs(0),
             packet_timestamp: 0,
             prev_dropped_packets: 0,
+            prev_padding_packets: 0,
         }
     }
 }
@@ -54,6 +100,10 @@ impl PartialEq for Sample {
         if self.prev_dropped_packets != other.prev_dropped_packets {
             equal = false;
         }
+        if self.prev_padding_packets != other.prev_padding_packets {
+            equal = false;
+        }
+
         equal
     }
 }


### PR DESCRIPTION
libWebRTC, among others, will sometime send padding RTP packets to keep send rates steady. When they do the packets are sent after a complete sequence of RTP packets that form a Sample/GOP/Frame. Example:

* P0, Timestamp=1, Start
* P1, T=1
* P2, T=1, End(RTP Marker Bit set)
* P3, T=1, Padding
* P4, T=1, Padding
* P5, T=2, Start
* P6, T=2 End

Here, when building a sample using the packets P5 and P6 we'll have `prev_dropped_packets = 2`, however these dropped packets are inconsequential as they don't carry media. The stream of samples is unbroken, despite having dropped some packets. With the introduction of `prev_padding_packets` it's possible to distinguish between dropped packets that are likely to break the sample stream and these unimportant padding packets