### PR TITLE
sctp: allow partial reads

### DIFF
--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Allow partial reads [\#304](https://github.com/webrtc-rs/webrtc/pull/304)
+  `read` no longer returns `ErrShortBuffer` if the buffer is too small to fit a
+  whole message. The buffer will be filled up to its size and the rest of the
+  msg will be returned upon the next call to `read`.
+
 ## v0.6.1
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -735,16 +735,12 @@ async fn test_assoc_reliable_short_buffer() -> Result<()> {
 
     flush_buffers(&br, &a0, &a1).await;
 
+    // Verify partial reads are permitted.
     let mut buf = vec![0u8; 3];
-    let result = s1.read_sctp(&mut buf).await;
-    assert!(result.is_err(), "expected error to be io.ErrShortBuffer");
-    if let Err(err) = result {
-        assert_eq!(
-            Error::ErrShortBuffer,
-            err,
-            "expected error to be io.ErrShortBuffer"
-        );
-    }
+    let (n, ppi) = s1.read_sctp(&mut buf).await?;
+    assert_eq!(n, 3, "unexpected length of received data");
+    assert_eq!(&buf[..n], &MSG[..3], "unexpected length of received data");
+    assert_eq!(ppi, PayloadProtocolIdentifier::Binary, "unexpected ppi");
 
     {
         let q = s0.reassembly_queue.lock().await;

--- a/sctp/src/error.rs
+++ b/sctp/src/error.rs
@@ -209,8 +209,6 @@ pub enum Error {
     ErrOutboundPacketTooLarge,
     #[error("Stream closed")]
     ErrStreamClosed,
-    #[error("Short buffer to be filled")]
-    ErrShortBuffer,
     #[error("Io EOF")]
     ErrEof,
     #[error("Invalid SystemTime")]

--- a/sctp/src/queue/queue_test.rs
+++ b/sctp/src/queue/queue_test.rs
@@ -776,12 +776,20 @@ fn test_reassembly_queue_permits_partial_reads() -> Result<()> {
     assert!(complete, "the set should be complete");
     assert_eq!(10, rq.get_num_bytes(), "num bytes mismatch");
 
+    // partial read
     let mut buf = vec![0u8; 8]; // <- passing buffer too short
     let (n, ppi) = rq.read(&mut buf)?;
     assert_eq!(8, n, "should received 8 bytes");
     assert_eq!(2, rq.get_num_bytes(), "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"01234567", "data should match");
+
+    // read the remaining bytes
+    let (n, ppi) = rq.read(&mut buf)?;
+    assert_eq!(2, n, "should received 1 bytes");
+    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(ppi, org_ppi, "should have valid ppi");
+    assert_eq!(&buf[..n], b"89", "data should match");
 
     Ok(())
 }

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -173,7 +173,6 @@ impl Stream {
 
     /// Reads a packet of len(p) bytes, dropping the Payload Protocol Identifier.
     ///
-    /// Returns `Error::ErrShortBuffer` if `p` is too short.
     /// Returns `0` if the reading half of this stream is shutdown or it (the stream) was reset.
     pub async fn read(&self, p: &mut [u8]) -> Result<usize> {
         let (n, _) = self.read_sctp(p).await?;
@@ -182,7 +181,6 @@ impl Stream {
 
     /// Reads a packet of len(p) bytes and returns the associated Payload Protocol Identifier.
     ///
-    /// Returns `Error::ErrShortBuffer` if `p` is too short.
     /// Returns `(0, PayloadProtocolIdentifier::Unknown)` if the reading half of this stream is shutdown or it (the stream) was reset.
     pub async fn read_sctp(&self, p: &mut [u8]) -> Result<(usize, PayloadProtocolIdentifier)> {
         loop {
@@ -196,7 +194,7 @@ impl Stream {
             };
 
             match result {
-                Ok(_) | Err(Error::ErrShortBuffer) => return result,
+                Ok(_) => return result,
                 Err(_) => {
                     // wait for the next chunk to become available
                     self.read_notifier.notified().await;


### PR DESCRIPTION
This PR modifies `read` behaviour to permit partial reads and no longer return `ErrShortBuffer` if the buffer is too small to fit a whole message. The buffer will be filled up to its size and the rest of the msg will be returned upon the next call to `read`.

Closes #273