### PR TITLE
Rework data-channels-flow-control example

### DIFF
--- a/examples/examples/data-channels-flow-control/README.md
+++ b/examples/examples/data-channels-flow-control/README.md
@@ -22,10 +22,8 @@ The rate you wish to send data might be much higher than the rate the data chann
 actually send to the peer over the Internet. The above properties/methods help your
 application to pace the amount of data to be pushed into the data channel.
 
-
 ## How to run the example code
-
-The demo code implements two endpoints (offer_pc and answer_pc) in it.
+The demo code implements two endpoints (requester and responder) in it.
 
 ```
                         signaling messages
@@ -34,31 +32,31 @@ The demo code implements two endpoints (offer_pc and answer_pc) in it.
            v                                        v
    +---------------+                        +---------------+
    |               |          data          |               |
-   |    offer_pc    |----------------------->|    answer_pc   |
+   |   requester   |----------------------->|   responder   |
    |:PeerConnection|                        |:PeerConnection|
    +---------------+                        +---------------+
 ```
 
-First offer_pc and answer_pc will exchange signaling message to establish a peer-to-peer
+First requester and responder will exchange signaling message to establish a peer-to-peer
 connection, and data channel (label: "data").
 
-Once the data channel is successfully opened, offer_pc will start sending a series of
-1024-byte packets to answer_pc as fast as it can, until you kill the process by Ctrl-c.
+Once the data channel is successfully opened, requester will start sending a series of
+1024-byte packets to responder, until you kill the process by Ctrl+С.
 
+Here's how to run the code:
 
-Here's how to run the code.
-
-At the root of the example:
 ```
-$ cargo run
-Peer Connection State has changed: connected (offerer)
-Peer Connection State has changed: connected (answerer)
-OnOpen: data-1. Start sending a series of 1024-byte packets as fast as it can
-OnOpen: data-1. Start receiving data
-Throughput: 12.990 Mbps
-Throughput: 13.698 Mbps
-Throughput: 13.559 Mbps
-Throughput: 13.345 Mbps
-Throughput: 13.565 Mbps
- :
+$ cargo run --release --example data-channels-flow-control
+    Finished release [optimized] target(s) in 0.36s
+     Running `target\release\examples\data-channels-flow-control.exe`
+
+Throughput is about 127.060 Mbps
+Throughput is about 122.091 Mbps
+Throughput is about 120.630 Mbps
+Throughput is about 120.105 Mbps
+Throughput is about 119.873 Mbps
+Throughput is about 118.890 Mbps
+Throughput is about 118.525 Mbps
+Throughput is about 118.614 Mbps
+
 ```

--- a/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
+++ b/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
@@ -1,368 +1,263 @@
-use anyhow::Result;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime},
+};
+
 use bytes::Bytes;
-use clap::{AppSettings, Arg, Command};
-use std::io::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::SystemTime;
-use tokio::time::Duration;
-use webrtc::api::interceptor_registry::register_default_interceptors;
-use webrtc::api::media_engine::MediaEngine;
-use webrtc::api::APIBuilder;
-use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
-use webrtc::data_channel::data_channel_message::DataChannelMessage;
-use webrtc::data_channel::RTCDataChannel;
-use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
-use webrtc::ice_transport::ice_server::RTCIceServer;
-use webrtc::interceptor::registry::Registry;
-use webrtc::peer_connection::configuration::RTCConfiguration;
-use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
-use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
-use webrtc::peer_connection::RTCPeerConnection;
+
+use webrtc::{
+    api::{
+        interceptor_registry::register_default_interceptors, media_engine::MediaEngine, APIBuilder,
+    },
+    data_channel::data_channel_init::RTCDataChannelInit,
+    ice_transport::{ice_candidate::RTCIceCandidate, ice_server::RTCIceServer},
+    interceptor::registry::Registry,
+    peer_connection::{
+        configuration::RTCConfiguration, peer_connection_state::RTCPeerConnectionState,
+        RTCPeerConnection,
+    },
+};
 
 const BUFFERED_AMOUNT_LOW_THRESHOLD: usize = 512 * 1024; // 512 KB
 const MAX_BUFFERED_AMOUNT: usize = 1024 * 1024; // 1 MB
 
