### PR TITLE
add support for the telephone-event codec

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add IP filter to WebRTC `SettingEngine` [#306](https://github.com/webrtc-rs/webrtc/pull/306)
 * Stop sequence numbers from increasing in `TrackLocalStaticSample` while the bound `RTCRtpSender` have
 directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull/316)
+* Add support for a mime type "audio/telephone-event" (rfc4733)
 
 #### Breaking changes
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add IP filter to WebRTC `SettingEngine` [#306](https://github.com/webrtc-rs/webrtc/pull/306)
 * Stop sequence numbers from increasing in `TrackLocalStaticSample` while the bound `RTCRtpSender` have
 directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull/316)
-* Add support for a mime type "audio/telephone-event" (rfc4733)
+* Add support for a mime type "audio/telephone-event" (rfc4733) [#322](https://github.com/webrtc-rs/webrtc/pull/322)
 
 #### Breaking changes
 

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -48,6 +48,9 @@ pub const MIME_TYPE_PCMU: &str = "audio/PCMU";
 /// MIME_TYPE_PCMA PCMA MIME type
 /// Note: Matching should be case insensitive.
 pub const MIME_TYPE_PCMA: &str = "audio/PCMA";
+/// MIME_TYPE_TELEPHONE_EVENT telephone-event MIME type
+/// Note: Matching should be case insensitive.
+pub const MIME_TYPE_TELEPHONE_EVENT: &str = "audio/telephone-event";
 
 const VALID_EXT_IDS: Range<isize> = 1..15;
 

--- a/webrtc/src/rtp_transceiver/rtp_codec.rs
+++ b/webrtc/src/rtp_transceiver/rtp_codec.rs
@@ -83,6 +83,7 @@ impl RTCRtpCodecCapability {
         } else if mime_type == MIME_TYPE_G722.to_lowercase()
             || mime_type == MIME_TYPE_PCMU.to_lowercase()
             || mime_type == MIME_TYPE_PCMA.to_lowercase()
+            || mime_type == MIME_TYPE_TELEPHONE_EVENT.to_lowercase()
         {
             Ok(Box::new(rtp::codecs::g7xx::G7xxPayloader::default()))
         } else {


### PR DESCRIPTION
Hi,

This just adds a mime type and resolves it to the G7xxPayloader. 

Telephone event packets are just a 4 byte payload, and I could add an even simpler payloader but I think the G7xxPayloader does the right thing here, even if the name is not really fitting this usecase.

Any other places this new codec would need mentioning?