### PR TITLE
Marshalled extension types derive Serialize/Deserialize

### DIFF
--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -17,6 +17,7 @@ bytes = "1"
 rand = "0.8.5"
 thiserror = "1.0"
 async-trait = "0.1.56"
+serde = { version = "1.0.102", features = ["derive"] }
 
 [dev-dependencies]
 chrono = "0.4.19"

--- a/rtp/src/extension/audio_level_extension/mod.rs
+++ b/rtp/src/extension/audio_level_extension/mod.rs
@@ -2,6 +2,7 @@
 mod audio_level_extension_test;
 
 use crate::error::Error;
+use serde::{Deserialize, Serialize};
 use util::marshal::{Marshal, MarshalSize, Unmarshal};
 
 use bytes::{Buf, BufMut};
@@ -28,7 +29,7 @@ pub const AUDIO_LEVEL_EXTENSION_SIZE: usize = 1;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |      ID       |     len=1     |V|    level    |    0 (pad)    |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone, Serialize, Deserialize)]
 pub struct AudioLevelExtension {
     pub level: u8,
     pub voice: bool,

--- a/rtp/src/extension/transport_cc_extension/mod.rs
+++ b/rtp/src/extension/transport_cc_extension/mod.rs
@@ -2,6 +2,7 @@
 mod transport_cc_extension_test;
 
 use crate::error::Error;
+use serde::{Deserialize, Serialize};
 use util::marshal::{Marshal, MarshalSize, Unmarshal};
 
 use bytes::{Buf, BufMut};
@@ -18,7 +19,7 @@ pub const TRANSPORT_CC_EXTENSION_SIZE: usize = 2;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |  ID   | L=1   |transport-wide sequence number | zero padding  |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone, Serialize, Deserialize)]
 pub struct TransportCcExtension {
     pub transport_sequence: u16,
 }

--- a/rtp/src/extension/video_orientation_extension/mod.rs
+++ b/rtp/src/extension/video_orientation_extension/mod.rs
@@ -4,6 +4,7 @@ mod video_orientation_extension_test;
 use std::convert::{TryFrom, TryInto};
 
 use bytes::BufMut;
+use serde::{Deserialize, Serialize};
 use util::{marshal::Unmarshal, Marshal, MarshalSize};
 
 use crate::Error;
@@ -34,20 +35,20 @@ pub const VIDEO_ORIENTATION_EXTENSION_SIZE: usize = 1;
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///   |  ID   | len=0 |0 0 0 0 C F R R|
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone, Serialize, Deserialize)]
 pub struct VideoOrientationExtension {
     pub direction: CameraDirection,
     pub flip: bool,
     pub rotation: VideoRotation,
 }
 
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum CameraDirection {
     Front = 0,
     Back = 1,
 }
 
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum VideoRotation {
     Degree0 = 0,
     Degree90 = 1,


### PR DESCRIPTION
To make them more usable for the consumer of these types.