-async fn set_remote_description(pc: &Arc<RTCPeerConnection>, sdp_str: &str) -> Result<()> {
-    let desc = serde_json::from_str::<RTCSessionDescription>(sdp_str)?;
+async fn create_peer_connection() -> RTCPeerConnection {
+    let mut media_engine = MediaEngine::default();
 
-    // Apply the desc as the remote description
-    pc.set_remote_description(desc).await?;
+    media_engine.register_default_codecs().unwrap();
 
-    Ok(())
-}
+    let mut interceptor_registry = Registry::new();
 
-async fn create_offerer() -> Result<Arc<RTCPeerConnection>> {
-    // Create a MediaEngine object to configure the supported codec
-    let mut m = MediaEngine::default();
+    interceptor_registry =
+        register_default_interceptors(interceptor_registry, &mut media_engine).unwrap();
 
-    // Register default codecs
-    m.register_default_codecs()?;
-
-    // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
-    // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
-    // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
-    // for each PeerConnection.
-    let mut registry = Registry::new();
-
-    // Use the default set of Interceptors
-    registry = register_default_interceptors(registry, &mut m)?;
-
-    // Create the API object with the MediaEngine
     let api = APIBuilder::new()
-        .with_media_engine(m)
-        .with_interceptor_registry(registry)
+        .with_media_engine(media_engine)
+        .with_interceptor_registry(interceptor_registry)
         .build();
 
-    // Prepare the configuration
+    let ice_servers = vec![RTCIceServer {
+        ..Default::default()
+    }];
+
     let config = RTCConfiguration {
-        ice_servers: vec![RTCIceServer {
-            //urls: vec!["stun:stun.l.google.com:19302".to_owned()],
-            ..Default::default()
-        }],
+        ice_servers,
         ..Default::default()
     };
 
-    // Create a new RTCPeerConnection
-    let pc = Arc::new(api.new_peer_connection(config).await?);
+    api.new_peer_connection(config).await.unwrap()
+}
 
-    let ordered = Some(false);
-    let max_retransmits = Some(0u16);
+async fn create_requester() -> RTCPeerConnection {
+    let pc = create_peer_connection().await;
 
     let options = Some(RTCDataChannelInit {
-        ordered,
-        max_retransmits,
+        ordered: Some(false),
+        max_retransmits: Some(0u16),
         ..Default::default()
     });
 
-    let (send_more_ch_tx, mut send_more_ch_rx) = tokio::sync::mpsc::channel::<()>(1);
-    let send_more_ch_tx = Arc::new(send_more_ch_tx);
+    let (more_can_be_sent, mut maybe_more_can_be_sent) = tokio::sync::mpsc::channel(1);
+    let dc = pc.create_data_channel("data", options).await.unwrap();
 
-    // Create a datachannel with label 'data'
-    let dc = pc.create_data_channel("data", options).await?;
-
-    // Register channel opening handling
-
-    // no need to downgrade this to Weak, since on_open is FnOnce callback
-    let dc2 = Arc::clone(&dc);
+    let shared_dc = dc.clone();
     dc.on_open(Box::new(|| {
-        println!(
-            "OnOpen-{}-{} : Start sending a series of 1024-byte packets as fast as it can",
-            dc2.label(),
-            dc2.id()
-        );
+        Box::pin(async move {
+            println!("requester :: on_open");
 
-        tokio::spawn(async move {
-            let buf = Bytes::from_static(&[0u8; 1024]);
-            loop {
-                if dc2.send(&buf).await.is_err() {
-                    break;
-                }
+            let task = tokio::spawn(async move {
+                let buf = Bytes::from_static(&[0u8; 1024]);
 
-                tokio::time::sleep(Duration::from_micros(1)).await;
-                let buffered_amount = dc2.buffered_amount().await;
-                if buffered_amount + buf.len() > MAX_BUFFERED_AMOUNT {
-                    let _ = send_more_ch_rx.recv().await;
+                loop {
+                    if shared_dc.send(&buf).await.is_err() {
+                        break;
+                    }
+
+                    let buffered_amount = shared_dc.buffered_amount().await;
+
+                    if buffered_amount + buf.len() > MAX_BUFFERED_AMOUNT {
+                        let _ = maybe_more_can_be_sent.recv().await;
+                    }
                 }
-            }
-            println!("exit on_open");
-        });
-        Box::pin(async {})
+            });
+
+            task.await.unwrap();
+        })
     }))
     .await;
 
-    // Set BUFFERED_AMOUNT_LOW_THRESHOLD so that we can get notified when
-    // we can send more
     dc.set_buffered_amount_low_threshold(BUFFERED_AMOUNT_LOW_THRESHOLD)
         .await;
 
-    // This callback is made when the current bufferedAmount becomes lower than the threshold
     dc.on_buffered_amount_low(Box::new(move || {
-        let send_more_ch_tx2 = Arc::clone(&send_more_ch_tx);
+        let more_can_be_sent = more_can_be_sent.clone();
+
         Box::pin(async move {
-            let _ = send_more_ch_tx2.send(()).await;
+            more_can_be_sent.send(()).await.unwrap();
         })
     }))
     .await;
 
-    Ok(pc)
+    pc
 }
 
-async fn create_answerer() -> Result<Arc<RTCPeerConnection>> {
-    // Create a MediaEngine object to configure the supported codec
-    let mut m = MediaEngine::default();
+async fn create_responder() -> RTCPeerConnection {
+    let pc = create_peer_connection().await;
 
-    // Register default codecs
-    m.register_default_codecs()?;
-
-    // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
-    // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
-    // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
-    // for each PeerConnection.
-    let mut registry = Registry::new();
-
-    // Use the default set of Interceptors
-    registry = register_default_interceptors(registry, &mut m)?;
-
-    // Create the API object with the MediaEngine
-    let api = APIBuilder::new()
-        .with_media_engine(m)
-        .with_interceptor_registry(registry)
-        .build();
-
-    // Prepare the configuration
-    let config = RTCConfiguration {
-        ice_servers: vec![RTCIceServer {
-            //urls: vec!["stun:stun.l.google.com:19302".to_owned()],
-            ..Default::default()
-        }],
-        ..Default::default()
-    };
-
-    // Create a new RTCPeerConnection
-    let pc = Arc::new(api.new_peer_connection(config).await?);
-
-    pc.on_data_channel(Box::new(move |dc: Arc<RTCDataChannel>| {
-        let total_bytes_received = Arc::new(AtomicUsize::new(0));
-
+    pc.on_data_channel(Box::new(move |dc| {
         Box::pin(async move {
-            // Register channel opening handling
-            let total_bytes_received2 = Arc::clone(&total_bytes_received);
+            let total_bytes_received = Arc::new(AtomicUsize::new(0));
+
+            let get_total_bytes_received = total_bytes_received.clone();
             dc.on_open(Box::new(move || {
-                println!("OnOpen: Start receiving data"); //, dc2.label(), dc2.id());
-                tokio::spawn(async move {
-                    let since = SystemTime::now();
+                Box::pin(async {
+                    println!("responder :: on_open");
 
-                    // Start printing out the observed throughput
-                    loop {
+                    let task = tokio::spawn(async move {
+                        let start = SystemTime::now();
+
                         tokio::time::sleep(Duration::from_secs(1)).await;
-                        let total_bytes = total_bytes_received2.load(Ordering::SeqCst);
-                        let bps = (total_bytes * 8) as f64
-                            / SystemTime::now()
-                                .duration_since(since)
-                                .unwrap()
-                                .as_secs_f64();
-                        println!("Throughput: {:.03} Mbps", bps / (1024 * 1024) as f64);
-                    }
-                });
+                        println!("");
 
-                Box::pin(async {})
+                        loop {
+                            let total_bytes = get_total_bytes_received.load(Ordering::Relaxed);
+
+                            let elapsed = SystemTime::now().duration_since(start);
+                            let bps = (total_bytes * 8) as f64 / elapsed.unwrap().as_secs_f64();
+
+                            println!(
+                                "Throughput is about {:.03} Mbps",
+                                bps / (1024 * 1024) as f64
+                            );
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    });
+
+                    task.await.unwrap();
+                })
             }))
             .await;
 
-            // Register the OnMessage to handle incoming messages
-            dc.on_message(Box::new(move |msg: DataChannelMessage| {
-                let n = msg.data.len();
-                total_bytes_received.fetch_add(n, Ordering::SeqCst);
-                Box::pin(async {})
+            dc.on_message(Box::new(move |msg| {
+                let total_bytes_received = total_bytes_received.clone();
+
+                Box::pin(async move {
+                    total_bytes_received.fetch_add(msg.data.len(), Ordering::Relaxed);
+                })
             }))
             .await;
         })
     }))
     .await;
 
-    Ok(pc)
+    pc
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    let mut app = Command::new("data-channels-flow-control")
-        .version("0.1.0")
-        .author("Rain Liu <yliu@webrtc.rs>")
-        .about("An example of Data-Channels-Flow-Control.")
-        .setting(AppSettings::DeriveDisplayOrder)
-        .subcommand_negates_reqs(true)
-        .arg(
-            Arg::new("FULLHELP")
-                .help("Prints more detailed help information")
-                .long("fullhelp"),
-        )
-        .arg(
-            Arg::new("debug")
-                .long("debug")
-                .short('d')
-                .help("Prints debug log information"),
-        );
+async fn main() {
+    let requester = Arc::new(create_requester().await);
+    let responder = Arc::new(create_responder().await);
 
-    let matches = app.clone().get_matches();
+    let maybe_requester = Arc::downgrade(&requester);
+    responder
+        .on_ice_candidate(Box::new(move |candidate: Option<RTCIceCandidate>| {
+            let maybe_requester = maybe_requester.clone();
 
-    if matches.is_present("FULLHELP") {
-        app.print_long_help().unwrap();
-        std::process::exit(0);
-    }
-
-    let debug = matches.is_present("debug");
-    if debug {
-        env_logger::Builder::new()
-            .format(|buf, record| {
-                writeln!(
-                    buf,
-                    "{}:{} [{}] {} - {}",
-                    record.file().unwrap_or("unknown"),
-                    record.line().unwrap_or(0),
-                    record.level(),
-                    chrono::Local::now().format("%H:%M:%S.%6f"),
-                    record.args()
-                )
+            Box::pin(async move {
+                if let Some(candidate) = candidate {
+                    if let Ok(candidate) = candidate.to_json().await {
+                        if let Some(requester) = maybe_requester.upgrade() {
+                            requester.add_ice_candidate(candidate).await.unwrap();
+                        }
+                    }
+                }
             })
-            .filter(None, log::LevelFilter::Trace)
-            .init();
-    }
+        }))
+        .await;
 
-    {
-        let offer_pc = create_offerer().await?;
-        let answer_pc = create_answerer().await?;
+    let maybe_responder = Arc::downgrade(&responder);
+    requester
+        .on_ice_candidate(Box::new(move |candidate: Option<RTCIceCandidate>| {
+            let maybe_responder = maybe_responder.clone();
 
-        // Set ICE Candidate handler. As soon as a PeerConnection has gathered a candidate
-        // send it to the other peer
-        let offer_pc2 = Arc::downgrade(&offer_pc);
-        answer_pc
-            .on_ice_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-                let offer_pc3 = offer_pc2.clone();
-                Box::pin(async move {
-                    if let Some(c) = c {
-                        if let Ok(c) = c.to_json().await {
-                            if let Some(offer_pc3) = offer_pc3.upgrade() {
-                                let _ = offer_pc3.add_ice_candidate(c).await;
-                            }
+            Box::pin(async move {
+                if let Some(candidate) = candidate {
+                    if let Ok(candidate) = candidate.to_json().await {
+                        if let Some(responder) = maybe_responder.upgrade() {
+                            responder.add_ice_candidate(candidate).await.unwrap();
                         }
                     }
-                })
-            }))
-            .await;
+                }
+            })
+        }))
+        .await;
 
-        // Set ICE Candidate handler. As soon as a PeerConnection has gathered a candidate
-        // send it to the other peer
-        let answer_pc2 = Arc::downgrade(&answer_pc);
-        offer_pc
-            .on_ice_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-                let answer_pc3 = answer_pc2.clone();
-                Box::pin(async move {
-                    if let Some(c) = c {
-                        if let Ok(c) = c.to_json().await {
-                            if let Some(answer_pc3) = answer_pc3.upgrade() {
-                                let _ = answer_pc3.add_ice_candidate(c).await;
-                            }
-                        }
-                    }
-                })
-            }))
-            .await;
+    let (fault, mut reqs_fault) = tokio::sync::mpsc::channel(1);
+    requester
+        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+            let fault = fault.clone();
 
-        let (offer_done_tx, mut offer_done_rx) = tokio::sync::mpsc::channel::<()>(1);
-
-        // Set the handler for Peer connection state
-        // This will notify you when the peer has connected/disconnected
-        offer_pc
-            .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-                println!("Peer Connection State has changed: {} (offerer)", s);
+            Box::pin(async move {
+                println!("requester :: peer_connection_state_change :: {}", s);
 
                 if s == RTCPeerConnectionState::Failed {
-                    // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                    // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                    // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                    println!("Peer Connection (offerer) has gone to failed exiting");
-                    let _ = offer_done_tx.try_send(());
+                    println!("{:?}", s);
+
+                    let _ = fault.try_send(());
                 }
-                Box::pin(async {})
-            }))
-            .await;
+            })
+        }))
+        .await;
 
-        let (answer_done_tx, mut answer_done_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let (fault, mut resp_fault) = tokio::sync::mpsc::channel(1);
+    responder
+        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+            let fault = fault.clone();
 
-        // Set the handler for Peer connection state
-        // This will notify you when the peer has connected/disconnected
-        answer_pc
-            .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-                println!("Peer Connection State has changed: {} (answerer)", s);
+            Box::pin(async move {
+                println!("responder :: peer_connection_state_change :: {}", s);
 
                 if s == RTCPeerConnectionState::Failed {
-                    // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                    // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                    // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                    println!("Peer Connection (answerer) has gone to failed exiting");
-                    let _ = answer_done_tx.try_send(());
+                    println!("{:?}", s);
+
+                    let _ = fault.try_send(());
                 }
-                Box::pin(async {})
-            }))
-            .await;
+            })
+        }))
+        .await;
 
-        // Now, create an offer
-        let offer = offer_pc.create_offer(None).await?;
-        let desc = serde_json::to_string(&offer)?;
-        offer_pc.set_local_description(offer).await?;
-        set_remote_description(&answer_pc, &desc).await?;
+    let reqs = requester.create_offer(None).await.unwrap();
 
-        let answer = answer_pc.create_answer(None).await?;
-        let desc2 = serde_json::to_string(&answer)?;
-        answer_pc.set_local_description(answer).await?;
-        set_remote_description(&offer_pc, &desc2).await?;
+    requester.set_local_description(reqs.clone()).await.unwrap();
+    responder.set_remote_description(reqs).await.unwrap();
 
-        println!("Press ctrl-c to stop or wait for 5s");
-        let timeout = tokio::time::sleep(Duration::from_secs(5));
-        tokio::pin!(timeout);
+    let resp = responder.create_answer(None).await.unwrap();
 
-        tokio::select! {
-            _ = timeout.as_mut() => {}
-            _ = tokio::signal::ctrl_c() => {
-                println!("");
-            }
-            _ = offer_done_rx.recv() => {
-                println!("received offer done signal!");
-            }
-            _ = answer_done_rx.recv() => {
-                println!("received answer done signal!");
-            }
+    responder.set_local_description(resp.clone()).await.unwrap();
+    requester.set_remote_description(resp).await.unwrap();
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            println!("");
         }
-
-        if let Err(err) = offer_pc.close().await {
-            println!("cannot close offer_pc: {}", err);
+        _ = reqs_fault.recv() => {
+            println!("reqs_fault");
         }
-
-        if let Err(err) = answer_pc.close().await {
-            println!("cannot close answer_pc: {}", err);
+        _ = resp_fault.recv() => {
+            println!("resp_fault");
         }
     }
 
-    Ok(())
+    if let Err(err) = requester.close().await {
+        println!("{}", err);
+    }
+
+    if let Err(err) = responder.close().await {
+        println!("{}", err);
+    }
+
+    println!("");
 }

--- a/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
+++ b/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
@@ -163,7 +163,9 @@ async fn main() -> anyhow::Result<()> {
                 if let Some(candidate) = candidate {
                     if let Ok(candidate) = candidate.to_json().await {
                         if let Some(requester) = maybe_requester.upgrade() {
-                            requester.add_ice_candidate(candidate).await.unwrap();
+                            if let Err(err) = requester.add_ice_candidate(candidate).await {
+                                log::warn!("{}", err);
+                            }
                         }
                     }
                 }
@@ -180,7 +182,9 @@ async fn main() -> anyhow::Result<()> {
                 if let Some(candidate) = candidate {
                     if let Ok(candidate) = candidate.to_json().await {
                         if let Some(responder) = maybe_responder.upgrade() {
-                            responder.add_ice_candidate(candidate).await.unwrap();
+                            if let Err(err) = responder.add_ice_candidate(candidate).await {
+                                log::warn!("{}", err);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
All examples and tests should be reworked like this one to make it possible to rework inner callback representation.

Under "like this one" I mean reworking at least callbacks in examples and tests, so there is no logic outside of async blocks, only state management.

I want to merge this into master, and not into feature/rework-callbacks, because in this example old callback representation is used, it does not break anything and will not prevent the release in any way.

If I rework other examples, I will also use the old callback representation, since the examples are generally poorly written. It is too difficult to move them to a new representation at the moment, I will still have to rewrite them from scratch. So I don't want to rewrite and move them to a new representation at the same time.