### PR TITLE
Remove unnecessary async in public API

### DIFF
--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+
+#### Breaking changes
+
 * Make `DataChannel::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
 
 ## 0.5.0

--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+* Make `DataChannel::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
 
 ## 0.5.0
 

--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Increased minimum support rust version to `1.60.0`.
 
-#### Breaking changes
+### Breaking changes
 
 * Make `DataChannel::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
 

--- a/data/src/data_channel/data_channel_test.rs
+++ b/data/src/data_channel/data_channel_test.rs
@@ -282,7 +282,7 @@ async fn test_data_channel_channel_type_reliable_ordered() -> Result<()> {
     assert_eq!(dc0.config, cfg, "local config should match");
     assert_eq!(dc1.config, cfg, "remote config should match");
 
-    br.reorder_next_nwrites(0, 2).await; // reordering on the wire
+    br.reorder_next_nwrites(0, 2); // reordering on the wire
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = dc0.write(&Bytes::from(sbuf.clone())).await?;
@@ -475,8 +475,7 @@ async fn test_data_channel_buffered_amount() -> Result<()> {
     dc0.on_buffered_amount_low(Box::new(move || {
         n_cbs2.fetch_add(1, Ordering::SeqCst);
         Box::pin(async {})
-    }))
-    .await;
+    }));
 
     // Write 10 1000-byte packets (total 10,000 bytes)
     for i in 0..10 {

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -345,8 +345,8 @@ impl DataChannel {
 
     /// OnBufferedAmountLow sets the callback handler which would be called when the
     /// number of bytes of outgoing data buffered is lower than the threshold.
-    pub async fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
-        self.stream.on_buffered_amount_low(f).await
+    pub fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
+        self.stream.on_buffered_amount_low(f)
     }
 
     fn commit_reliability_params(&self) {

--- a/dtls/examples/hub/src/lib.rs
+++ b/dtls/examples/hub/src/lib.rs
@@ -29,9 +29,9 @@ impl Hub {
 
     /// register adds a new conn to the Hub
     pub async fn register(&self, conn: Arc<dyn Conn + Send + Sync>) {
-        println!("Connected to {}", conn.remote_addr().await.unwrap());
+        println!("Connected to {}", conn.remote_addr().unwrap());
 
-        if let Some(remote_addr) = conn.remote_addr().await {
+        if let Some(remote_addr) = conn.remote_addr() {
             let mut conns = self.conns.lock().await;
             conns.insert(remote_addr.to_string(), Arc::clone(&conn));
         }
@@ -60,7 +60,7 @@ impl Hub {
         conns: Arc<Mutex<HashMap<String, Arc<dyn Conn + Send + Sync>>>>,
         conn: Arc<dyn Conn + Send + Sync>,
     ) -> Result<(), Error> {
-        if let Some(remote_addr) = conn.remote_addr().await {
+        if let Some(remote_addr) = conn.remote_addr() {
             {
                 let mut cs = conns.lock().await;
                 cs.remove(&remote_addr.to_string());
@@ -82,7 +82,7 @@ impl Hub {
             if let Err(err) = conn.send(msg).await {
                 println!(
                     "Failed to write message to {:?}: {}",
-                    conn.remote_addr().await,
+                    conn.remote_addr(),
                     err
                 );
             }

--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -114,7 +114,7 @@ impl Conn for DTLSConn {
         self.read(buf, None).await.map_err(util::Error::from_std)
     }
     async fn recv_from(&self, buf: &mut [u8]) -> UtilResult<(usize, SocketAddr)> {
-        if let Some(raddr) = self.conn.remote_addr().await {
+        if let Some(raddr) = self.conn.remote_addr() {
             let n = self.read(buf, None).await.map_err(util::Error::from_std)?;
             Ok((n, raddr))
         } else {
@@ -129,11 +129,11 @@ impl Conn for DTLSConn {
     async fn send_to(&self, _buf: &[u8], _target: SocketAddr) -> UtilResult<usize> {
         Err(util::Error::Other("Not applicable".to_owned()))
     }
-    async fn local_addr(&self) -> UtilResult<SocketAddr> {
-        self.conn.local_addr().await
+    fn local_addr(&self) -> UtilResult<SocketAddr> {
+        self.conn.local_addr()
     }
-    async fn remote_addr(&self) -> Option<SocketAddr> {
-        self.conn.remote_addr().await
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.conn.remote_addr()
     }
     async fn close(&self) -> UtilResult<()> {
         self.close().await.map_err(util::Error::from_std)
@@ -191,7 +191,7 @@ impl DTLSConn {
 
         // Use host from conn address when server_name is not provided
         if is_client && server_name.is_empty() {
-            if let Some(remote_addr) = conn.remote_addr().await {
+            if let Some(remote_addr) = conn.remote_addr() {
                 server_name = remote_addr.ip().to_string();
             } else {
                 log::warn!("conn.remote_addr is empty, please set explicitly server_name in Config! Use default \"localhost\" as server_name now");

--- a/examples/examples/broadcast/broadcast.rs
+++ b/examples/examples/broadcast/broadcast.rs
@@ -127,72 +127,68 @@ async fn main() -> Result<()> {
     // Set a handler for when a new remote track starts, this handler copies inbound RTP packets,
     // replaces the SSRC and sends them back
     let pc = Arc::downgrade(&peer_connection);
-    peer_connection
-        .on_track(Box::new(
-            move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
-                if let Some(track) = track {
-                    // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
-                    // This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
-                    let media_ssrc = track.ssrc();
-                    let pc2 = pc.clone();
-                    tokio::spawn(async move {
-                        let mut result = Result::<usize>::Ok(0);
-                        while result.is_ok() {
-                            let timeout = tokio::time::sleep(Duration::from_secs(3));
-                            tokio::pin!(timeout);
+    peer_connection.on_track(Box::new(
+        move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
+            if let Some(track) = track {
+                // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+                // This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
+                let media_ssrc = track.ssrc();
+                let pc2 = pc.clone();
+                tokio::spawn(async move {
+                    let mut result = Result::<usize>::Ok(0);
+                    while result.is_ok() {
+                        let timeout = tokio::time::sleep(Duration::from_secs(3));
+                        tokio::pin!(timeout);
 
-                            tokio::select! {
-                                _ = timeout.as_mut() =>{
-                                    if let Some(pc) = pc2.upgrade(){
-                                        result = pc.write_rtcp(&[Box::new(PictureLossIndication{
-                                            sender_ssrc: 0,
-                                            media_ssrc,
-                                        })]).await.map_err(Into::into);
-                                    }else{
-                                        break;
-                                    }
-                                }
-                            };
-                        }
-                    });
-
-                    let local_track_chan_tx2 = Arc::clone(&local_track_chan_tx);
-                    tokio::spawn(async move {
-                        // Create Track that we send video back to browser on
-                        let local_track = Arc::new(TrackLocalStaticRTP::new(
-                            track.codec().await.capability,
-                            "video".to_owned(),
-                            "webrtc-rs".to_owned(),
-                        ));
-                        let _ = local_track_chan_tx2.send(Arc::clone(&local_track)).await;
-
-                        // Read RTP packets being sent to webrtc-rs
-                        while let Ok((rtp, _)) = track.read_rtp().await {
-                            if let Err(err) = local_track.write_rtp(&rtp).await {
-                                if Error::ErrClosedPipe != err {
-                                    print!("output track write_rtp got error: {} and break", err);
+                        tokio::select! {
+                            _ = timeout.as_mut() =>{
+                                if let Some(pc) = pc2.upgrade(){
+                                    result = pc.write_rtcp(&[Box::new(PictureLossIndication{
+                                        sender_ssrc: 0,
+                                        media_ssrc,
+                                    })]).await.map_err(Into::into);
+                                }else{
                                     break;
-                                } else {
-                                    print!("output track write_rtp got error: {}", err);
                                 }
                             }
-                        }
-                    });
-                }
+                        };
+                    }
+                });
 
-                Box::pin(async {})
-            },
-        ))
-        .await;
+                let local_track_chan_tx2 = Arc::clone(&local_track_chan_tx);
+                tokio::spawn(async move {
+                    // Create Track that we send video back to browser on
+                    let local_track = Arc::new(TrackLocalStaticRTP::new(
+                        track.codec().await.capability,
+                        "video".to_owned(),
+                        "webrtc-rs".to_owned(),
+                    ));
+                    let _ = local_track_chan_tx2.send(Arc::clone(&local_track)).await;
+
+                    // Read RTP packets being sent to webrtc-rs
+                    while let Ok((rtp, _)) = track.read_rtp().await {
+                        if let Err(err) = local_track.write_rtp(&rtp).await {
+                            if Error::ErrClosedPipe != err {
+                                print!("output track write_rtp got error: {} and break", err);
+                                break;
+                            } else {
+                                print!("output track write_rtp got error: {}", err);
+                            }
+                        }
+                    }
+                });
+            }
+
+            Box::pin(async {})
+        },
+    ));
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
-            Box::pin(async {})
-        }))
-        .await;
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
+        Box::pin(async {})
+    }));
 
     // Set the remote SessionDescription
     peer_connection.set_remote_description(offer).await?;
@@ -275,12 +271,12 @@ async fn main() -> Result<()> {
 
             // Set the handler for Peer connection state
             // This will notify you when the peer has connected/disconnected
-            peer_connection
-                .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+            peer_connection.on_peer_connection_state_change(Box::new(
+                move |s: RTCPeerConnectionState| {
                     println!("Peer Connection State has changed: {}", s);
                     Box::pin(async {})
-                }))
-                .await;
+                },
+            ));
 
             // Set the remote SessionDescription
             peer_connection

--- a/examples/examples/data-channels-close/data-channels-close.rs
+++ b/examples/examples/data-channels-close/data-channels-close.rs
@@ -115,21 +115,19 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Register data channel creation handling
     peer_connection
@@ -157,7 +155,7 @@ async fn main() -> Result<()> {
                                 let mut done = done_tx2.lock().await;
                                 done.take();
                             })
-                        })).await;
+                        }));
 
                         let mut result = Result::<usize>::Ok(0);
                         while result.is_ok() {
@@ -175,7 +173,7 @@ async fn main() -> Result<()> {
 
                                     let cnt = close_after2.fetch_sub(1, Ordering::SeqCst);
                                     if cnt <= 0 {
-                                        println!("Sent times out. Closing data channel '{}'-'{}'.", d2.label(), d2.id());                                       
+                                        println!("Sent times out. Closing data channel '{}'-'{}'.", d2.label(), d2.id());
                                         let _ = d2.close().await;
                                         break;
                                     }
@@ -183,17 +181,16 @@ async fn main() -> Result<()> {
                             };
                         }
                     })
-                })).await;
+                }));
 
                 // Register text message handling
                 d.on_message(Box::new(move |msg: DataChannelMessage| {
                     let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
                     println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
                     Box::pin(async {})
-                })).await;
+                }));
             })
-        }))
-        .await;
+        }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/data-channels-create/data-channels-create.rs
+++ b/examples/examples/data-channels-create/data-channels-create.rs
@@ -101,21 +101,19 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Register channel opening handling
     let d1 = Arc::clone(&data_channel);
@@ -138,17 +136,15 @@ async fn main() -> Result<()> {
                 };
             }
         })
-    })).await;
+    }));
 
     // Register text message handling
     let d_label = data_channel.label().to_owned();
-    data_channel
-        .on_message(Box::new(move |msg: DataChannelMessage| {
-            let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-            println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
-            Box::pin(async {})
-        }))
-        .await;
+    data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
+        let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
+        println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+        Box::pin(async {})
+    }));
 
     // Create an offer to send to the browser
     let offer = peer_connection.create_offer(None).await?;

--- a/examples/examples/data-channels-detach/data-channels-detach.rs
+++ b/examples/examples/data-channels-detach/data-channels-detach.rs
@@ -111,62 +111,57 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Register data channel creation handling
-    peer_connection
-        .on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
-            let d_label = d.label().to_owned();
-            let d_id = d.id();
-            println!("New DataChannel {} {}", d_label, d_id);
+    peer_connection.on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
+        let d_label = d.label().to_owned();
+        let d_id = d.id();
+        println!("New DataChannel {} {}", d_label, d_id);
 
-            // Register channel opening handling
-            Box::pin(async move {
-                let d2 = Arc::clone(&d);
-                let d_label2 = d_label.clone();
-                let d_id2 = d_id;
-                d.on_open(Box::new(move || {
-                    println!("Data channel '{}'-'{}' open.", d_label2, d_id2);
+        // Register channel opening handling
+        Box::pin(async move {
+            let d2 = Arc::clone(&d);
+            let d_label2 = d_label.clone();
+            let d_id2 = d_id;
+            d.on_open(Box::new(move || {
+                println!("Data channel '{}'-'{}' open.", d_label2, d_id2);
 
-                    Box::pin(async move {
-                        let raw = match d2.detach().await {
-                            Ok(raw) => raw,
-                            Err(err) => {
-                                println!("data channel detach got err: {}", err);
-                                return;
-                            }
-                        };
+                Box::pin(async move {
+                    let raw = match d2.detach().await {
+                        Ok(raw) => raw,
+                        Err(err) => {
+                            println!("data channel detach got err: {}", err);
+                            return;
+                        }
+                    };
 
-                        // Handle reading from the data channel
-                        let r = Arc::clone(&raw);
-                        tokio::spawn(async move {
-                            let _ = read_loop(r).await;
-                        });
+                    // Handle reading from the data channel
+                    let r = Arc::clone(&raw);
+                    tokio::spawn(async move {
+                        let _ = read_loop(r).await;
+                    });
 
-                        // Handle writing to the data channel
-                        tokio::spawn(async move {
-                            let _ = write_loop(raw).await;
-                        });
-                    })
-                }))
-                .await;
-            })
-        }))
-        .await;
+                    // Handle writing to the data channel
+                    tokio::spawn(async move {
+                        let _ = write_loop(raw).await;
+                    });
+                })
+            }));
+        })
+    }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/data-channels/data-channels.rs
+++ b/examples/examples/data-channels/data-channels.rs
@@ -99,21 +99,19 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Register data channel creation handling
     peer_connection
@@ -145,17 +143,16 @@ async fn main() -> Result<()> {
                             };
                         }
                     })
-                })).await;
+                }));
 
                 // Register text message handling
                 d.on_message(Box::new(move |msg: DataChannelMessage| {
                     let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
                     println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
                     Box::pin(async {})
-                })).await;
+                }));
             })
-        }))
-        .await;
+        }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/ice-restart/ice-restart.rs
+++ b/examples/examples/ice-restart/ice-restart.rs
@@ -114,8 +114,7 @@ async fn do_signaling(req: Request<Body>) -> Result<Response<Body>, hyper::Error
                     println!("ICE Connection State has changed: {}", connection_state);
                     Box::pin(async {})
                 },
-            ))
-            .await;
+            ));
 
             // Send the current time via a DataChannel to the remote peer every 3 seconds
             pc.on_data_channel(Box::new(|d: Arc<RTCDataChannel>| {
@@ -131,11 +130,9 @@ async fn do_signaling(req: Request<Body>) -> Result<Response<Body>, hyper::Error
                                 tokio::time::sleep(Duration::from_secs(3)).await;
                             }
                         })
-                    }))
-                    .await;
+                    }));
                 })
-            }))
-            .await;
+            }));
 
             *peer_connection = Some(Arc::clone(&pc));
             pc

--- a/examples/examples/insertable-streams/insertable-streams.rs
+++ b/examples/examples/insertable-streams/insertable-streams.rs
@@ -196,33 +196,31 @@ async fn main() -> Result<()> {
 
     // Set the handler for ICE connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_ice_connection_state_change(Box::new(move |connection_state: RTCIceConnectionState| {
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
             println!("Connection State has changed {}", connection_state);
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
             Box::pin(async {})
-        }))
-        .await;
+        },
+    ));
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/offer-answer/answer.rs
+++ b/examples/examples/offer-answer/answer.rs
@@ -37,7 +37,7 @@ async fn signal_candidate(addr: &str, c: &RTCIceCandidate) -> Result<()> {
         "signal_candidate Post candidate to {}",
         format!("http://{}/candidate", addr)
     );*/
-    let payload = c.to_json().await?.candidate;
+    let payload = c.to_json()?.candidate;
     let req = match Request::builder()
         .method(Method::POST)
         .uri(format!("http://{}/candidate", addr))
@@ -280,28 +280,26 @@ async fn main() -> Result<()> {
     let pc = Arc::downgrade(&peer_connection);
     let pending_candidates2 = Arc::clone(&PENDING_CANDIDATES);
     let addr2 = offer_addr.clone();
-    peer_connection
-        .on_ice_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-            //println!("on_ice_candidate {:?}", c);
+    peer_connection.on_ice_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
+        //println!("on_ice_candidate {:?}", c);
 
-            let pc2 = pc.clone();
-            let pending_candidates3 = Arc::clone(&pending_candidates2);
-            let addr3 = addr2.clone();
-            Box::pin(async move {
-                if let Some(c) = c {
-                    if let Some(pc) = pc2.upgrade() {
-                        let desc = pc.remote_description().await;
-                        if desc.is_none() {
-                            let mut cs = pending_candidates3.lock().await;
-                            cs.push(c);
-                        } else if let Err(err) = signal_candidate(&addr3, &c).await {
-                            assert!(false, "{}", err);
-                        }
+        let pc2 = pc.clone();
+        let pending_candidates3 = Arc::clone(&pending_candidates2);
+        let addr3 = addr2.clone();
+        Box::pin(async move {
+            if let Some(c) = c {
+                if let Some(pc) = pc2.upgrade() {
+                    let desc = pc.remote_description().await;
+                    if desc.is_none() {
+                        let mut cs = pending_candidates3.lock().await;
+                        cs.push(c);
+                    } else if let Err(err) = signal_candidate(&addr3, &c).await {
+                        assert!(false, "{}", err);
                     }
                 }
-            })
-        }))
-        .await;
+            }
+        })
+    }));
 
     println!("Listening on http://{}", answer_addr);
     {
@@ -324,21 +322,19 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Register data channel creation handling
     peer_connection.on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
@@ -368,16 +364,16 @@ async fn main() -> Result<()> {
                         };
                     }
                 })
-            })).await;
+            }));
 
             // Register text message handling
             d.on_message(Box::new(move |msg: DataChannelMessage| {
                let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
                println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
                Box::pin(async{})
-           })).await;
+           }));
         })
-    })).await;
+    }));
 
     println!("Press ctrl-c to stop");
     tokio::select! {

--- a/examples/examples/ortc/ortc.rs
+++ b/examples/examples/ortc/ortc.rs
@@ -122,30 +122,25 @@ async fn main() -> Result<()> {
 
                     println!("exit data answer");
                 })
-            }))
-            .await;
+            }));
 
             // Register text message handling
             d.on_message(Box::new(move |msg: DataChannelMessage| {
                 let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
                 println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
                 Box::pin(async {})
-            }))
-            .await;
+            }));
         })
-    }))
-    .await;
+    }));
 
     let (gather_finished_tx, mut gather_finished_rx) = tokio::sync::mpsc::channel::<()>(1);
     let mut gather_finished_tx = Some(gather_finished_tx);
-    gatherer
-        .on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-            if c.is_none() {
-                gather_finished_tx.take();
-            }
-            Box::pin(async {})
-        }))
-        .await;
+    gatherer.on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
+        if c.is_none() {
+            gather_finished_tx.take();
+        }
+        Box::pin(async {})
+    }));
 
     // Gather candidates
     gatherer.gather().await?;
@@ -229,8 +224,7 @@ async fn main() -> Result<()> {
             let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
             println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
             Box::pin(async {})
-        }))
-        .await;
+        }));
     }
 
     println!("Press ctrl-c to stop");

--- a/examples/examples/play-from-disk-h264/play-from-disk-h264.rs
+++ b/examples/examples/play-from-disk-h264/play-from-disk-h264.rs
@@ -288,33 +288,31 @@ async fn main() -> Result<()> {
 
     // Set the handler for ICE connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_ice_connection_state_change(Box::new(move |connection_state: RTCIceConnectionState| {
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
             println!("Connection State has changed {}", connection_state);
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
             Box::pin(async {})
-        }))
-        .await;
+        },
+    ));
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
+++ b/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
@@ -323,21 +323,19 @@ async fn main() -> Result<()> {
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     {
         let mut pcm = PEER_CONNECTION_MUTEX.lock().await;

--- a/examples/examples/play-from-disk-vpx/play-from-disk-vpx.rs
+++ b/examples/examples/play-from-disk-vpx/play-from-disk-vpx.rs
@@ -299,33 +299,31 @@ async fn main() -> Result<()> {
 
     // Set the handler for ICE connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_ice_connection_state_change(Box::new(move |connection_state: RTCIceConnectionState| {
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
             println!("Connection State has changed {}", connection_state);
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
             Box::pin(async {})
-        }))
-        .await;
+        },
+    ));
 
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting");
-                let _ = done_tx.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/rtp-to-webrtc/rtp-to-webrtc.rs
+++ b/examples/examples/rtp-to-webrtc/rtp-to-webrtc.rs
@@ -125,34 +125,32 @@ async fn main() -> Result<()> {
     let done_tx1 = done_tx.clone();
     // Set the handler for ICE connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_ice_connection_state_change(Box::new(move |connection_state: RTCIceConnectionState| {
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
             println!("Connection State has changed {}", connection_state);
             if connection_state == RTCIceConnectionState::Failed {
                 let _ = done_tx1.try_send(());
             }
             Box::pin(async {})
-        }))
-        .await;
+        },
+    ));
 
     let done_tx2 = done_tx.clone();
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-            println!("Peer Connection State has changed: {}", s);
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
 
-            if s == RTCPeerConnectionState::Failed {
-                // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
-                // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
-                // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
-                println!("Peer Connection has gone to failed exiting: Done forwarding");
-                let _ = done_tx2.try_send(());
-            }
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting: Done forwarding");
+            let _ = done_tx2.try_send(());
+        }
 
-            Box::pin(async {})
-        }))
-        .await;
+        Box::pin(async {})
+    }));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/examples/examples/save-to-disk-h264/save-to-disk-h264.rs
+++ b/examples/examples/save-to-disk-h264/save-to-disk-h264.rs
@@ -205,61 +205,65 @@ async fn main() -> Result<()> {
     // an ivf file, since we could have multiple video tracks we provide a counter.
     // In your application this is where you would handle/process video
     let pc = Arc::downgrade(&peer_connection);
-    peer_connection.on_track(Box::new(move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
-        if let Some(track) = track {
-            // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
-            let media_ssrc = track.ssrc();
-            let pc2 = pc.clone();
-            tokio::spawn(async move {
-                let mut result = Result::<usize>::Ok(0);
-                while result.is_ok() {
-                    let timeout = tokio::time::sleep(Duration::from_secs(3));
-                    tokio::pin!(timeout);
+    peer_connection.on_track(Box::new(
+        move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
+            if let Some(track) = track {
+                // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+                let media_ssrc = track.ssrc();
+                let pc2 = pc.clone();
+                tokio::spawn(async move {
+                    let mut result = Result::<usize>::Ok(0);
+                    while result.is_ok() {
+                        let timeout = tokio::time::sleep(Duration::from_secs(3));
+                        tokio::pin!(timeout);
 
-                    tokio::select! {
-                        _ = timeout.as_mut() =>{
-                            if let Some(pc) = pc2.upgrade(){
-                                result = pc.write_rtcp(&[Box::new(PictureLossIndication{
-                                    sender_ssrc: 0,
-                                    media_ssrc,
-                                })]).await.map_err(Into::into);
-                            }else {
-                                break;
+                        tokio::select! {
+                            _ = timeout.as_mut() =>{
+                                if let Some(pc) = pc2.upgrade(){
+                                    result = pc.write_rtcp(&[Box::new(PictureLossIndication{
+                                        sender_ssrc: 0,
+                                        media_ssrc,
+                                    })]).await.map_err(Into::into);
+                                }else {
+                                    break;
+                                }
                             }
-                        }
-                    };
-                }
-            });
+                        };
+                    }
+                });
 
-            let notify_rx2 = Arc::clone(&notify_rx);
-            let h264_writer2 = Arc::clone(&h264_writer);
-            let ogg_writer2 = Arc::clone(&ogg_writer);
-            Box::pin(async move {
-                let codec = track.codec().await;
-                let mime_type = codec.capability.mime_type.to_lowercase();
-                if mime_type == MIME_TYPE_OPUS.to_lowercase() {
-                    println!("Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)");     
-                    tokio::spawn(async move {
-                        let _ = save_to_disk(ogg_writer2, track, notify_rx2).await;
-                    });
-                } else if mime_type == MIME_TYPE_H264.to_lowercase() {
-                    println!("Got h264 track, saving to disk as output.h264");
-                     tokio::spawn(async move {
-                         let _ = save_to_disk(h264_writer2, track, notify_rx2).await;
-                     });
-                }
-            })
-        }else {
-            Box::pin(async {})
-        }
-	})).await;
+                let notify_rx2 = Arc::clone(&notify_rx);
+                let h264_writer2 = Arc::clone(&h264_writer);
+                let ogg_writer2 = Arc::clone(&ogg_writer);
+                Box::pin(async move {
+                    let codec = track.codec().await;
+                    let mime_type = codec.capability.mime_type.to_lowercase();
+                    if mime_type == MIME_TYPE_OPUS.to_lowercase() {
+                        println!(
+                            "Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)"
+                        );
+                        tokio::spawn(async move {
+                            let _ = save_to_disk(ogg_writer2, track, notify_rx2).await;
+                        });
+                    } else if mime_type == MIME_TYPE_H264.to_lowercase() {
+                        println!("Got h264 track, saving to disk as output.h264");
+                        tokio::spawn(async move {
+                            let _ = save_to_disk(h264_writer2, track, notify_rx2).await;
+                        });
+                    }
+                })
+            } else {
+                Box::pin(async {})
+            }
+        },
+    ));
 
     let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);
 
     // Set the handler for ICE connection state
     // This will notify you when the peer has connected/disconnected
-    peer_connection
-        .on_ice_connection_state_change(Box::new(move |connection_state: RTCIceConnectionState| {
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
             println!("Connection State has changed {}", connection_state);
 
             if connection_state == RTCIceConnectionState::Connected {
@@ -272,8 +276,8 @@ async fn main() -> Result<()> {
                 let _ = done_tx.try_send(());
             }
             Box::pin(async {})
-        }))
-        .await;
+        },
+    ));
 
     // Wait for the offer to be pasted
     let line = signal::must_read_stdin()?;

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Increased minimum support rust version to `1.60.0`.
 
-#### Breaking changes  
+### Breaking changes  
 
 * Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
     - `Agent`:

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -14,8 +14,7 @@
         - `on_selected_candidate_pair_change`;
         - `on_candidate`;
         - `add_remote_candidate`;
-        - `gather_candidates`;
-        - `get_selected_candidate_pair`.
+        - `gather_candidates`.
     - `unmarshal_candidate`;
     - `CandidateHostConfig::new_candidate_host`;
     - `CandidatePeerReflexiveConfig::new_candidate_peer_reflexive`;

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+
+#### Breaking changes  
+
 * Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
     - `Agent`:
         - `get_bytes_received`;

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+* Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
+    - `Agent`:
+        - `get_bytes_received`;
+        - `get_bytes_sent`;
+        - `on_connection_state_change`;
+        - `on_selected_candidate_pair_change`;
+        - `on_candidate`;
+        - `add_remote_candidate`;
+        - `gather_candidates`;
+        - `get_selected_candidate_pair`.
+    - `unmarshal_candidate`;
+    - `CandidateHostConfig::new_candidate_host`;
+    - `CandidatePeerReflexiveConfig::new_candidate_peer_reflexive`;
+    - `CandidateRelayConfig::new_candidate_relay`;
+    - `CandidateServerReflexiveConfig::new_candidate_server_reflexive`;
+    - `Candidate`:  
+        - `addr`;
+        - `set_ip`.
 
 ## v0.8.2
 

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -18,7 +18,7 @@ turn = { version = "0.6.0", path = "../turn" }
 stun = { version = "0.4.3", path = "../stun" }
 mdns = { version = "0.5.0", path = "../mdns", package = "webrtc-mdns" }
 
-arc-swap = "1.5.1"
+arc-swap = "1.5"
 async-trait = "0.1.56"
 crc = "3.0"
 log = "0.4.16"

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -18,6 +18,7 @@ turn = { version = "0.6.0", path = "../turn" }
 stun = { version = "0.4.3", path = "../stun" }
 mdns = { version = "0.5.0", path = "../mdns", package = "webrtc-mdns" }
 
+arc-swap = "1.5.1"
 async-trait = "0.1.56"
 crc = "3.0"
 log = "0.4.16"

--- a/ice/examples/ping_pong.rs
+++ b/ice/examples/ping_pong.rs
@@ -304,7 +304,7 @@ async fn main() -> Result<(), Error> {
             }
         });
 
-        ice_agent.gather_candidates().await?;
+        ice_agent.gather_candidates()?;
         println!("Connecting...");
 
         let (_cancel_tx, cancel_rx) = mpsc::channel(1);

--- a/ice/examples/ping_pong.rs
+++ b/ice/examples/ping_pong.rs
@@ -201,53 +201,49 @@ async fn main() -> Result<(), Error> {
 
         // When we have gathered a new ICE Candidate send it to the remote peer
         let client2 = Arc::clone(&client);
-        ice_agent
-            .on_candidate(Box::new(
-                move |c: Option<Arc<dyn Candidate + Send + Sync>>| {
-                    let client3 = Arc::clone(&client2);
-                    Box::pin(async move {
-                        if let Some(c) = c {
-                            println!("posting remoteCandidate with {}", c.marshal());
+        ice_agent.on_candidate(Box::new(
+            move |c: Option<Arc<dyn Candidate + Send + Sync>>| {
+                let client3 = Arc::clone(&client2);
+                Box::pin(async move {
+                    if let Some(c) = c {
+                        println!("posting remoteCandidate with {}", c.marshal());
 
-                            let req = match Request::builder()
-                                .method(Method::POST)
-                                .uri(format!(
-                                    "http://localhost:{}/remoteCandidate",
-                                    remote_http_port
-                                ))
-                                .body(Body::from(c.marshal()))
-                            {
-                                Ok(req) => req,
-                                Err(err) => {
-                                    println!("{}", err);
-                                    return;
-                                }
-                            };
-                            let resp = match client3.request(req).await {
-                                Ok(resp) => resp,
-                                Err(err) => {
-                                    println!("{}", err);
-                                    return;
-                                }
-                            };
-                            println!("Response from remoteCandidate: {}", resp.status());
-                        }
-                    })
-                },
-            ))
-            .await;
+                        let req = match Request::builder()
+                            .method(Method::POST)
+                            .uri(format!(
+                                "http://localhost:{}/remoteCandidate",
+                                remote_http_port
+                            ))
+                            .body(Body::from(c.marshal()))
+                        {
+                            Ok(req) => req,
+                            Err(err) => {
+                                println!("{}", err);
+                                return;
+                            }
+                        };
+                        let resp = match client3.request(req).await {
+                            Ok(resp) => resp,
+                            Err(err) => {
+                                println!("{}", err);
+                                return;
+                            }
+                        };
+                        println!("Response from remoteCandidate: {}", resp.status());
+                    }
+                })
+            },
+        ));
 
         let (ice_done_tx, mut ice_done_rx) = mpsc::channel::<()>(1);
         // When ICE Connection state has change print to stdout
-        ice_agent
-            .on_connection_state_change(Box::new(move |c: ConnectionState| {
-                println!("ICE Connection State has changed: {}", c);
-                if c == ConnectionState::Failed {
-                    let _ = ice_done_tx.try_send(());
-                }
-                Box::pin(async move {})
-            }))
-            .await;
+        ice_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+            println!("ICE Connection State has changed: {}", c);
+            if c == ConnectionState::Failed {
+                let _ = ice_done_tx.try_send(());
+            }
+            Box::pin(async move {})
+        }));
 
         // Get the local auth details and send to remote peer
         let (local_ufrag, local_pwd) = ice_agent.get_local_user_credentials().await;
@@ -291,10 +287,10 @@ async fn main() -> Result<(), Error> {
                     }
                     result = rx.recv() => {
                         if let Some(s) = result {
-                            if let Ok(c) = unmarshal_candidate(&s).await {
+                            if let Ok(c) = unmarshal_candidate(&s) {
                                 println!("add_remote_candidate: {}", c);
                                 let c: Arc<dyn Candidate + Send + Sync> = Arc::new(c);
-                                let _ = ice_agent2.add_remote_candidate(&c).await;
+                                let _ = ice_agent2.add_remote_candidate(&c);
                             }else{
                                 println!("unmarshal_candidate error!");
                                 break;

--- a/ice/src/agent/agent_gather.rs
+++ b/ice/src/agent/agent_gather.rs
@@ -225,7 +225,7 @@ impl Agent {
             return;
         }
 
-        let ips = local_interfaces(&net, &*interface_filter, &*ip_filter, &network_types).await;
+        let ips = local_interfaces(&net, &interface_filter, &ip_filter, &network_types).await;
         for ip in ips {
             let mut mapped_ip = ip;
 

--- a/ice/src/agent/agent_gather_test.rs
+++ b/ice/src/agent/agent_gather_test.rs
@@ -98,7 +98,7 @@ async fn test_vnet_gather_listen_udp() -> Result<()> {
         );
 
         let conn = listen_udp_in_port_range(&nw, 5000, 5000, SocketAddr::new(ip, 0)).await?;
-        let port = conn.local_addr().await?.port();
+        let port = conn.local_addr()?.port();
         assert_eq!(
             port, 5000,
             "listenUDP with port restriction of 5000 listened on incorrect port ({})",
@@ -164,8 +164,7 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<()> {
                 }
             })
         },
-    ))
-    .await;
+    ));
 
     a.gather_candidates().await?;
 
@@ -179,7 +178,7 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<()> {
     let mut laddrs = vec![];
     for candi in &candidates {
         if let Some(conn) = candi.get_conn() {
-            let laddr = conn.local_addr().await?;
+            let laddr = conn.local_addr()?;
             assert_eq!(
                 candi.port(),
                 laddr.port(),
@@ -282,8 +281,7 @@ async fn test_vnet_gather_with_nat_1to1_as_srflx_candidates() -> Result<()> {
                 }
             })
         },
-    ))
-    .await;
+    ));
 
     a.gather_candidates().await?;
 
@@ -467,8 +465,7 @@ async fn test_vnet_gather_muxed_udp() -> Result<()> {
                 }
             })
         },
-    ))
-    .await;
+    ));
 
     a.gather_candidates().await?;
 
@@ -480,7 +477,7 @@ async fn test_vnet_gather_muxed_udp() -> Result<()> {
     assert_eq!(candidates.len(), 1, "There must be a single candidate");
 
     let candi = &candidates[0];
-    let laddr = candi.get_conn().unwrap().local_addr().await?;
+    let laddr = candi.get_conn().unwrap().local_addr()?;
     assert_eq!(candi.address(), "1.2.3.4");
     assert_eq!(
         candi.port(),

--- a/ice/src/agent/agent_gather_test.rs
+++ b/ice/src/agent/agent_gather_test.rs
@@ -166,7 +166,7 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<()> {
         },
     ));
 
-    a.gather_candidates().await?;
+    a.gather_candidates()?;
 
     log::debug!("wait for gathering is done...");
     let _ = done_rx.recv().await;
@@ -283,7 +283,7 @@ async fn test_vnet_gather_with_nat_1to1_as_srflx_candidates() -> Result<()> {
         },
     ));
 
-    a.gather_candidates().await?;
+    a.gather_candidates()?;
 
     log::debug!("wait for gathering is done...");
     let _ = done_rx.recv().await;
@@ -467,7 +467,7 @@ async fn test_vnet_gather_muxed_udp() -> Result<()> {
         },
     ));
 
-    a.gather_candidates().await?;
+    a.gather_candidates()?;
 
     log::debug!("wait for gathering is done...");
     let _ = done_rx.recv().await;

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -1079,14 +1079,14 @@ impl AgentInternal {
                 tokio::select! {
                     opt_state = chan_state_rx.recv() => {
                         if let Some(s) = opt_state {
-                            if let Some(hndlr) = &*ai.on_connection_state_change_hdlr.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*ai.on_connection_state_change_hdlr.load() {
+                                let mut f = handler.lock().await;
                                 f(s).await;
                             }
                         } else {
                             while let Some(c) = chan_candidate_rx.recv().await {
-                                if let Some(hndlr) = &*ai.on_candidate_hdlr.load() {
-                                    let mut f = hndlr.lock().await;
+                                if let Some(handler) = &*ai.on_candidate_hdlr.load() {
+                                    let mut f = handler.lock().await;
                                     f(c).await;
                                 }
                             }
@@ -1095,14 +1095,14 @@ impl AgentInternal {
                     },
                     opt_cand = chan_candidate_rx.recv() => {
                         if let Some(c) = opt_cand {
-                            if let Some(hndlr) = &*ai.on_candidate_hdlr.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*ai.on_candidate_hdlr.load() {
+                                let mut f = handler.lock().await;
                                 f(c).await;
                             }
                         } else {
                             while let Some(s) = chan_state_rx.recv().await {
-                                if let Some(hndlr) = &*ai.on_connection_state_change_hdlr.load() {
-                                    let mut f = hndlr.lock().await;
+                                if let Some(handler) = &*ai.on_connection_state_change_hdlr.load() {
+                                    let mut f = handler.lock().await;
                                     f(s).await;
                                 }
                             }

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -3,12 +3,9 @@ use super::*;
 use crate::candidate::candidate_base::CandidateBaseConfig;
 use crate::candidate::candidate_peer_reflexive::CandidatePeerReflexiveConfig;
 use crate::util::*;
-use std::sync::{
-    atomic::{AtomicBool, AtomicU64},
-    Mutex as StdMutex,
-};
-
 use arc_swap::ArcSwapOption;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use util::sync::Mutex as SyncMutex;
 
 pub type ChanCandidateTx =
     Arc<Mutex<Option<mpsc::Sender<Option<Arc<dyn Candidate + Send + Sync>>>>>>;
@@ -46,7 +43,7 @@ pub struct AgentInternal {
     pub(crate) is_controlling: AtomicBool,
     pub(crate) lite: AtomicBool,
 
-    pub(crate) start_time: StdMutex<Instant>,
+    pub(crate) start_time: SyncMutex<Instant>,
     pub(crate) nominated_pair: Mutex<Option<Arc<CandidatePair>>>,
 
     pub(crate) connection_state: AtomicU8, //ConnectionState,
@@ -117,7 +114,7 @@ impl AgentInternal {
             is_controlling: AtomicBool::new(config.is_controlling),
             lite: AtomicBool::new(config.lite),
 
-            start_time: StdMutex::new(Instant::now()),
+            start_time: SyncMutex::new(Instant::now()),
             nominated_pair: Mutex::new(None),
 
             connection_state: AtomicU8::new(ConnectionState::New as u8),

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -3,7 +3,12 @@ use super::*;
 use crate::candidate::candidate_base::CandidateBaseConfig;
 use crate::candidate::candidate_peer_reflexive::CandidatePeerReflexiveConfig;
 use crate::util::*;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64},
+    Mutex as StdMutex,
+};
+
+use arc_swap::ArcSwapOption;
 
 pub type ChanCandidateTx =
     Arc<Mutex<Option<mpsc::Sender<Option<Arc<dyn Candidate + Send + Sync>>>>>>;
@@ -32,16 +37,16 @@ pub struct AgentInternal {
     pub(crate) chan_candidate_pair_tx: Mutex<Option<mpsc::Sender<()>>>,
     pub(crate) chan_state_tx: Mutex<Option<mpsc::Sender<ConnectionState>>>,
 
-    pub(crate) on_connection_state_change_hdlr: Mutex<Option<OnConnectionStateChangeHdlrFn>>,
+    pub(crate) on_connection_state_change_hdlr: ArcSwapOption<Mutex<OnConnectionStateChangeHdlrFn>>,
     pub(crate) on_selected_candidate_pair_change_hdlr:
-        Mutex<Option<OnSelectedCandidatePairChangeHdlrFn>>,
-    pub(crate) on_candidate_hdlr: Mutex<Option<OnCandidateHdlrFn>>,
+        ArcSwapOption<Mutex<OnSelectedCandidatePairChangeHdlrFn>>,
+    pub(crate) on_candidate_hdlr: ArcSwapOption<Mutex<OnCandidateHdlrFn>>,
 
     pub(crate) tie_breaker: AtomicU64,
     pub(crate) is_controlling: AtomicBool,
     pub(crate) lite: AtomicBool,
 
-    pub(crate) start_time: Mutex<Instant>,
+    pub(crate) start_time: StdMutex<Instant>,
     pub(crate) nominated_pair: Mutex<Option<Arc<CandidatePair>>>,
 
     pub(crate) connection_state: AtomicU8, //ConnectionState,
@@ -104,15 +109,15 @@ impl AgentInternal {
             chan_candidate_pair_tx: Mutex::new(Some(chan_candidate_pair_tx)),
             chan_state_tx: Mutex::new(Some(chan_state_tx)),
 
-            on_connection_state_change_hdlr: Mutex::new(None),
-            on_selected_candidate_pair_change_hdlr: Mutex::new(None),
-            on_candidate_hdlr: Mutex::new(None),
+            on_connection_state_change_hdlr: ArcSwapOption::empty(),
+            on_selected_candidate_pair_change_hdlr: ArcSwapOption::empty(),
+            on_candidate_hdlr: ArcSwapOption::empty(),
 
             tie_breaker: AtomicU64::new(rand::random::<u64>()),
             is_controlling: AtomicBool::new(config.is_controlling),
             lite: AtomicBool::new(config.lite),
 
-            start_time: Mutex::new(Instant::now()),
+            start_time: StdMutex::new(Instant::now()),
             nominated_pair: Mutex::new(None),
 
             connection_state: AtomicU8::new(ConnectionState::New as u8),
@@ -333,10 +338,7 @@ impl AgentInternal {
 
         if let Some(p) = p {
             p.nominated.store(true, Ordering::SeqCst);
-            {
-                let mut selected_pair = self.agent_conn.selected_pair.lock().await;
-                *selected_pair = Some(p);
-            }
+            self.agent_conn.selected_pair.store(Some(p));
 
             self.update_connection_state(ConnectionState::Connected)
                 .await;
@@ -355,8 +357,7 @@ impl AgentInternal {
                 on_connected_tx.take();
             }
         } else {
-            let mut selected_pair = self.agent_conn.selected_pair.lock().await;
-            *selected_pair = None;
+            self.agent_conn.selected_pair.store(None);
         }
     }
 
@@ -439,7 +440,7 @@ impl AgentInternal {
     /// Note: the caller should hold the agent lock.
     pub(crate) async fn validate_selected_pair(&self) -> bool {
         let (valid, disconnected_time) = {
-            let selected_pair = self.agent_conn.selected_pair.lock().await;
+            let selected_pair = self.agent_conn.selected_pair.load();
             (*selected_pair).as_ref().map_or_else(
                 || (false, Duration::from_secs(0)),
                 |selected_pair| {
@@ -481,7 +482,7 @@ impl AgentInternal {
     /// Note: the caller should hold the agent lock.
     pub(crate) async fn check_keepalive(&self) {
         let (local, remote) = {
-            let selected_pair = self.agent_conn.selected_pair.lock().await;
+            let selected_pair = self.agent_conn.selected_pair.load();
             (*selected_pair)
                 .as_ref()
                 .map_or((None, None), |selected_pair| {
@@ -726,7 +727,7 @@ impl AgentInternal {
             pending_binding_requests.push(BindingRequest {
                 timestamp: Instant::now(),
                 transaction_id: m.transaction_id,
-                destination: remote.addr().await,
+                destination: remote.addr(),
                 is_use_candidate: m.contains(ATTR_USE_CANDIDATE),
             });
         }
@@ -740,7 +741,7 @@ impl AgentInternal {
         local: &Arc<dyn Candidate + Send + Sync>,
         remote: &Arc<dyn Candidate + Send + Sync>,
     ) {
-        let addr = remote.addr().await;
+        let addr = remote.addr();
         let (ip, port) = (addr.ip(), addr.port());
         let local_pwd = {
             let ufrag_pwd = self.ufrag_pwd.lock().await;
@@ -936,7 +937,7 @@ impl AgentInternal {
                     rel_port: 0,
                 };
 
-                match prflx_candidate_config.new_candidate_peer_reflexive().await {
+                match prflx_candidate_config.new_candidate_peer_reflexive() {
                     Ok(prflx_candidate) => remote_candidate = Some(Arc::new(prflx_candidate)),
                     Err(err) => {
                         log::error!(
@@ -1039,7 +1040,7 @@ impl AgentInternal {
         let cand = Arc::clone(candidate);
         if let Some(conn) = candidate.get_conn() {
             let conn = Arc::clone(conn);
-            let addr = candidate.addr().await;
+            let addr = candidate.addr();
             let ai = Arc::clone(self);
             tokio::spawn(async move {
                 let _ = ai
@@ -1051,7 +1052,7 @@ impl AgentInternal {
         }
     }
 
-    pub(super) async fn start_on_connection_state_change_routine(
+    pub(super) fn start_on_connection_state_change_routine(
         self: &Arc<Self>,
         mut chan_state_rx: mpsc::Receiver<ConnectionState>,
         mut chan_candidate_rx: mpsc::Receiver<Option<Arc<dyn Candidate + Send + Sync>>>,
@@ -1062,19 +1063,12 @@ impl AgentInternal {
             // CandidatePair and ConnectionState are usually changed at once.
             // Blocking one by the other one causes deadlock.
             while chan_candidate_pair_rx.recv().await.is_some() {
-                let selected_pair = {
-                    let selected_pair = ai.agent_conn.selected_pair.lock().await;
-                    selected_pair.clone()
-                };
-
-                {
-                    let mut on_selected_candidate_pair_change_hdlr =
-                        ai.on_selected_candidate_pair_change_hdlr.lock().await;
-                    if let (Some(f), Some(p)) =
-                        (&mut *on_selected_candidate_pair_change_hdlr, &selected_pair)
-                    {
-                        f(&p.local, &p.remote).await;
-                    }
+                if let (Some(cb), Some(p)) = (
+                    &*ai.on_selected_candidate_pair_change_hdlr.load(),
+                    &*ai.agent_conn.selected_pair.load(),
+                ) {
+                    let mut f = cb.lock().await;
+                    f(&p.local, &p.remote).await;
                 }
             }
         });
@@ -1085,14 +1079,14 @@ impl AgentInternal {
                 tokio::select! {
                     opt_state = chan_state_rx.recv() => {
                         if let Some(s) = opt_state {
-                            let mut on_connection_state_change_hdlr = ai.on_connection_state_change_hdlr.lock().await;
-                            if let Some(f) = &mut *on_connection_state_change_hdlr{
+                            if let Some(hndlr) = &*ai.on_connection_state_change_hdlr.load() {
+                                let mut f = hndlr.lock().await;
                                 f(s).await;
                             }
                         } else {
                             while let Some(c) = chan_candidate_rx.recv().await {
-                                let mut on_candidate_hdlr = ai.on_candidate_hdlr.lock().await;
-                                if let Some(f) = &mut *on_candidate_hdlr {
+                                if let Some(hndlr) = &*ai.on_candidate_hdlr.load() {
+                                    let mut f = hndlr.lock().await;
                                     f(c).await;
                                 }
                             }
@@ -1101,14 +1095,14 @@ impl AgentInternal {
                     },
                     opt_cand = chan_candidate_rx.recv() => {
                         if let Some(c) = opt_cand {
-                            let mut on_candidate_hdlr = ai.on_candidate_hdlr.lock().await;
-                            if let Some(f) = &mut *on_candidate_hdlr{
+                            if let Some(hndlr) = &*ai.on_candidate_hdlr.load() {
+                                let mut f = hndlr.lock().await;
                                 f(c).await;
                             }
                         } else {
                             while let Some(s) = chan_state_rx.recv().await {
-                                let mut on_connection_state_change_hdlr = ai.on_connection_state_change_hdlr.lock().await;
-                                if let Some(f) = &mut *on_connection_state_change_hdlr{
+                                if let Some(hndlr) = &*ai.on_connection_state_change_hdlr.load() {
+                                    let mut f = hndlr.lock().await;
                                     f(s).await;
                                 }
                             }

--- a/ice/src/agent/agent_selector.rs
+++ b/ice/src/agent/agent_selector.rs
@@ -61,33 +61,33 @@ trait ControlledSelector {
 }
 
 impl AgentInternal {
-    async fn is_nominatable(&self, c: &Arc<dyn Candidate + Send + Sync>) -> bool {
-        let start_time = self.start_time.lock().await;
+    fn is_nominatable(&self, c: &Arc<dyn Candidate + Send + Sync>) -> bool {
+        let start_time = { *self.start_time.lock().unwrap() };
         match c.candidate_type() {
             CandidateType::Host => {
                 Instant::now()
-                    .checked_duration_since(*start_time)
+                    .checked_duration_since(start_time)
                     .unwrap_or_else(|| Duration::from_secs(0))
                     .as_nanos()
                     > self.host_acceptance_min_wait.as_nanos()
             }
             CandidateType::ServerReflexive => {
                 Instant::now()
-                    .checked_duration_since(*start_time)
+                    .checked_duration_since(start_time)
                     .unwrap_or_else(|| Duration::from_secs(0))
                     .as_nanos()
                     > self.srflx_acceptance_min_wait.as_nanos()
             }
             CandidateType::PeerReflexive => {
                 Instant::now()
-                    .checked_duration_since(*start_time)
+                    .checked_duration_since(start_time)
                     .unwrap_or_else(|| Duration::from_secs(0))
                     .as_nanos()
                     > self.prflx_acceptance_min_wait.as_nanos()
             }
             CandidateType::Relay => {
                 Instant::now()
-                    .checked_duration_since(*start_time)
+                    .checked_duration_since(start_time)
                     .unwrap_or_else(|| Duration::from_secs(0))
                     .as_nanos()
                     > self.relay_acceptance_min_wait.as_nanos()
@@ -218,8 +218,7 @@ impl ControllingSelector for AgentInternal {
             *nominated_pair = None;
         }
         {
-            let mut start_time = self.start_time.lock().await;
-            *start_time = Instant::now();
+            *self.start_time.lock().unwrap() = Instant::now();
         }
     }
 
@@ -235,7 +234,7 @@ impl ControllingSelector for AgentInternal {
             nominated_pair.is_some()
         };
 
-        if self.agent_conn.get_selected_pair().await.is_some() {
+        if self.agent_conn.get_selected_pair().is_some() {
             if self.validate_selected_pair().await {
                 log::trace!("[{}]: checking keepalive", self.get_name());
                 self.check_keepalive().await;
@@ -245,7 +244,7 @@ impl ControllingSelector for AgentInternal {
         } else {
             let has_nominated_pair =
                 if let Some(p) = self.agent_conn.get_best_valid_candidate_pair().await {
-                    self.is_nominatable(&p.local).await && self.is_nominatable(&p.remote).await
+                    self.is_nominatable(&p.local) && self.is_nominatable(&p.remote)
                 } else {
                     false
                 };
@@ -323,7 +322,7 @@ impl ControllingSelector for AgentInternal {
                 remote,
                 local
             );
-            let selected_pair_is_none = self.agent_conn.get_selected_pair().await.is_none();
+            let selected_pair_is_none = self.agent_conn.get_selected_pair().is_none();
 
             if let Some(p) = self.find_pair(local, remote).await {
                 p.state
@@ -375,7 +374,7 @@ impl ControllingSelector for AgentInternal {
             );
             if p.state.load(Ordering::SeqCst) == CandidatePairState::Succeeded as u8
                 && nominated_pair_is_none
-                && self.agent_conn.get_selected_pair().await.is_none()
+                && self.agent_conn.get_selected_pair().is_none()
             {
                 if let Some(best_pair) = self.agent_conn.get_best_available_candidate_pair().await {
                     log::trace!(
@@ -383,8 +382,8 @@ impl ControllingSelector for AgentInternal {
                         best_pair
                     );
                     if best_pair == p
-                        && self.is_nominatable(&p.local).await
-                        && self.is_nominatable(&p.remote).await
+                        && self.is_nominatable(&p.local)
+                        && self.is_nominatable(&p.remote)
                     {
                         log::trace!("The candidate ({}, {}) is the best candidate available, marking it as nominated",
                             p.local, p.remote);
@@ -413,7 +412,7 @@ impl ControlledSelector for AgentInternal {
         // A lite selector should not contact candidates
         if self.lite.load(Ordering::SeqCst) {
             self.validate_selected_pair().await;
-        } else if self.agent_conn.get_selected_pair().await.is_some() {
+        } else if self.agent_conn.get_selected_pair().is_some() {
             if self.validate_selected_pair().await {
                 log::trace!("[{}]: checking keepalive", self.get_name());
                 self.check_keepalive().await;
@@ -519,7 +518,7 @@ impl ControlledSelector for AgentInternal {
                     // previously sent by this pair produced a successful response and
                     // generated a valid pair (Section 7.2.5.3.2).  The agent sets the
                     // nominated flag value of the valid pair to true.
-                    if self.agent_conn.get_selected_pair().await.is_none() {
+                    if self.agent_conn.get_selected_pair().is_none() {
                         self.set_selected_pair(Some(Arc::clone(&p))).await;
                     }
                     self.send_binding_success(m, local, remote).await;

--- a/ice/src/agent/agent_selector.rs
+++ b/ice/src/agent/agent_selector.rs
@@ -62,7 +62,7 @@ trait ControlledSelector {
 
 impl AgentInternal {
     fn is_nominatable(&self, c: &Arc<dyn Candidate + Send + Sync>) -> bool {
-        let start_time = { *self.start_time.lock() };
+        let start_time = *self.start_time.lock();
         match c.candidate_type() {
             CandidateType::Host => {
                 Instant::now()
@@ -217,9 +217,7 @@ impl ControllingSelector for AgentInternal {
             let mut nominated_pair = self.nominated_pair.lock().await;
             *nominated_pair = None;
         }
-        {
-            *self.start_time.lock() = Instant::now();
-        }
+        *self.start_time.lock() = Instant::now();
     }
 
     async fn contact_candidates(&self) {

--- a/ice/src/agent/agent_selector.rs
+++ b/ice/src/agent/agent_selector.rs
@@ -62,7 +62,13 @@ trait ControlledSelector {
 
 impl AgentInternal {
     fn is_nominatable(&self, c: &Arc<dyn Candidate + Send + Sync>) -> bool {
-        let start_time = { *self.start_time.lock().unwrap() };
+        let start_time = {
+            // Won't panic since we only do set/get one-liners.
+            *self
+                .start_time
+                .lock()
+                .expect("AgentInternal::start_time is poisoned")
+        };
         match c.candidate_type() {
             CandidateType::Host => {
                 Instant::now()
@@ -218,7 +224,11 @@ impl ControllingSelector for AgentInternal {
             *nominated_pair = None;
         }
         {
-            *self.start_time.lock().unwrap() = Instant::now();
+            // Won't panic since we only do set/get one-liners.
+            *self
+                .start_time
+                .lock()
+                .expect("AgentInternal::start_time is poisoned") = Instant::now();
         }
     }
 

--- a/ice/src/agent/agent_selector.rs
+++ b/ice/src/agent/agent_selector.rs
@@ -62,13 +62,7 @@ trait ControlledSelector {
 
 impl AgentInternal {
     fn is_nominatable(&self, c: &Arc<dyn Candidate + Send + Sync>) -> bool {
-        let start_time = {
-            // Won't panic since we only do set/get one-liners.
-            *self
-                .start_time
-                .lock()
-                .expect("AgentInternal::start_time is poisoned")
-        };
+        let start_time = { *self.start_time.lock() };
         match c.candidate_type() {
             CandidateType::Host => {
                 Instant::now()
@@ -224,11 +218,7 @@ impl ControllingSelector for AgentInternal {
             *nominated_pair = None;
         }
         {
-            // Won't panic since we only do set/get one-liners.
-            *self
-                .start_time
-                .lock()
-                .expect("AgentInternal::start_time is poisoned") = Instant::now();
+            *self.start_time.lock() = Instant::now();
         }
     }
 

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -59,8 +59,7 @@ async fn test_pair_priority() -> Result<()> {
         },
         ..Default::default()
     };
-    let host_local: Arc<dyn Candidate + Send + Sync> =
-        Arc::new(host_config.new_candidate_host().await?);
+    let host_local: Arc<dyn Candidate + Send + Sync> = Arc::new(host_config.new_candidate_host()?);
 
     let relay_config = CandidateRelayConfig {
         base_config: CandidateBaseConfig {
@@ -75,7 +74,7 @@ async fn test_pair_priority() -> Result<()> {
         ..Default::default()
     };
 
-    let relay_remote = relay_config.new_candidate_relay().await?;
+    let relay_remote = relay_config.new_candidate_relay()?;
 
     let srflx_config = CandidateServerReflexiveConfig {
         base_config: CandidateBaseConfig {
@@ -89,7 +88,7 @@ async fn test_pair_priority() -> Result<()> {
         rel_port: 43212,
     };
 
-    let srflx_remote = srflx_config.new_candidate_server_reflexive().await?;
+    let srflx_remote = srflx_config.new_candidate_server_reflexive()?;
 
     let prflx_config = CandidatePeerReflexiveConfig {
         base_config: CandidateBaseConfig {
@@ -103,7 +102,7 @@ async fn test_pair_priority() -> Result<()> {
         rel_port: 43211,
     };
 
-    let prflx_remote = prflx_config.new_candidate_peer_reflexive().await?;
+    let prflx_remote = prflx_config.new_candidate_peer_reflexive()?;
 
     let host_config = CandidateHostConfig {
         base_config: CandidateBaseConfig {
@@ -115,7 +114,7 @@ async fn test_pair_priority() -> Result<()> {
         },
         ..Default::default()
     };
-    let host_remote = host_config.new_candidate_host().await?;
+    let host_remote = host_config.new_candidate_host()?;
 
     let remotes: Vec<Arc<dyn Candidate + Send + Sync>> = vec![
         Arc::new(relay_remote),
@@ -168,20 +167,20 @@ async fn test_pair_priority() -> Result<()> {
 #[tokio::test]
 async fn test_agent_get_stats() -> Result<()> {
     let (conn_a, conn_b, agent_a, agent_b) = pipe(None, None).await?;
-    assert_eq!(agent_a.get_bytes_received().await, 0);
-    assert_eq!(agent_a.get_bytes_sent().await, 0);
-    assert_eq!(agent_b.get_bytes_received().await, 0);
-    assert_eq!(agent_b.get_bytes_sent().await, 0);
+    assert_eq!(agent_a.get_bytes_received(), 0);
+    assert_eq!(agent_a.get_bytes_sent(), 0);
+    assert_eq!(agent_b.get_bytes_received(), 0);
+    assert_eq!(agent_b.get_bytes_sent(), 0);
 
     let _na = conn_a.send(&[0u8; 10]).await?;
     let mut buf = vec![0u8; 10];
     let _nb = conn_b.recv(&mut buf).await?;
 
-    assert_eq!(agent_a.get_bytes_received().await, 0);
-    assert_eq!(agent_a.get_bytes_sent().await, 10);
+    assert_eq!(agent_a.get_bytes_received(), 0);
+    assert_eq!(agent_a.get_bytes_sent(), 10);
 
-    assert_eq!(agent_b.get_bytes_received().await, 10);
-    assert_eq!(agent_b.get_bytes_sent().await, 0);
+    assert_eq!(agent_b.get_bytes_received(), 10);
+    assert_eq!(agent_b.get_bytes_sent(), 0);
 
     Ok(())
 }
@@ -198,7 +197,7 @@ async fn test_on_selected_candidate_pair_change() -> Result<()> {
             tx.take();
         })
     });
-    a.on_selected_candidate_pair_change(cb).await;
+    a.on_selected_candidate_pair_change(cb);
 
     let host_config = CandidateHostConfig {
         base_config: CandidateBaseConfig {
@@ -210,7 +209,7 @@ async fn test_on_selected_candidate_pair_change() -> Result<()> {
         },
         ..Default::default()
     };
-    let host_local = host_config.new_candidate_host().await?;
+    let host_local = host_config.new_candidate_host()?;
 
     let relay_config = CandidateRelayConfig {
         base_config: CandidateBaseConfig {
@@ -224,7 +223,7 @@ async fn test_on_selected_candidate_pair_change() -> Result<()> {
         rel_port: 43210,
         ..Default::default()
     };
-    let relay_remote = relay_config.new_candidate_relay().await?;
+    let relay_remote = relay_config.new_candidate_relay()?;
 
     // select the pair
     let p = Arc::new(CandidatePair::new(
@@ -257,7 +256,7 @@ async fn test_handle_peer_reflexive_udp_pflx_candidate() -> Result<()> {
         ..Default::default()
     };
 
-    let local: Arc<dyn Candidate + Send + Sync> = Arc::new(host_config.new_candidate_host().await?);
+    let local: Arc<dyn Candidate + Send + Sync> = Arc::new(host_config.new_candidate_host()?);
     let remote = SocketAddr::from_str("172.17.0.3:999")?;
 
     let (username, local_pwd, tie_breaker) = {
@@ -356,7 +355,7 @@ async fn test_handle_peer_reflexive_unknown_remote() -> Result<()> {
         ..Default::default()
     };
 
-    let local: Arc<dyn Candidate + Send + Sync> = Arc::new(host_config.new_candidate_host().await?);
+    let local: Arc<dyn Candidate + Send + Sync> = Arc::new(host_config.new_candidate_host()?);
     let remote = SocketAddr::from_str("172.17.0.3:999")?;
 
     let mut msg = Message::new();
@@ -437,7 +436,7 @@ async fn test_connectivity_on_startup() -> Result<()> {
     };
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         network_types: supported_network_types(),
@@ -450,7 +449,7 @@ async fn test_connectivity_on_startup() -> Result<()> {
     };
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     // Manual signaling
     let (a_ufrag, a_pwd) = a_agent.get_local_user_credentials().await;
@@ -464,17 +463,15 @@ async fn test_connectivity_on_startup() -> Result<()> {
     let (_b_cancel_tx, b_cancel_rx) = mpsc::channel(1);
 
     let accepting_tx = Arc::new(Mutex::new(Some(accepting_tx)));
-    a_agent
-        .on_connection_state_change(Box::new(move |s: ConnectionState| {
-            let accepted_tx_clone = Arc::clone(&accepting_tx);
-            Box::pin(async move {
-                if s == ConnectionState::Checking {
-                    let mut tx = accepted_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |s: ConnectionState| {
+        let accepted_tx_clone = Arc::clone(&accepting_tx);
+        Box::pin(async move {
+            if s == ConnectionState::Checking {
+                let mut tx = accepted_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     tokio::spawn(async move {
         let result = a_agent.accept(a_cancel_rx, b_ufrag, b_pwd).await;
@@ -547,7 +544,7 @@ async fn test_connectivity_lite() -> Result<()> {
     };
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         urls: vec![],
@@ -560,7 +557,7 @@ async fn test_connectivity_lite() -> Result<()> {
     };
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     let _ = connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -605,11 +602,11 @@ impl Conn for MockPacketConn {
         Ok(0)
     }
 
-    async fn local_addr(&self) -> std::result::Result<SocketAddr, util::Error> {
+    fn local_addr(&self) -> std::result::Result<SocketAddr, util::Error> {
         Ok(SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0))
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 
@@ -660,8 +657,7 @@ async fn test_inbound_validity() -> Result<()> {
             },
             ..Default::default()
         }
-        .new_candidate_host()
-        .await?,
+        .new_candidate_host()?,
     );
 
     //"Invalid Binding requests should be discarded"
@@ -972,45 +968,43 @@ async fn test_connection_state_callback() -> Result<()> {
     let is_failed_tx = Arc::new(Mutex::new(Some(is_failed_tx)));
     let is_closed_tx = Arc::new(Mutex::new(Some(is_closed_tx)));
 
-    a_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let is_checking_tx_clone = Arc::clone(&is_checking_tx);
-            let is_connected_tx_clone = Arc::clone(&is_connected_tx);
-            let is_disconnected_tx_clone = Arc::clone(&is_disconnected_tx);
-            let is_failed_tx_clone = Arc::clone(&is_failed_tx);
-            let is_closed_tx_clone = Arc::clone(&is_closed_tx);
-            Box::pin(async move {
-                match c {
-                    ConnectionState::Checking => {
-                        log::debug!("drop is_checking_tx");
-                        let mut tx = is_checking_tx_clone.lock().await;
-                        tx.take();
-                    }
-                    ConnectionState::Connected => {
-                        log::debug!("drop is_connected_tx");
-                        let mut tx = is_connected_tx_clone.lock().await;
-                        tx.take();
-                    }
-                    ConnectionState::Disconnected => {
-                        log::debug!("drop is_disconnected_tx");
-                        let mut tx = is_disconnected_tx_clone.lock().await;
-                        tx.take();
-                    }
-                    ConnectionState::Failed => {
-                        log::debug!("drop is_failed_tx");
-                        let mut tx = is_failed_tx_clone.lock().await;
-                        tx.take();
-                    }
-                    ConnectionState::Closed => {
-                        log::debug!("drop is_closed_tx");
-                        let mut tx = is_closed_tx_clone.lock().await;
-                        tx.take();
-                    }
-                    _ => {}
-                };
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let is_checking_tx_clone = Arc::clone(&is_checking_tx);
+        let is_connected_tx_clone = Arc::clone(&is_connected_tx);
+        let is_disconnected_tx_clone = Arc::clone(&is_disconnected_tx);
+        let is_failed_tx_clone = Arc::clone(&is_failed_tx);
+        let is_closed_tx_clone = Arc::clone(&is_closed_tx);
+        Box::pin(async move {
+            match c {
+                ConnectionState::Checking => {
+                    log::debug!("drop is_checking_tx");
+                    let mut tx = is_checking_tx_clone.lock().await;
+                    tx.take();
+                }
+                ConnectionState::Connected => {
+                    log::debug!("drop is_connected_tx");
+                    let mut tx = is_connected_tx_clone.lock().await;
+                    tx.take();
+                }
+                ConnectionState::Disconnected => {
+                    log::debug!("drop is_disconnected_tx");
+                    let mut tx = is_disconnected_tx_clone.lock().await;
+                    tx.take();
+                }
+                ConnectionState::Failed => {
+                    log::debug!("drop is_failed_tx");
+                    let mut tx = is_failed_tx_clone.lock().await;
+                    tx.take();
+                }
+                ConnectionState::Closed => {
+                    log::debug!("drop is_closed_tx");
+                    let mut tx = is_closed_tx_clone.lock().await;
+                    tx.take();
+                }
+                _ => {}
+            };
+        })
+    }));
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -1065,8 +1059,7 @@ async fn test_candidate_pair_stats() -> Result<()> {
             },
             ..Default::default()
         }
-        .new_candidate_host()
-        .await?,
+        .new_candidate_host()?,
     );
 
     let relay_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1082,8 +1075,7 @@ async fn test_candidate_pair_stats() -> Result<()> {
             rel_port: 43210,
             ..Default::default()
         }
-        .new_candidate_relay()
-        .await?,
+        .new_candidate_relay()?,
     );
 
     let srflx_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1098,8 +1090,7 @@ async fn test_candidate_pair_stats() -> Result<()> {
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
         }
-        .new_candidate_server_reflexive()
-        .await?,
+        .new_candidate_server_reflexive()?,
     );
 
     let prflx_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1114,8 +1105,7 @@ async fn test_candidate_pair_stats() -> Result<()> {
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43211,
         }
-        .new_candidate_peer_reflexive()
-        .await?,
+        .new_candidate_peer_reflexive()?,
     );
 
     let host_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1129,8 +1119,7 @@ async fn test_candidate_pair_stats() -> Result<()> {
             },
             ..Default::default()
         }
-        .new_candidate_host()
-        .await?,
+        .new_candidate_host()?,
     );
 
     for remote in &[
@@ -1232,8 +1221,7 @@ async fn test_local_candidate_stats() -> Result<()> {
             },
             ..Default::default()
         }
-        .new_candidate_host()
-        .await?,
+        .new_candidate_host()?,
     );
 
     let srflx_local: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1248,8 +1236,7 @@ async fn test_local_candidate_stats() -> Result<()> {
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
         }
-        .new_candidate_server_reflexive()
-        .await?,
+        .new_candidate_server_reflexive()?,
     );
 
     {
@@ -1327,8 +1314,7 @@ async fn test_remote_candidate_stats() -> Result<()> {
             rel_port: 43210,
             ..Default::default()
         }
-        .new_candidate_relay()
-        .await?,
+        .new_candidate_relay()?,
     );
 
     let srflx_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1343,8 +1329,7 @@ async fn test_remote_candidate_stats() -> Result<()> {
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
         }
-        .new_candidate_server_reflexive()
-        .await?,
+        .new_candidate_server_reflexive()?,
     );
 
     let prflx_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1359,8 +1344,7 @@ async fn test_remote_candidate_stats() -> Result<()> {
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43211,
         }
-        .new_candidate_peer_reflexive()
-        .await?,
+        .new_candidate_peer_reflexive()?,
     );
 
     let host_remote: Arc<dyn Candidate + Send + Sync> = Arc::new(
@@ -1374,8 +1358,7 @@ async fn test_remote_candidate_stats() -> Result<()> {
             },
             ..Default::default()
         }
-        .new_candidate_host()
-        .await?,
+        .new_candidate_host()?,
     );
 
     {
@@ -1677,17 +1660,15 @@ async fn test_connection_state_failed_delete_all_candidates() -> Result<()> {
 
     let (is_failed_tx, mut is_failed_rx) = mpsc::channel::<()>(1);
     let is_failed_tx = Arc::new(Mutex::new(Some(is_failed_tx)));
-    a_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let is_failed_tx_clone = Arc::clone(&is_failed_tx);
-            Box::pin(async move {
-                if c == ConnectionState::Failed {
-                    let mut tx = is_failed_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let is_failed_tx_clone = Arc::clone(&is_failed_tx);
+        Box::pin(async move {
+            if c == ConnectionState::Failed {
+                let mut tx = is_failed_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     connect_with_vnet(&a_agent, &b_agent).await?;
     let _ = is_failed_rx.recv().await;
@@ -1756,14 +1737,10 @@ async fn test_connection_state_connecting_to_failed() -> Result<()> {
     };
 
     let (wf1, wc1) = (is_failed.worker(), is_checking.worker());
-    a_agent
-        .on_connection_state_change(connection_state_check(wf1, wc1))
-        .await;
+    a_agent.on_connection_state_change(connection_state_check(wf1, wc1));
 
     let (wf2, wc2) = (is_failed.worker(), is_checking.worker());
-    b_agent
-        .on_connection_state_change(connection_state_check(wf2, wc2))
-        .await;
+    b_agent.on_connection_state_change(connection_state_check(wf2, wc2));
 
     let agent_a = Arc::clone(&a_agent);
     tokio::spawn(async move {
@@ -1850,17 +1827,15 @@ async fn test_agent_restart_one_side() -> Result<()> {
 
     let (cancel_tx, mut cancel_rx) = mpsc::channel::<()>(1);
     let cancel_tx = Arc::new(Mutex::new(Some(cancel_tx)));
-    agent_b
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let cancel_tx_clone = Arc::clone(&cancel_tx);
-            Box::pin(async move {
-                if c == ConnectionState::Failed || c == ConnectionState::Disconnected {
-                    let mut tx = cancel_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    agent_b.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let cancel_tx_clone = Arc::clone(&cancel_tx);
+        Box::pin(async move {
+            if c == ConnectionState::Failed || c == ConnectionState::Disconnected {
+                let mut tx = cancel_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     agent_a.restart("".to_owned(), "".to_owned()).await?;
 
@@ -1914,10 +1889,10 @@ async fn test_agent_restart_both_side() -> Result<()> {
         generate_candidate_address_strings(agent_b.get_local_candidates().await);
 
     let (a_notifier, mut a_connected) = on_connected();
-    agent_a.on_connection_state_change(a_notifier).await;
+    agent_a.on_connection_state_change(a_notifier);
 
     let (b_notifier, mut b_connected) = on_connected();
-    agent_b.on_connection_state_change(b_notifier).await;
+    agent_b.on_connection_state_change(b_notifier);
 
     // Restart and Re-Signal
     agent_a.restart("".to_owned(), "".to_owned()).await?;
@@ -2009,21 +1984,19 @@ async fn test_close_in_connection_state_callback() -> Result<()> {
     let (is_connected_tx, mut is_connected_rx) = mpsc::channel::<()>(1);
     let is_closed_tx = Arc::new(Mutex::new(Some(is_closed_tx)));
     let is_connected_tx = Arc::new(Mutex::new(Some(is_connected_tx)));
-    a_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let is_closed_tx_clone = Arc::clone(&is_closed_tx);
-            let is_connected_tx_clone = Arc::clone(&is_connected_tx);
-            Box::pin(async move {
-                if c == ConnectionState::Connected {
-                    let mut tx = is_connected_tx_clone.lock().await;
-                    tx.take();
-                } else if c == ConnectionState::Closed {
-                    let mut tx = is_closed_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let is_closed_tx_clone = Arc::clone(&is_closed_tx);
+        let is_connected_tx_clone = Arc::clone(&is_connected_tx);
+        Box::pin(async move {
+            if c == ConnectionState::Connected {
+                let mut tx = is_connected_tx_clone.lock().await;
+                tx.take();
+            } else if c == ConnectionState::Closed {
+                let mut tx = is_closed_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -2066,17 +2039,15 @@ async fn test_run_task_in_connection_state_callback() -> Result<()> {
 
     let (is_complete_tx, mut is_complete_rx) = mpsc::channel::<()>(1);
     let is_complete_tx = Arc::new(Mutex::new(Some(is_complete_tx)));
-    a_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let is_complete_tx_clone = Arc::clone(&is_complete_tx);
-            Box::pin(async move {
-                if c == ConnectionState::Connected {
-                    let mut tx = is_complete_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let is_complete_tx_clone = Arc::clone(&is_complete_tx);
+        Box::pin(async move {
+            if c == ConnectionState::Connected {
+                let mut tx = is_complete_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -2120,31 +2091,27 @@ async fn test_run_task_in_selected_candidate_pair_change_callback() -> Result<()
 
     let (is_tested_tx, mut is_tested_rx) = mpsc::channel::<()>(1);
     let is_tested_tx = Arc::new(Mutex::new(Some(is_tested_tx)));
-    a_agent
-        .on_selected_candidate_pair_change(Box::new(
-            move |_: &Arc<dyn Candidate + Send + Sync>, _: &Arc<dyn Candidate + Send + Sync>| {
-                let is_tested_tx_clone = Arc::clone(&is_tested_tx);
-                Box::pin(async move {
-                    let mut tx = is_tested_tx_clone.lock().await;
-                    tx.take();
-                })
-            },
-        ))
-        .await;
+    a_agent.on_selected_candidate_pair_change(Box::new(
+        move |_: &Arc<dyn Candidate + Send + Sync>, _: &Arc<dyn Candidate + Send + Sync>| {
+            let is_tested_tx_clone = Arc::clone(&is_tested_tx);
+            Box::pin(async move {
+                let mut tx = is_tested_tx_clone.lock().await;
+                tx.take();
+            })
+        },
+    ));
 
     let (is_complete_tx, mut is_complete_rx) = mpsc::channel::<()>(1);
     let is_complete_tx = Arc::new(Mutex::new(Some(is_complete_tx)));
-    a_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let is_complete_tx_clone = Arc::clone(&is_complete_tx);
-            Box::pin(async move {
-                if c == ConnectionState::Connected {
-                    let mut tx = is_complete_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+    a_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let is_complete_tx_clone = Arc::clone(&is_complete_tx);
+        Box::pin(async move {
+            if c == ConnectionState::Connected {
+                let mut tx = is_complete_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -2173,7 +2140,7 @@ async fn test_lite_lifecycle() -> Result<()> {
         .await?,
     );
 
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let disconnected_duration = Duration::from_secs(1);
     let failed_duration = Duration::from_secs(1);
@@ -2201,26 +2168,24 @@ async fn test_lite_lifecycle() -> Result<()> {
     let b_disconnected_tx = Arc::new(Mutex::new(Some(b_disconnected_tx)));
     let b_failed_tx = Arc::new(Mutex::new(Some(b_failed_tx)));
 
-    b_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let b_connected_tx_clone = Arc::clone(&b_connected_tx);
-            let b_disconnected_tx_clone = Arc::clone(&b_disconnected_tx);
-            let b_failed_tx_clone = Arc::clone(&b_failed_tx);
+    b_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let b_connected_tx_clone = Arc::clone(&b_connected_tx);
+        let b_disconnected_tx_clone = Arc::clone(&b_disconnected_tx);
+        let b_failed_tx_clone = Arc::clone(&b_failed_tx);
 
-            Box::pin(async move {
-                if c == ConnectionState::Connected {
-                    let mut tx = b_connected_tx_clone.lock().await;
-                    tx.take();
-                } else if c == ConnectionState::Disconnected {
-                    let mut tx = b_disconnected_tx_clone.lock().await;
-                    tx.take();
-                } else if c == ConnectionState::Failed {
-                    let mut tx = b_failed_tx_clone.lock().await;
-                    tx.take();
-                }
-            })
-        }))
-        .await;
+        Box::pin(async move {
+            if c == ConnectionState::Connected {
+                let mut tx = b_connected_tx_clone.lock().await;
+                tx.take();
+            } else if c == ConnectionState::Disconnected {
+                let mut tx = b_disconnected_tx_clone.lock().await;
+                tx.take();
+            } else if c == ConnectionState::Failed {
+                let mut tx = b_failed_tx_clone.lock().await;
+                tx.take();
+            }
+        })
+    }));
 
     connect_with_vnet(&b_agent, &a_agent).await?;
 

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -1031,7 +1031,7 @@ async fn test_invalid_gather() -> Result<()> {
     //"Gather with no OnCandidate should error"
     let a = Agent::new(AgentConfig::default()).await?;
 
-    if let Err(err) = a.gather_candidates().await {
+    if let Err(err) = a.gather_candidates() {
         assert_eq!(
             Error::ErrNoOnCandidateHandler,
             err,

--- a/ice/src/agent/agent_transport_test.rs
+++ b/ice/src/agent/agent_transport_test.rs
@@ -21,7 +21,7 @@ pub(crate) async fn pipe(
     cfg0.network_types = supported_network_types();
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let mut cfg1 = if let Some(cfg) = default_config1 {
         cfg
@@ -32,7 +32,7 @@ pub(crate) async fn pipe(
     cfg1.network_types = supported_network_types();
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     let (a_conn, b_conn) = connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -70,7 +70,7 @@ async fn test_remote_local_addr() -> Result<()> {
     //"Disconnected Returns nil"
     {
         let disconnected_conn = AgentConn::new();
-        let result = disconnected_conn.local_addr().await;
+        let result = disconnected_conn.local_addr();
         assert!(result.is_err(), "Disconnected Returns nil");
     }
 
@@ -89,8 +89,8 @@ async fn test_remote_local_addr() -> Result<()> {
         )
         .await?;
 
-        let a_laddr = ca.local_addr().await?;
-        let b_laddr = cb.local_addr().await?;
+        let a_laddr = ca.local_addr()?;
+        let b_laddr = cb.local_addr()?;
 
         // Assert addresses
         assert_eq!(a_laddr.ip().to_string(), VNET_LOCAL_IPA.to_string());

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -29,10 +29,10 @@ impl Conn for MockConn {
     async fn send_to(&self, _buf: &[u8], _target: SocketAddr) -> Result<usize, util::Error> {
         Ok(0)
     }
-    async fn local_addr(&self) -> Result<SocketAddr, util::Error> {
+    fn local_addr(&self) -> Result<SocketAddr, util::Error> {
         Ok(SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0))
     }
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
     async fn close(&self) -> Result<(), util::Error> {
@@ -308,7 +308,7 @@ pub(crate) async fn pipe_with_vnet(
     };
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let nat_1to1_ips = if a1test_config.nat_1to1_ip_candidate_type != CandidateType::Unspecified {
         vec![VNET_GLOBAL_IPB.to_owned()]
@@ -326,7 +326,7 @@ pub(crate) async fn pipe_with_vnet(
     };
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     let (a_conn, b_conn) = connect_with_vnet(&a_agent, &b_agent).await?;
 
@@ -360,35 +360,31 @@ pub(crate) async fn gather_and_exchange_candidates(
     let wg = WaitGroup::new();
 
     let w1 = Arc::new(Mutex::new(Some(wg.worker())));
-    a_agent
-        .on_candidate(Box::new(
-            move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
-                let w3 = Arc::clone(&w1);
-                Box::pin(async move {
-                    if candidate.is_none() {
-                        let mut w = w3.lock().await;
-                        w.take();
-                    }
-                })
-            },
-        ))
-        .await;
+    a_agent.on_candidate(Box::new(
+        move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
+            let w3 = Arc::clone(&w1);
+            Box::pin(async move {
+                if candidate.is_none() {
+                    let mut w = w3.lock().await;
+                    w.take();
+                }
+            })
+        },
+    ));
     a_agent.gather_candidates().await?;
 
     let w2 = Arc::new(Mutex::new(Some(wg.worker())));
-    b_agent
-        .on_candidate(Box::new(
-            move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
-                let w3 = Arc::clone(&w2);
-                Box::pin(async move {
-                    if candidate.is_none() {
-                        let mut w = w3.lock().await;
-                        w.take();
-                    }
-                })
-            },
-        ))
-        .await;
+    b_agent.on_candidate(Box::new(
+        move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
+            let w3 = Arc::clone(&w2);
+            Box::pin(async move {
+                if candidate.is_none() {
+                    let mut w = w3.lock().await;
+                    w.take();
+                }
+            })
+        },
+    ));
     b_agent.gather_candidates().await?;
 
     wg.wait().await;
@@ -396,15 +392,15 @@ pub(crate) async fn gather_and_exchange_candidates(
     let candidates = a_agent.get_local_candidates().await?;
     for c in candidates {
         let c2: Arc<dyn Candidate + Send + Sync> =
-            Arc::new(unmarshal_candidate(c.marshal().as_str()).await?);
-        b_agent.add_remote_candidate(&c2).await?;
+            Arc::new(unmarshal_candidate(c.marshal().as_str())?);
+        b_agent.add_remote_candidate(&c2)?;
     }
 
     let candidates = b_agent.get_local_candidates().await?;
     for c in candidates {
         let c2: Arc<dyn Candidate + Send + Sync> =
-            Arc::new(unmarshal_candidate(c.marshal().as_str()).await?);
-        a_agent.add_remote_candidate(&c2).await?;
+            Arc::new(unmarshal_candidate(c.marshal().as_str())?);
+        a_agent.add_remote_candidate(&c2)?;
     }
 
     Ok(())
@@ -822,26 +818,22 @@ async fn test_disconnected_to_connected() -> Result<(), Error> {
     let (controlling_state_changes_tx, mut controlling_state_changes_rx) =
         mpsc::channel::<ConnectionState>(100);
     let controlling_state_changes_tx = Arc::new(controlling_state_changes_tx);
-    controlling_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let controlling_state_changes_tx_clone = Arc::clone(&controlling_state_changes_tx);
-            Box::pin(async move {
-                let _ = controlling_state_changes_tx_clone.try_send(c);
-            })
-        }))
-        .await;
+    controlling_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let controlling_state_changes_tx_clone = Arc::clone(&controlling_state_changes_tx);
+        Box::pin(async move {
+            let _ = controlling_state_changes_tx_clone.try_send(c);
+        })
+    }));
 
     let (controlled_state_changes_tx, mut controlled_state_changes_rx) =
         mpsc::channel::<ConnectionState>(100);
     let controlled_state_changes_tx = Arc::new(controlled_state_changes_tx);
-    controlled_agent
-        .on_connection_state_change(Box::new(move |c: ConnectionState| {
-            let controlled_state_changes_tx_clone = Arc::clone(&controlled_state_changes_tx);
-            Box::pin(async move {
-                let _ = controlled_state_changes_tx_clone.try_send(c);
-            })
-        }))
-        .await;
+    controlled_agent.on_connection_state_change(Box::new(move |c: ConnectionState| {
+        let controlled_state_changes_tx_clone = Arc::clone(&controlled_state_changes_tx);
+        Box::pin(async move {
+            let _ = controlled_state_changes_tx_clone.try_send(c);
+        })
+    }));
 
     connect_with_vnet(&controlling_agent, &controlled_agent).await?;
 

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -371,7 +371,7 @@ pub(crate) async fn gather_and_exchange_candidates(
             })
         },
     ));
-    a_agent.gather_candidates().await?;
+    a_agent.gather_candidates()?;
 
     let w2 = Arc::new(Mutex::new(Some(wg.worker())));
     b_agent.on_candidate(Box::new(
@@ -385,7 +385,7 @@ pub(crate) async fn gather_and_exchange_candidates(
             })
         },
     ));
-    b_agent.gather_candidates().await?;
+    b_agent.gather_candidates()?;
 
     wg.wait().await;
 

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -210,14 +210,11 @@ impl Agent {
             gather_candidate_cancel: None, //TODO: add cancel
         };
 
-        agent
-            .internal
-            .start_on_connection_state_change_routine(
-                chan_state_rx,
-                chan_candidate_rx,
-                chan_candidate_pair_rx,
-            )
-            .await;
+        agent.internal.start_on_connection_state_change_routine(
+            chan_state_rx,
+            chan_candidate_rx,
+            chan_candidate_pair_rx,
+        );
 
         // Restart is also used to initialize the agent for the first time
         if let Err(err) = agent.restart(config.local_ufrag, config.local_pwd).await {
@@ -229,40 +226,38 @@ impl Agent {
         Ok(agent)
     }
 
-    pub async fn get_bytes_received(&self) -> usize {
+    pub fn get_bytes_received(&self) -> usize {
         self.internal.agent_conn.bytes_received()
     }
 
-    pub async fn get_bytes_sent(&self) -> usize {
+    pub fn get_bytes_sent(&self) -> usize {
         self.internal.agent_conn.bytes_sent()
     }
 
     /// Sets a handler that is fired when the connection state changes.
-    pub async fn on_connection_state_change(&self, f: OnConnectionStateChangeHdlrFn) {
-        let mut on_connection_state_change_hdlr =
-            self.internal.on_connection_state_change_hdlr.lock().await;
-        *on_connection_state_change_hdlr = Some(f);
+    pub fn on_connection_state_change(&self, f: OnConnectionStateChangeHdlrFn) {
+        self.internal
+            .on_connection_state_change_hdlr
+            .store(Some(Arc::new(Mutex::new(f))))
     }
 
     /// Sets a handler that is fired when the final candidate pair is selected.
-    pub async fn on_selected_candidate_pair_change(&self, f: OnSelectedCandidatePairChangeHdlrFn) {
-        let mut on_selected_candidate_pair_change_hdlr = self
-            .internal
+    pub fn on_selected_candidate_pair_change(&self, f: OnSelectedCandidatePairChangeHdlrFn) {
+        self.internal
             .on_selected_candidate_pair_change_hdlr
-            .lock()
-            .await;
-        *on_selected_candidate_pair_change_hdlr = Some(f);
+            .store(Some(Arc::new(Mutex::new(f))))
     }
 
     /// Sets a handler that is fired when new candidates gathered. When the gathering process
     /// complete the last candidate is nil.
-    pub async fn on_candidate(&self, f: OnCandidateHdlrFn) {
-        let mut on_candidate_hdlr = self.internal.on_candidate_hdlr.lock().await;
-        *on_candidate_hdlr = Some(f);
+    pub fn on_candidate(&self, f: OnCandidateHdlrFn) {
+        self.internal
+            .on_candidate_hdlr
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// Adds a new remote candidate.
-    pub async fn add_remote_candidate(&self, c: &Arc<dyn Candidate + Send + Sync>) -> Result<()> {
+    pub fn add_remote_candidate(&self, c: &Arc<dyn Candidate + Send + Sync>) -> Result<()> {
         // cannot check for network yet because it might not be applied
         // when mDNS hostame is used.
         if c.tcp_type() == TcpType::Active {
@@ -353,8 +348,8 @@ impl Agent {
     }
 
     /// Returns the selected pair or nil if there is none
-    pub async fn get_selected_candidate_pair(&self) -> Option<Arc<CandidatePair>> {
-        self.internal.agent_conn.get_selected_pair().await
+    pub fn get_selected_candidate_pair(&self) -> Option<Arc<CandidatePair>> {
+        self.internal.agent_conn.get_selected_pair()
     }
 
     /// Sets the credentials of the remote agent.
@@ -442,11 +437,8 @@ impl Agent {
             return Err(Error::ErrMultipleGatherAttempted);
         }
 
-        {
-            let on_candidate_hdlr = self.internal.on_candidate_hdlr.lock().await;
-            if on_candidate_hdlr.is_none() {
-                return Err(Error::ErrNoOnCandidateHandler);
-            }
+        if self.internal.on_candidate_hdlr.load().is_none() {
+            return Err(Error::ErrNoOnCandidateHandler);
         }
 
         if let Some(gather_candidate_cancel) = &self.gather_candidate_cancel {
@@ -506,7 +498,7 @@ impl Agent {
             }
         };
 
-        c.set_ip(&src.ip()).await?;
+        c.set_ip(&src.ip())?;
 
         Ok(c)
     }

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -432,7 +432,7 @@ impl Agent {
     }
 
     /// Initiates the trickle based gathering process.
-    pub async fn gather_candidates(&self) -> Result<()> {
+    pub fn gather_candidates(&self) -> Result<()> {
         if self.gathering_state.load(Ordering::SeqCst) != GatheringState::New as u8 {
             return Err(Error::ErrMultipleGatherAttempted);
         }

--- a/ice/src/candidate/candidate_base.rs
+++ b/ice/src/candidate/candidate_base.rs
@@ -298,9 +298,7 @@ impl Candidate for CandidateBase {
             .store(network_type as u8, Ordering::SeqCst);
 
         let addr = create_addr(network_type, *ip, self.port);
-        {
-            *self.resolved_addr.lock() = addr;
-        }
+        *self.resolved_addr.lock() = addr;
 
         Ok(())
     }

--- a/ice/src/candidate/candidate_base.rs
+++ b/ice/src/candidate/candidate_base.rs
@@ -233,7 +233,11 @@ impl Candidate for CandidateBase {
     }
 
     fn addr(&self) -> SocketAddr {
-        *self.resolved_addr.lock().unwrap()
+        // Won't panic since we only do set/get one-liners.
+        *self
+            .resolved_addr
+            .lock()
+            .expect("CandidateBase::resolved_addr is poisoned")
     }
 
     /// Stops the recvLoop.
@@ -296,7 +300,14 @@ impl Candidate for CandidateBase {
         self.network_type
             .store(network_type as u8, Ordering::SeqCst);
 
-        *self.resolved_addr.lock().unwrap() = create_addr(network_type, *ip, self.port);
+        let addr = create_addr(network_type, *ip, self.port);
+        {
+            // Won't panic since we only do set/get one-liners.
+            *self
+                .resolved_addr
+                .lock()
+                .expect("CandidateBase::resolved_addr is poisoned") = addr;
+        }
 
         Ok(())
     }

--- a/ice/src/candidate/candidate_host.rs
+++ b/ice/src/candidate/candidate_host.rs
@@ -14,7 +14,7 @@ pub struct CandidateHostConfig {
 
 impl CandidateHostConfig {
     /// Creates a new host candidate.
-    pub async fn new_candidate_host(self) -> Result<CandidateBase> {
+    pub fn new_candidate_host(self) -> Result<CandidateBase> {
         let mut candidate_id = self.base_config.candidate_id;
         if candidate_id.is_empty() {
             candidate_id = generate_cand_id();
@@ -37,7 +37,7 @@ impl CandidateHostConfig {
 
         if !self.base_config.address.ends_with(".local") {
             let ip = self.base_config.address.parse()?;
-            c.set_ip(&ip).await?;
+            c.set_ip(&ip)?;
         };
 
         Ok(c)

--- a/ice/src/candidate/candidate_pair_test.rs
+++ b/ice/src/candidate/candidate_pair_test.rs
@@ -5,7 +5,7 @@ use crate::candidate::candidate_peer_reflexive::CandidatePeerReflexiveConfig;
 use crate::candidate::candidate_relay::CandidateRelayConfig;
 use crate::candidate::candidate_server_reflexive::CandidateServerReflexiveConfig;
 
-pub(crate) async fn host_candidate() -> Result<CandidateBase> {
+pub(crate) fn host_candidate() -> Result<CandidateBase> {
     CandidateHostConfig {
         base_config: CandidateBaseConfig {
             network: "udp".to_owned(),
@@ -16,10 +16,9 @@ pub(crate) async fn host_candidate() -> Result<CandidateBase> {
         ..Default::default()
     }
     .new_candidate_host()
-    .await
 }
 
-pub(crate) async fn prflx_candidate() -> Result<CandidateBase> {
+pub(crate) fn prflx_candidate() -> Result<CandidateBase> {
     CandidatePeerReflexiveConfig {
         base_config: CandidateBaseConfig {
             network: "udp".to_owned(),
@@ -30,10 +29,9 @@ pub(crate) async fn prflx_candidate() -> Result<CandidateBase> {
         ..Default::default()
     }
     .new_candidate_peer_reflexive()
-    .await
 }
 
-pub(crate) async fn srflx_candidate() -> Result<CandidateBase> {
+pub(crate) fn srflx_candidate() -> Result<CandidateBase> {
     CandidateServerReflexiveConfig {
         base_config: CandidateBaseConfig {
             network: "udp".to_owned(),
@@ -44,10 +42,9 @@ pub(crate) async fn srflx_candidate() -> Result<CandidateBase> {
         ..Default::default()
     }
     .new_candidate_server_reflexive()
-    .await
 }
 
-pub(crate) async fn relay_candidate() -> Result<CandidateBase> {
+pub(crate) fn relay_candidate() -> Result<CandidateBase> {
     CandidateRelayConfig {
         base_config: CandidateBaseConfig {
             network: "udp".to_owned(),
@@ -58,72 +55,71 @@ pub(crate) async fn relay_candidate() -> Result<CandidateBase> {
         ..Default::default()
     }
     .new_candidate_relay()
-    .await
 }
 
-#[tokio::test]
-async fn test_candidate_pair_priority() -> Result<()> {
+#[test]
+fn test_candidate_pair_priority() -> Result<()> {
     let tests = vec![
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(host_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(host_candidate()?),
                 false,
             ),
             9151314440652587007,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(host_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(host_candidate()?),
                 true,
             ),
             9151314440652587007,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(prflx_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(prflx_candidate()?),
                 true,
             ),
             7998392936314175488,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(prflx_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(prflx_candidate()?),
                 false,
             ),
             7998392936314175487,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(srflx_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(srflx_candidate()?),
                 true,
             ),
             7277816996102668288,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(srflx_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(srflx_candidate()?),
                 false,
             ),
             7277816996102668287,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(relay_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(relay_candidate()?),
                 true,
             ),
             72057593987596288,
         ),
         (
             CandidatePair::new(
-                Arc::new(host_candidate().await?),
-                Arc::new(relay_candidate().await?),
+                Arc::new(host_candidate()?),
+                Arc::new(relay_candidate()?),
                 false,
             ),
             72057593987596287,
@@ -142,16 +138,16 @@ async fn test_candidate_pair_priority() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_candidate_pair_equality() -> Result<()> {
+#[test]
+fn test_candidate_pair_equality() -> Result<()> {
     let pair_a = CandidatePair::new(
-        Arc::new(host_candidate().await?),
-        Arc::new(srflx_candidate().await?),
+        Arc::new(host_candidate()?),
+        Arc::new(srflx_candidate()?),
         true,
     );
     let pair_b = CandidatePair::new(
-        Arc::new(host_candidate().await?),
-        Arc::new(srflx_candidate().await?),
+        Arc::new(host_candidate()?),
+        Arc::new(srflx_candidate()?),
         false,
     );
 

--- a/ice/src/candidate/candidate_peer_reflexive.rs
+++ b/ice/src/candidate/candidate_peer_reflexive.rs
@@ -3,10 +3,9 @@ use super::*;
 use crate::error::*;
 use crate::rand::generate_cand_id;
 use crate::util::*;
-use std::sync::{
-    atomic::{AtomicU16, AtomicU8},
-    Mutex as StdMutex,
-};
+use std::sync::atomic::{AtomicU16, AtomicU8};
+
+use util::sync::Mutex as SyncMutex;
 
 /// The config required to create a new `CandidatePeerReflexive`.
 #[derive(Default)]
@@ -37,7 +36,7 @@ impl CandidatePeerReflexiveConfig {
             candidate_type: CandidateType::PeerReflexive,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: SyncMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_peer_reflexive.rs
+++ b/ice/src/candidate/candidate_peer_reflexive.rs
@@ -3,7 +3,10 @@ use super::*;
 use crate::error::*;
 use crate::rand::generate_cand_id;
 use crate::util::*;
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use std::sync::{
+    atomic::{AtomicU16, AtomicU8},
+    Mutex as StdMutex,
+};
 
 /// The config required to create a new `CandidatePeerReflexive`.
 #[derive(Default)]
@@ -16,7 +19,7 @@ pub struct CandidatePeerReflexiveConfig {
 
 impl CandidatePeerReflexiveConfig {
     /// Creates a new peer reflective candidate.
-    pub async fn new_candidate_peer_reflexive(self) -> Result<CandidateBase> {
+    pub fn new_candidate_peer_reflexive(self) -> Result<CandidateBase> {
         let ip: IpAddr = match self.base_config.address.parse() {
             Ok(ip) => ip,
             Err(_) => return Err(Error::ErrAddressParseFailed),
@@ -34,7 +37,7 @@ impl CandidatePeerReflexiveConfig {
             candidate_type: CandidateType::PeerReflexive,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: Mutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_relay.rs
+++ b/ice/src/candidate/candidate_relay.rs
@@ -5,8 +5,9 @@ use crate::rand::generate_cand_id;
 use crate::util::*;
 use std::sync::{
     atomic::{AtomicU16, AtomicU8},
-    Arc, Mutex as StdMutex,
+    Arc,
 };
+use util::sync::Mutex as SyncMutex;
 
 /// The config required to create a new `CandidateRelay`.
 #[derive(Default)]
@@ -38,7 +39,7 @@ impl CandidateRelayConfig {
             candidate_type: CandidateType::Relay,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: SyncMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_relay.rs
+++ b/ice/src/candidate/candidate_relay.rs
@@ -3,8 +3,10 @@ use super::*;
 use crate::error::*;
 use crate::rand::generate_cand_id;
 use crate::util::*;
-use std::sync::atomic::{AtomicU16, AtomicU8};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU16, AtomicU8},
+    Arc, Mutex as StdMutex,
+};
 
 /// The config required to create a new `CandidateRelay`.
 #[derive(Default)]
@@ -18,7 +20,7 @@ pub struct CandidateRelayConfig {
 
 impl CandidateRelayConfig {
     /// Creates a new relay candidate.
-    pub async fn new_candidate_relay(self) -> Result<CandidateBase> {
+    pub fn new_candidate_relay(self) -> Result<CandidateBase> {
         let mut candidate_id = self.base_config.candidate_id;
         if candidate_id.is_empty() {
             candidate_id = generate_cand_id();
@@ -36,7 +38,7 @@ impl CandidateRelayConfig {
             candidate_type: CandidateType::Relay,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: Mutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_relay_test.rs
+++ b/ice/src/candidate/candidate_relay_test.rs
@@ -80,7 +80,7 @@ async fn test_relay_only_connection() -> Result<(), Error> {
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
     let (a_notifier, mut a_connected) = on_connected();
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         network_types: supported_network_types(),
@@ -98,7 +98,7 @@ async fn test_relay_only_connection() -> Result<(), Error> {
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
     let (b_notifier, mut b_connected) = on_connected();
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 

--- a/ice/src/candidate/candidate_server_reflexive.rs
+++ b/ice/src/candidate/candidate_server_reflexive.rs
@@ -3,7 +3,10 @@ use super::*;
 use crate::error::*;
 use crate::rand::generate_cand_id;
 use crate::util::*;
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use std::sync::{
+    atomic::{AtomicU16, AtomicU8},
+    Mutex as StdMutex,
+};
 
 /// The config required to create a new `CandidateServerReflexive`.
 #[derive(Default)]
@@ -16,7 +19,7 @@ pub struct CandidateServerReflexiveConfig {
 
 impl CandidateServerReflexiveConfig {
     /// Creates a new server reflective candidate.
-    pub async fn new_candidate_server_reflexive(self) -> Result<CandidateBase> {
+    pub fn new_candidate_server_reflexive(self) -> Result<CandidateBase> {
         let ip: IpAddr = match self.base_config.address.parse() {
             Ok(ip) => ip,
             Err(_) => return Err(Error::ErrAddressParseFailed),
@@ -34,7 +37,7 @@ impl CandidateServerReflexiveConfig {
             candidate_type: CandidateType::ServerReflexive,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: Mutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_server_reflexive.rs
+++ b/ice/src/candidate/candidate_server_reflexive.rs
@@ -3,10 +3,8 @@ use super::*;
 use crate::error::*;
 use crate::rand::generate_cand_id;
 use crate::util::*;
-use std::sync::{
-    atomic::{AtomicU16, AtomicU8},
-    Mutex as StdMutex,
-};
+use std::sync::atomic::{AtomicU16, AtomicU8};
+use util::sync::Mutex as SyncMutex;
 
 /// The config required to create a new `CandidateServerReflexive`.
 #[derive(Default)]
@@ -37,7 +35,7 @@ impl CandidateServerReflexiveConfig {
             candidate_type: CandidateType::ServerReflexive,
             address: self.base_config.address,
             port: self.base_config.port,
-            resolved_addr: StdMutex::new(create_addr(network_type, ip, self.base_config.port)),
+            resolved_addr: SyncMutex::new(create_addr(network_type, ip, self.base_config.port)),
             component: AtomicU16::new(self.base_config.component),
             foundation_override: self.base_config.foundation,
             priority_override: self.base_config.priority,

--- a/ice/src/candidate/candidate_server_reflexive_test.rs
+++ b/ice/src/candidate/candidate_server_reflexive_test.rs
@@ -57,7 +57,7 @@ async fn test_server_reflexive_only_connection() -> Result<()> {
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
     let (a_notifier, mut a_connected) = on_connected();
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         network_types: vec![NetworkType::Udp4],
@@ -73,7 +73,7 @@ async fn test_server_reflexive_only_connection() -> Result<()> {
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
     let (b_notifier, mut b_connected) = on_connected();
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     connect_with_vnet(&a_agent, &b_agent).await?;
 

--- a/ice/src/candidate/candidate_test.rs
+++ b/ice/src/candidate/candidate_test.rs
@@ -300,8 +300,8 @@ fn test_candidate_type_to_string() {
     }
 }
 
-#[tokio::test]
-async fn test_candidate_marshal() -> Result<()> {
+#[test]
+fn test_candidate_marshal() -> Result<()> {
     let tests = vec![
        (
             Some(CandidateBase{
@@ -332,7 +332,7 @@ async fn test_candidate_marshal() -> Result<()> {
                     address:        "191.228.238.68".to_owned(),
                     port:           53991,
                     related_address: Some(CandidateRelatedAddress{
-                        address: "192.168.0.274".to_owned(), 
+                        address: "192.168.0.274".to_owned(),
                         port:53991
                     }),
                 ..Default::default()
@@ -347,7 +347,7 @@ async fn test_candidate_marshal() -> Result<()> {
                     port:           5000,
                     related_address: Some(
                         CandidateRelatedAddress{
-                            address: "192.168.0.1".to_owned(), 
+                            address: "192.168.0.1".to_owned(),
                             port:5001}
                     ),
                 ..Default::default()
@@ -373,7 +373,7 @@ async fn test_candidate_marshal() -> Result<()> {
                     port:          60542,
                 ..Default::default()
             }),
-            "1380287402 1 udp 2130706431 e2494022-4d9a-4c1e-a750-cc48d4f8d6ee.local 60542 typ host", 
+            "1380287402 1 udp 2130706431 e2494022-4d9a-4c1e-a750-cc48d4f8d6ee.local 60542 typ host",
         ),
         // Invalid candidates
         (None, ""),
@@ -390,7 +390,7 @@ async fn test_candidate_marshal() -> Result<()> {
     ];
 
     for (candidate, marshaled) in tests {
-        let actual_candidate = unmarshal_candidate(marshaled).await;
+        let actual_candidate = unmarshal_candidate(marshaled);
         if let Some(candidate) = candidate {
             if let Ok(actual_candidate) = actual_candidate {
                 assert!(

--- a/ice/src/candidate/mod.rs
+++ b/ice/src/candidate/mod.rs
@@ -314,7 +314,7 @@ impl CandidatePair {
         // maxUint32, this result would overflow uint64
         ((1 << 32_u64) - 1) * u64::from(std::cmp::min(g, d))
             + 2 * u64::from(std::cmp::max(g, d))
-            + if g > d { 1 } else { 0 }
+            + u64::from(g > d)
     }
 
     pub async fn write(&self, b: &[u8]) -> Result<usize> {

--- a/ice/src/candidate/mod.rs
+++ b/ice/src/candidate/mod.rs
@@ -74,14 +74,14 @@ pub trait Candidate: fmt::Display {
 
     fn marshal(&self) -> String;
 
-    async fn addr(&self) -> SocketAddr;
+    fn addr(&self) -> SocketAddr;
 
     async fn close(&self) -> Result<()>;
     fn seen(&self, outbound: bool);
 
     async fn write_to(&self, raw: &[u8], dst: &(dyn Candidate + Send + Sync)) -> Result<usize>;
     fn equal(&self, other: &dyn Candidate) -> bool;
-    async fn set_ip(&self, ip: &IpAddr) -> Result<()>;
+    fn set_ip(&self, ip: &IpAddr) -> Result<()>;
     fn get_conn(&self) -> Option<&Arc<dyn util::Conn + Send + Sync>>;
     fn get_closed_ch(&self) -> Arc<Mutex<Option<broadcast::Sender<()>>>>;
 }

--- a/ice/src/mdns/mdns_test.rs
+++ b/ice/src/mdns/mdns_test.rs
@@ -23,7 +23,7 @@ async fn test_multicast_dns_only_connection() -> Result<()> {
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
     let (a_notifier, mut a_connected) = on_connected();
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         network_types: vec![NetworkType::Udp4],
@@ -34,7 +34,7 @@ async fn test_multicast_dns_only_connection() -> Result<()> {
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
     let (b_notifier, mut b_connected) = on_connected();
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     connect_with_vnet(&a_agent, &b_agent).await?;
     let _ = a_connected.recv().await;
@@ -57,7 +57,7 @@ async fn test_multicast_dns_mixed_connection() -> Result<()> {
 
     let a_agent = Arc::new(Agent::new(cfg0).await?);
     let (a_notifier, mut a_connected) = on_connected();
-    a_agent.on_connection_state_change(a_notifier).await;
+    a_agent.on_connection_state_change(a_notifier);
 
     let cfg1 = AgentConfig {
         network_types: vec![NetworkType::Udp4],
@@ -68,7 +68,7 @@ async fn test_multicast_dns_mixed_connection() -> Result<()> {
 
     let b_agent = Arc::new(Agent::new(cfg1).await?);
     let (b_notifier, mut b_connected) = on_connected();
-    b_agent.on_connection_state_change(b_notifier).await;
+    b_agent.on_connection_state_change(b_notifier);
 
     connect_with_vnet(&a_agent, &b_agent).await?;
     let _ = a_connected.recv().await;
@@ -117,8 +117,7 @@ async fn test_multicast_dns_static_host_name() -> Result<()> {
                 }
             })
         },
-    ))
-    .await;
+    ));
 
     a.gather_candidates().await?;
 

--- a/ice/src/mdns/mdns_test.rs
+++ b/ice/src/mdns/mdns_test.rs
@@ -119,7 +119,7 @@ async fn test_multicast_dns_static_host_name() -> Result<()> {
         },
     ));
 
-    a.gather_candidates().await?;
+    a.gather_candidates()?;
 
     log::debug!("wait for gathering is done...");
     let _ = done_rx.recv().await;

--- a/ice/src/udp_mux/mod.rs
+++ b/ice/src/udp_mux/mod.rs
@@ -104,8 +104,8 @@ impl UDPMuxDefault {
     }
 
     /// Create a muxed connection for a given ufrag.
-    async fn create_muxed_conn(self: &Arc<Self>, ufrag: &str) -> Result<UDPMuxConn, Error> {
-        let local_addr = self.params.conn.local_addr().await?;
+    fn create_muxed_conn(self: &Arc<Self>, ufrag: &str) -> Result<UDPMuxConn, Error> {
+        let local_addr = self.params.conn.local_addr()?;
 
         let params = UDPMuxConnParams {
             local_addr,
@@ -267,7 +267,7 @@ impl UDPMux for UDPMuxDefault {
                 return Ok(Arc::new(conn.clone()) as Arc<dyn Conn + Send + Sync>);
             }
 
-            let muxed_conn = self.create_muxed_conn(ufrag).await?;
+            let muxed_conn = self.create_muxed_conn(ufrag)?;
             let mut close_rx = muxed_conn.close_rx();
             let cloned_self = Arc::clone(&self);
             let cloned_ufrag = ufrag.to_string();

--- a/ice/src/udp_mux/udp_mux_conn.rs
+++ b/ice/src/udp_mux/udp_mux_conn.rs
@@ -289,11 +289,11 @@ impl Conn for UDPMuxConn {
         self.inner.send_to(buf, &normalized_target).await
     }
 
-    async fn local_addr(&self) -> ConnResult<SocketAddr> {
+    fn local_addr(&self) -> ConnResult<SocketAddr> {
         Ok(self.inner.local_addr())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
     async fn close(&self) -> ConnResult<()> {

--- a/interceptor/src/mock/mock_time.rs
+++ b/interceptor/src/mock/mock_time.rs
@@ -1,5 +1,6 @@
-use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
+
+use util::sync::Mutex;
 
 /// MockTime is a helper to replace SystemTime::now() for testing purposes.
 pub struct MockTime {
@@ -17,19 +18,19 @@ impl Default for MockTime {
 impl MockTime {
     /// set_now sets the current time.
     pub fn set_now(&self, now: SystemTime) {
-        let mut cur_now = self.cur_now.lock().unwrap();
+        let mut cur_now = self.cur_now.lock();
         *cur_now = now;
     }
 
     /// now returns the current time.
     pub fn now(&self) -> SystemTime {
-        let cur_now = self.cur_now.lock().unwrap();
+        let cur_now = self.cur_now.lock();
         *cur_now
     }
 
     /// advance advances duration d
     pub fn advance(&mut self, d: Duration) {
-        let mut cur_now = self.cur_now.lock().unwrap();
+        let mut cur_now = self.cur_now.lock();
         *cur_now = cur_now.checked_add(d).unwrap_or(*cur_now);
     }
 }

--- a/interceptor/src/nack/generator/generator_stream.rs
+++ b/interceptor/src/nack/generator/generator_stream.rs
@@ -1,9 +1,8 @@
-use std::sync::Mutex;
-
 use super::*;
 
 use crate::nack::UINT16SIZE_HALF;
 
+use util::sync::Mutex;
 use util::Unmarshal;
 
 struct GeneratorStreamInternal {
@@ -139,12 +138,12 @@ impl GeneratorStream {
     }
 
     pub(super) fn missing_seq_numbers(&self, skip_last_n: u16) -> Vec<u16> {
-        let internal = self.internal.lock().unwrap();
+        let internal = self.internal.lock();
         internal.missing_seq_numbers(skip_last_n)
     }
 
     pub(super) fn add(&self, seq: u16) {
-        let mut internal = self.internal.lock().unwrap();
+        let mut internal = self.internal.lock();
         internal.add(seq);
     }
 }

--- a/interceptor/src/report/receiver/receiver_stream.rs
+++ b/interceptor/src/report/receiver/receiver_stream.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::{Attributes, RTPReader};
 
 use async_trait::async_trait;
-use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
+use util::sync::Mutex;
 use util::Unmarshal;
 
 struct ReceiverStreamInternal {
@@ -185,7 +185,7 @@ impl ReceiverStream {
     }
 
     pub(crate) fn process_rtp(&self, now: SystemTime, pkt: &rtp::packet::Packet) {
-        let mut internal = self.internal.lock().unwrap();
+        let mut internal = self.internal.lock();
         internal.process_rtp(now, pkt);
     }
 
@@ -194,12 +194,12 @@ impl ReceiverStream {
         now: SystemTime,
         sr: &rtcp::sender_report::SenderReport,
     ) {
-        let mut internal = self.internal.lock().unwrap();
+        let mut internal = self.internal.lock();
         internal.process_sender_report(now, sr);
     }
 
     pub(crate) fn generate_report(&self, now: SystemTime) -> rtcp::receiver_report::ReceiverReport {
-        let mut internal = self.internal.lock().unwrap();
+        let mut internal = self.internal.lock();
         internal.generate_report(now)
     }
 }

--- a/media/src/io/sample_builder/mod.rs
+++ b/media/src/io/sample_builder/mod.rs
@@ -94,7 +94,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
             i = i.wrapping_add(1);
         }
 
-        if found_head == None {
+        if found_head.is_none() {
             return false;
         }
 
@@ -107,7 +107,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
             i = i.wrapping_sub(1);
         }
 
-        if found_tail == None {
+        if found_tail.is_none() {
             return false;
         }
 

--- a/rtcp/src/lib.rs
+++ b/rtcp/src/lib.rs
@@ -22,7 +22,7 @@
 //!          .as_any()
 //!          .downcast_ref::<PictureLossIndication>()
 //!      {
-//!    
+//!
 //!      }
 //!     else if let Some(e) = packet
 //!          .as_any()

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/webrtc-rs/rtp"
 rust-version = "1.60.0"
 
 [dependencies]
-util = { version = "0.6.0", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }
+util = { version = "0.6.0", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal", "sync"] }
 
 bytes = "1"
 rand = "0.8.5"

--- a/rtp/src/sequence.rs
+++ b/rtp/src/sequence.rs
@@ -1,5 +1,7 @@
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use util::sync::Mutex;
 
 /// Sequencer generates sequential sequence numbers for building RTP packets
 pub trait Sequencer: fmt::Debug {
@@ -50,7 +52,7 @@ impl Sequencer for SequencerImpl {
     /// NextSequenceNumber increment and returns a new sequence number for
     /// building RTP packets
     fn next_sequence_number(&self) -> u16 {
-        let mut lock = self.0.lock().unwrap();
+        let mut lock = self.0.lock();
 
         if lock.sequence_number == u16::MAX {
             lock.roll_over_count += 1;
@@ -65,7 +67,7 @@ impl Sequencer for SequencerImpl {
     /// RollOverCount returns the amount of times the 16bit sequence number
     /// has wrapped
     fn roll_over_count(&self) -> u64 {
-        self.0.lock().unwrap().roll_over_count
+        self.0.lock().roll_over_count
     }
 
     fn clone_to(&self) -> Box<dyn Sequencer + Send + Sync> {

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+* Make `Stream::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
+    
 
 ## v0.6.1
 

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Increased minimum support rust version to `1.60.0`.
 
-#### Breaking changes
+### Breaking changes
 
 * Make `Stream::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
     

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+
+#### Breaking changes
+
 * Make `Stream::on_buffered_amount_low` function non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338).
     
 

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.57.0"
 [dependencies]
 util = { version = "0.6.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
+arc-swap = "1.5.1"
 tokio = { version = "1.19", features = ["full"] }
 bytes = "1"
 rand = "0.8.5"

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60.0"
 [dependencies]
 util = { version = "0.6.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
-arc-swap = "1.5.1"
+arc-swap = "1.5"
 tokio = { version = "1.19", features = ["full"] }
 bytes = "1"
 rand = "0.8.5"

--- a/sctp/examples/pong.rs
+++ b/sctp/examples/pong.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Error> {
 
     let host = matches.value_of("host").unwrap();
     let conn = DisconnectedPacketConn::new(Arc::new(UdpSocket::bind(host).await.unwrap()));
-    println!("listening {}...", conn.local_addr().await.unwrap());
+    println!("listening {}...", conn.local_addr().unwrap());
 
     let config = Config {
         net_conn: Arc::new(conn),

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -34,11 +34,11 @@ impl Conn for DumbConn {
         Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Addr Not Available").into())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -555,7 +555,7 @@ async fn test_assoc_reliable_unordered_ordered() -> Result<()> {
     s0.set_reliability_params(true, ReliabilityType::Reliable, 0);
     s1.set_reliability_params(true, ReliabilityType::Reliable, 0);
 
-    br.reorder_next_nwrites(0, 2).await;
+    br.reorder_next_nwrites(0, 2);
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -798,7 +798,7 @@ async fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
     s0.set_reliability_params(false, ReliabilityType::Rexmit, 0);
     s1.set_reliability_params(false, ReliabilityType::Rexmit, 0); // doesn't matter
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -888,7 +888,7 @@ async fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     s0.set_reliability_params(false, ReliabilityType::Rexmit, 0);
     s1.set_reliability_params(false, ReliabilityType::Rexmit, 0); // doesn't matter
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -973,7 +973,7 @@ async fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
     s0.set_reliability_params(true, ReliabilityType::Rexmit, 0);
     s1.set_reliability_params(true, ReliabilityType::Rexmit, 0); // doesn't matter
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -1156,7 +1156,7 @@ async fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     s0.set_reliability_params(false, ReliabilityType::Timed, 0);
     s1.set_reliability_params(false, ReliabilityType::Timed, 0); // doesn't matter
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -1241,7 +1241,7 @@ async fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
     s0.set_reliability_params(true, ReliabilityType::Timed, 0);
     s1.set_reliability_params(true, ReliabilityType::Timed, 0); // doesn't matter
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
     let n = s0
@@ -1339,7 +1339,7 @@ async fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
 
     let (s0, s1) = establish_session_pair(&br, &a0, &mut a1, SI).await?;
 
-    br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
+    br.drop_next_nwrites(0, 1); // drop the first packet (second one should be sacked)
 
     for i in 0..4u32 {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
@@ -2169,11 +2169,11 @@ impl Conn for FakeEchoConn {
         Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> UResult<SocketAddr> {
+    fn local_addr(&self) -> UResult<SocketAddr> {
         Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Addr Not Available").into())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -453,8 +453,8 @@ impl Stream {
         );
 
         if from_amount > buffered_amount_low && new_amount <= buffered_amount_low {
-            if let Some(hndlr) = &*self.on_buffered_amount_low.load() {
-                let mut f = hndlr.lock().await;
+            if let Some(handler) = &*self.on_buffered_amount_low.load() {
+                let mut f = handler.lock().await;
                 f().await;
             }
         }

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -8,6 +8,7 @@ use crate::queue::reassembly_queue::ReassemblyQueue;
 
 use crate::queue::pending_queue::PendingQueue;
 
+use arc_swap::ArcSwapOption;
 use bytes::Bytes;
 use std::fmt;
 use std::future::Future;
@@ -84,7 +85,7 @@ pub struct Stream {
     pub(crate) reliability_value: AtomicU32,
     pub(crate) buffered_amount: AtomicUsize,
     pub(crate) buffered_amount_low: AtomicUsize,
-    pub(crate) on_buffered_amount_low: Mutex<Option<OnBufferedAmountLowFn>>,
+    pub(crate) on_buffered_amount_low: ArcSwapOption<Mutex<OnBufferedAmountLowFn>>,
     pub(crate) name: String,
 }
 
@@ -140,7 +141,7 @@ impl Stream {
             reliability_value: AtomicU32::new(0),
             buffered_amount: AtomicUsize::new(0),
             buffered_amount_low: AtomicUsize::new(0),
-            on_buffered_amount_low: Mutex::new(None),
+            on_buffered_amount_low: ArcSwapOption::empty(),
             name,
         }
     }
@@ -412,9 +413,9 @@ impl Stream {
 
     /// on_buffered_amount_low sets the callback handler which would be called when the number of
     /// bytes of outgoing data buffered is lower than the threshold.
-    pub async fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
-        let mut on_buffered_amount_low = self.on_buffered_amount_low.lock().await;
-        *on_buffered_amount_low = Some(f);
+    pub fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
+        self.on_buffered_amount_low
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// This method is called by association's read_loop (go-)routine to notify this stream
@@ -452,8 +453,8 @@ impl Stream {
         );
 
         if from_amount > buffered_amount_low && new_amount <= buffered_amount_low {
-            let mut handler = self.on_buffered_amount_low.lock().await;
-            if let Some(f) = &mut *handler {
+            if let Some(hndlr) = &*self.on_buffered_amount_low.load() {
+                let mut f = hndlr.lock().await;
                 f().await;
             }
         }

--- a/sctp/src/stream/stream_test.rs
+++ b/sctp/src/stream/stream_test.rs
@@ -36,8 +36,7 @@ async fn test_stream_amount_on_buffered_amount_low() -> Result<()> {
     s.on_buffered_amount_low(Box::new(move || {
         n_cbs2.fetch_add(1, Ordering::SeqCst);
         Box::pin(async {})
-    }))
-    .await;
+    }));
 
     // Negative value should be ignored (by design)
     s.on_buffer_released(-32).await; // bufferedAmount = 3072

--- a/stun/src/message.rs
+++ b/stun/src/message.rs
@@ -64,7 +64,7 @@ pub struct Message {
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let t_id = base64::encode(&self.transaction_id.0);
+        let t_id = base64::encode(self.transaction_id.0);
         write!(
             f,
             "{} l={} attrs={} id={}",

--- a/turn/examples/turn_client_udp.rs
+++ b/turn/examples/turn_client_udp.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Error> {
 
     // The relayConn's local address is actually the transport
     // address assigned on the TURN server.
-    println!("relayed-address={}", relay_conn.local_addr().await?);
+    println!("relayed-address={}", relay_conn.local_addr()?);
 
     // If you provided `-ping`, perform a ping test agaist the
     // relayConn we have just allocated.
@@ -132,7 +132,7 @@ async fn do_ping_test(
     // the TURN server.
     //println!("relay_conn send hello to mapped_addr {}", mapped_addr);
     relay_conn.send_to("Hello".as_bytes(), mapped_addr).await?;
-    let relay_addr = relay_conn.local_addr().await?;
+    let relay_addr = relay_conn.local_addr()?;
 
     let pinger_conn_rx = Arc::clone(&pinger_conn_tx);
 

--- a/turn/src/allocation/allocation_manager/allocation_manager_test.rs
+++ b/turn/src/allocation/allocation_manager/allocation_manager_test.rs
@@ -94,7 +94,7 @@ async fn test_packet_handler() -> Result<()> {
         a.add_channel_bind(channel_bind.clone(), DEFAULT_LIFETIME)
             .await?;
 
-        a.relay_socket.local_addr().await?.port()
+        a.relay_socket.local_addr()?.port()
     };
 
     let relay_addr_with_host_str = format!("127.0.0.1:{}", port);

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -11,8 +11,8 @@ use crate::proto::{chandata::*, channum::*, data::*, peeraddr::*, *};
 use channel_bind::*;
 use five_tuple::*;
 use permission::*;
-
 use stun::{agent::*, message::*, textattrs::Username};
+use util::sync::Mutex as SyncMutex;
 
 use util::Conn;
 
@@ -21,7 +21,7 @@ use std::{
     collections::HashMap,
     marker::{Send, Sync},
     net::SocketAddr,
-    sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex as StdMutex},
+    sync::{atomic::AtomicBool, atomic::Ordering, Arc},
 };
 use tokio::{
     sync::{mpsc, Mutex},
@@ -74,7 +74,7 @@ pub struct Allocation {
     permissions: Arc<Mutex<HashMap<String, Permission>>>,
     channel_bindings: Arc<Mutex<HashMap<ChannelNumber, ChannelBind>>>,
     pub(crate) allocations: Option<AllocationMap>,
-    reset_tx: StdMutex<Option<mpsc::Sender<Duration>>>,
+    reset_tx: SyncMutex<Option<mpsc::Sender<Duration>>>,
     timer_expired: Arc<AtomicBool>,
     closed: AtomicBool, // Option<mpsc::Receiver<()>>,
     pub(crate) relayed_bytes: AtomicUsize,
@@ -103,7 +103,7 @@ impl Allocation {
             permissions: Arc::new(Mutex::new(HashMap::new())),
             channel_bindings: Arc::new(Mutex::new(HashMap::new())),
             allocations: None,
-            reset_tx: StdMutex::new(None),
+            reset_tx: SyncMutex::new(None),
             timer_expired: Arc::new(AtomicBool::new(false)),
             closed: AtomicBool::new(false),
             relayed_bytes: Default::default(),
@@ -246,11 +246,7 @@ impl Allocation {
     pub async fn start(&self, lifetime: Duration) {
         let (reset_tx, mut reset_rx) = mpsc::channel(1);
         {
-            // Won't panic since we only do set/take/clone one-liners.
-            self.reset_tx
-                .lock()
-                .expect("Allocation::reset_tx is poisoned")
-                .replace(reset_tx);
+            self.reset_tx.lock().replace(reset_tx);
         }
 
         let allocations = self.allocations.clone();
@@ -288,25 +284,13 @@ impl Allocation {
     }
 
     fn stop(&self) -> bool {
-        let reset_tx = {
-            // Won't panic since we only do set/take/clone one-liners.
-            self.reset_tx
-                .lock()
-                .expect("Allocation::reset_tx is poisoned")
-                .take()
-        };
+        let reset_tx = { self.reset_tx.lock().take() };
         reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst)
     }
 
     // Refresh updates the allocations lifetime
     pub async fn refresh(&self, lifetime: Duration) {
-        let reset_tx = {
-            // Won't panic since we only do set/take/clone one-liners.
-            self.reset_tx
-                .lock()
-                .expect("Allocation::reset_tx is poisoned")
-                .clone()
-        };
+        let reset_tx = { self.reset_tx.lock().clone() };
         if let Some(tx) = reset_tx {
             let _ = tx.send(lifetime).await;
         }

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -245,9 +245,7 @@ impl Allocation {
 
     pub async fn start(&self, lifetime: Duration) {
         let (reset_tx, mut reset_rx) = mpsc::channel(1);
-        {
-            self.reset_tx.lock().replace(reset_tx);
-        }
+        self.reset_tx.lock().replace(reset_tx);
 
         let allocations = self.allocations.clone();
         let five_tuple = self.five_tuple;
@@ -284,13 +282,13 @@ impl Allocation {
     }
 
     fn stop(&self) -> bool {
-        let reset_tx = { self.reset_tx.lock().take() };
+        let reset_tx = self.reset_tx.lock().take();
         reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst)
     }
 
     // Refresh updates the allocations lifetime
     pub async fn refresh(&self, lifetime: Duration) {
-        let reset_tx = { self.reset_tx.lock().clone() };
+        let reset_tx = self.reset_tx.lock().clone();
         if let Some(tx) = reset_tx {
             let _ = tx.send(lifetime).await;
         }

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -341,7 +341,7 @@ impl Allocation {
 
                 log::debug!(
                     "relay socket {:?} received {} bytes from {}",
-                    relay_socket.local_addr().await,
+                    relay_socket.local_addr(),
                     n,
                     src_addr
                 );

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -288,15 +288,14 @@ impl Allocation {
     }
 
     fn stop(&self) -> bool {
-        let mut reset_tx = {
+        let reset_tx = {
             // Won't panic since we only do set/take/clone one-liners.
             self.reset_tx
                 .lock()
                 .expect("Allocation::reset_tx is poisoned")
                 .take()
         };
-        let expired = reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst);
-        expired
+        reset_tx.is_none() || self.timer_expired.load(Ordering::SeqCst)
     }
 
     // Refresh updates the allocations lifetime

--- a/turn/src/client/mod.rs
+++ b/turn/src/client/mod.rs
@@ -166,7 +166,7 @@ impl ClientInternal {
             String::new()
         } else {
             log::debug!("resolving {}", config.stun_serv_addr);
-            let local_addr = config.conn.local_addr().await?;
+            let local_addr = config.conn.local_addr()?;
             let stun_serv = net
                 .resolve_addr(local_addr.is_ipv4(), &config.stun_serv_addr)
                 .await?;
@@ -178,7 +178,7 @@ impl ClientInternal {
             String::new()
         } else {
             log::debug!("resolving {}", config.turn_serv_addr);
-            let local_addr = config.conn.local_addr().await?;
+            let local_addr = config.conn.local_addr()?;
             let turn_serv = net
                 .resolve_addr(local_addr.is_ipv4(), &config.turn_serv_addr)
                 .await?;

--- a/turn/src/client/mod.rs
+++ b/turn/src/client/mod.rs
@@ -103,7 +103,7 @@ impl RelayConnObserver for ClientInternal {
         to: &str,
         ignore_result: bool,
     ) -> Result<TransactionResult> {
-        let tr_key = base64::encode(&msg.transaction_id.0);
+        let tr_key = base64::encode(msg.transaction_id.0);
 
         let mut tr = Transaction::new(TransactionConfig {
             key: tr_key.clone(),
@@ -341,7 +341,7 @@ impl ClientInternal {
         // - stun.ClassSuccessResponse
         // - stun.ClassErrorResponse
 
-        let tr_key = base64::encode(&msg.transaction_id.0);
+        let tr_key = base64::encode(msg.transaction_id.0);
 
         let mut tm = tr_map.lock().await;
         if tm.find(&tr_key).is_none() {

--- a/turn/src/client/relay_conn.rs
+++ b/turn/src/client/relay_conn.rs
@@ -167,11 +167,11 @@ impl<T: RelayConnObserver + Send + Sync> Conn for RelayConn<T> {
     }
 
     // LocalAddr returns the local network address.
-    async fn local_addr(&self) -> Result<SocketAddr, util::Error> {
+    fn local_addr(&self) -> Result<SocketAddr, util::Error> {
         Ok(self.relayed_addr)
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/turn/src/relay/relay_none.rs
+++ b/turn/src/relay/relay_none.rs
@@ -33,7 +33,7 @@ impl RelayAddressGenerator for RelayAddressGeneratorNone {
             .resolve_addr(use_ipv4, &format!("{}:{}", self.address, requested_port))
             .await?;
         let conn = self.net.bind(addr).await?;
-        let relay_addr = conn.local_addr().await?;
+        let relay_addr = conn.local_addr()?;
         Ok((conn, relay_addr))
     }
 }

--- a/turn/src/relay/relay_range.rs
+++ b/turn/src/relay/relay_range.rs
@@ -60,7 +60,7 @@ impl RelayAddressGenerator for RelayAddressGeneratorRanges {
                 .resolve_addr(use_ipv4, &format!("{}:{}", self.address, requested_port))
                 .await?;
             let conn = self.net.bind(addr).await?;
-            let mut relay_addr = conn.local_addr().await?;
+            let mut relay_addr = conn.local_addr()?;
             relay_addr.set_ip(self.relay_address);
             return Ok((conn, relay_addr));
         }
@@ -76,7 +76,7 @@ impl RelayAddressGenerator for RelayAddressGeneratorRanges {
                 Err(_) => continue,
             };
 
-            let mut relay_addr = conn.local_addr().await?;
+            let mut relay_addr = conn.local_addr()?;
             relay_addr.set_ip(self.relay_address);
             return Ok((conn, relay_addr));
         }

--- a/turn/src/relay/relay_static.rs
+++ b/turn/src/relay/relay_static.rs
@@ -39,7 +39,7 @@ impl RelayAddressGenerator for RelayAddressGeneratorStatic {
             .resolve_addr(use_ipv4, &format!("{}:{}", self.address, requested_port))
             .await?;
         let conn = self.net.bind(addr).await?;
-        let mut relay_addr = conn.local_addr().await?;
+        let mut relay_addr = conn.local_addr()?;
         relay_addr.set_ip(self.relay_address);
         return Ok((conn, relay_addr));
     }

--- a/turn/src/server/request.rs
+++ b/turn/src/server/request.rs
@@ -296,7 +296,7 @@ impl Request {
 
         let five_tuple = FiveTuple {
             src_addr: self.src_addr,
-            dst_addr: self.conn.local_addr().await?,
+            dst_addr: self.conn.local_addr()?,
             protocol: PROTO_UDP,
         };
         let mut requested_port = 0;
@@ -565,7 +565,7 @@ impl Request {
         let lifetime_duration = allocation_lifetime(m);
         let five_tuple = FiveTuple {
             src_addr: self.src_addr,
-            dst_addr: self.conn.local_addr().await?,
+            dst_addr: self.conn.local_addr()?,
             protocol: PROTO_UDP,
         };
 
@@ -599,7 +599,7 @@ impl Request {
             .allocation_manager
             .get_allocation(&FiveTuple {
                 src_addr: self.src_addr,
-                dst_addr: self.conn.local_addr().await?,
+                dst_addr: self.conn.local_addr()?,
                 protocol: PROTO_UDP,
             })
             .await;
@@ -666,7 +666,7 @@ impl Request {
             .allocation_manager
             .get_allocation(&FiveTuple {
                 src_addr: self.src_addr,
-                dst_addr: self.conn.local_addr().await?,
+                dst_addr: self.conn.local_addr()?,
                 protocol: PROTO_UDP,
             })
             .await;
@@ -707,7 +707,7 @@ impl Request {
             .allocation_manager
             .get_allocation(&FiveTuple {
                 src_addr: self.src_addr,
-                dst_addr: self.conn.local_addr().await?,
+                dst_addr: self.conn.local_addr()?,
                 protocol: PROTO_UDP,
             })
             .await;
@@ -776,7 +776,7 @@ impl Request {
             .allocation_manager
             .get_allocation(&FiveTuple {
                 src_addr: self.src_addr,
-                dst_addr: self.conn.local_addr().await?,
+                dst_addr: self.conn.local_addr()?,
                 protocol: PROTO_UDP,
             })
             .await;

--- a/turn/src/server/request/request_test.rs
+++ b/turn/src/server/request/request_test.rs
@@ -82,7 +82,7 @@ async fn test_allocation_lifetime_deletion_zero_lifetime() -> Result<()> {
 
     let five_tuple = FiveTuple {
         src_addr: r.src_addr,
-        dst_addr: r.conn.local_addr().await?,
+        dst_addr: r.conn.local_addr()?,
         protocol: PROTO_UDP,
     };
 

--- a/turn/src/server/server_test.rs
+++ b/turn/src/server/server_test.rs
@@ -275,12 +275,12 @@ async fn test_server_vnet_echo_via_relay() -> Result<()> {
 
     log::debug!("sending a binding request.");
     let conn = client.allocate().await?;
-    let local_addr = conn.local_addr().await?;
+    let local_addr = conn.local_addr()?;
 
-    log::debug!("laddr: {}", conn.local_addr().await?);
+    log::debug!("laddr: {}", conn.local_addr()?);
 
     let echo_conn = v.net1.bind(SocketAddr::from_str("1.2.3.5:5678")?).await?;
-    let echo_addr = echo_conn.local_addr().await?;
+    let echo_addr = echo_conn.local_addr()?;
 
     let (done_tx, mut done_rx) = mpsc::channel::<()>(1);
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-#### Breaking changes
+### Breaking changes
 
 * Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
     - `Bridge`:

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
+    - `Bridge`:
+        - `drop_next_nwrites`;
+        - `reorder_next_nwrites`.
+    - `Conn`:
+        - `local_addr`;
+        - `remote_addr`.
+
 ## v0.6.0
 
 * Increase min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+#### Breaking changes
+
 * Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
     - `Bridge`:
         - `drop_next_nwrites`;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -30,7 +30,6 @@ log = "0.4.16"
 rand = "0.8.5"
 bytes = "1"
 thiserror = "~1.0.2"
-parking_lot = "0.12.1"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.24.1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60.0"
 [features]
 default = ["buffer", "conn", "ifaces", "vnet", "marshal", "sync"]
 buffer = []
-conn = ["buffer"]
+conn = ["buffer", "sync"]
 ifaces = []
 vnet = ["ifaces"]
 marshal = []

--- a/util/src/conn/conn_bridge.rs
+++ b/util/src/conn/conn_bridge.rs
@@ -53,11 +53,11 @@ impl Conn for BridgeConn {
         Err(Error::new(ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Err(Error::new(ErrorKind::AddrNotAvailable, "Addr Not Available").into())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 
@@ -166,13 +166,13 @@ impl Bridge {
 
     /// drop_next_nwrites drops the next n packets that will be written
     /// to the specified queue.
-    pub async fn drop_next_nwrites(&self, id: usize, n: usize) {
+    pub fn drop_next_nwrites(&self, id: usize, n: usize) {
         self.drop_nwrites[id].store(n, Ordering::SeqCst);
     }
 
     /// reorder_next_nwrites drops the next n packets that will be written
     /// to the specified queue.
-    pub async fn reorder_next_nwrites(&self, id: usize, n: usize) {
+    pub fn reorder_next_nwrites(&self, id: usize, n: usize) {
         self.reorder_nwrites[id].store(n, Ordering::SeqCst);
     }
 

--- a/util/src/conn/conn_bridge_test.rs
+++ b/util/src/conn/conn_bridge_test.rs
@@ -215,7 +215,7 @@ async fn test_bridge_inverse_error() -> Result<()> {
 async fn test_bridge_drop_next_n_packets() -> Result<()> {
     for id in 0..2 {
         let (br, conn0, conn1) = Bridge::new(0, None, None);
-        br.drop_next_nwrites(id, 3).await;
+        br.drop_next_nwrites(id, 3);
         let conns: Vec<Arc<dyn Conn + Send + Sync>> = vec![Arc::new(conn0), Arc::new(conn1)];
         let src_conn = Arc::clone(&conns[id]);
         let dst_conn = Arc::clone(&conns[1 - id]);

--- a/util/src/conn/conn_disconnected_packet.rs
+++ b/util/src/conn/conn_disconnected_packet.rs
@@ -29,9 +29,7 @@ impl Conn for DisconnectedPacketConn {
 
     async fn recv(&self, buf: &mut [u8]) -> Result<usize> {
         let (n, addr) = self.pconn.recv_from(buf).await?;
-        {
-            *self.raddr.write() = addr;
-        }
+        *self.raddr.write() = addr;
         Ok(n)
     }
 
@@ -40,7 +38,7 @@ impl Conn for DisconnectedPacketConn {
     }
 
     async fn send(&self, buf: &[u8]) -> Result<usize> {
-        let addr = { *self.raddr.read() };
+        let addr = *self.raddr.read();
         self.pconn.send_to(buf, addr).await
     }
 
@@ -53,7 +51,7 @@ impl Conn for DisconnectedPacketConn {
     }
 
     fn remote_addr(&self) -> Option<SocketAddr> {
-        let raddr = { *self.raddr.read() };
+        let raddr = *self.raddr.read();
         Some(raddr)
     }
 

--- a/util/src/conn/conn_disconnected_packet.rs
+++ b/util/src/conn/conn_disconnected_packet.rs
@@ -1,8 +1,9 @@
 use super::*;
 
-use crate::sync::RwLock;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
+
+use crate::sync::RwLock;
 
 /// Since UDP is connectionless, as a server, it doesn't know how to reply
 /// simply using the `Write` method. So, to make it work, `disconnectedPacketConn`

--- a/util/src/conn/conn_pipe.rs
+++ b/util/src/conn/conn_pipe.rs
@@ -61,11 +61,11 @@ impl Conn for Pipe {
         Err(Error::new(ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Err(Error::new(ErrorKind::AddrNotAvailable, "Addr Not Available").into())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/util/src/conn/conn_udp.rs
+++ b/util/src/conn/conn_udp.rs
@@ -24,11 +24,11 @@ impl Conn for UdpSocket {
         Ok(self.send_to(buf, target).await?)
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.local_addr()?)
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/util/src/conn/conn_udp_listener.rs
+++ b/util/src/conn/conn_udp_listener.rs
@@ -69,7 +69,7 @@ impl Listener for ListenerImpl {
 
     /// Addr returns the listener's network address.
     async fn addr(&self) -> Result<SocketAddr> {
-        self.pconn.local_addr().await
+        self.pconn.local_addr()
     }
 }
 
@@ -277,11 +277,11 @@ impl Conn for UdpConn {
         self.pconn.send_to(buf, target).await
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
-        self.pconn.local_addr().await
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.pconn.local_addr()
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         Some(self.raddr)
     }
 

--- a/util/src/conn/conn_udp_listener_test.rs
+++ b/util/src/conn/conn_udp_listener_test.rs
@@ -29,7 +29,7 @@ async fn pipe() -> Result<(
     let (l_conn, raddr) = listener.accept().await?;
     assert_eq!(daddr, raddr, "remote address should be match");
 
-    let raddr = l_conn.remote_addr().await;
+    let raddr = l_conn.remote_addr();
     if let Some(raddr) = raddr {
         assert_eq!(daddr, raddr, "remote address should be match");
     } else {

--- a/util/src/conn/mod.rs
+++ b/util/src/conn/mod.rs
@@ -30,8 +30,8 @@ pub trait Conn {
     async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)>;
     async fn send(&self, buf: &[u8]) -> Result<usize>;
     async fn send_to(&self, buf: &[u8], target: SocketAddr) -> Result<usize>;
-    async fn local_addr(&self) -> Result<SocketAddr>;
-    async fn remote_addr(&self) -> Option<SocketAddr>;
+    fn local_addr(&self) -> Result<SocketAddr>;
+    fn remote_addr(&self) -> Option<SocketAddr>;
     async fn close(&self) -> Result<()>;
 }
 

--- a/util/src/fixed_big_int/mod.rs
+++ b/util/src/fixed_big_int/mod.rs
@@ -81,11 +81,7 @@ impl FixedBigInt {
         }
         let chunk = i / 64;
         let pos = i % 64;
-        if self.bits[chunk] & (1 << pos) != 0 {
-            1
-        } else {
-            0
-        }
+        usize::from(self.bits[chunk] & (1 << pos) != 0)
     }
 
     // set_bit sets i-th bit to 1.

--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -80,7 +80,7 @@ impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
     }
 }
 
-/// RAII structure used to release the shared read access of a lock when
+/// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
 pub struct RwLockWriteGuard<'a, T>(sync::RwLockWriteGuard<'a, T>);
 

--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -46,14 +46,16 @@ impl<T> RwLock<T> {
         Self(sync::RwLock::new(value))
     }
 
-    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    /// Locks this rwlock with shared read access, blocking the current thread
+    /// until it can be acquired.
     pub fn read(&self) -> RwLockReadGuard<'_, T> {
         let guard = self.0.read().unwrap();
 
         RwLockReadGuard(guard)
     }
 
-    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    /// Locks this rwlock with exclusive write access, blocking the current
+    /// thread until it can be acquired.
     pub fn write(&self) -> RwLockWriteGuard<'_, T> {
         let guard = self.0.write().unwrap();
 

--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -1,8 +1,92 @@
-/// A synchronous mutual exclusion primitive useful for protecting shared data
-pub type Mutex<T> = parking_lot::Mutex<T>;
+use std::{ops, sync};
 
-/// A synchronous reader-writer lock
-pub type RwLock<T> = parking_lot::RwLock<T>;
+/// A synchronous mutual exclusion primitive useful for protecting shared data.
+#[derive(Default)]
+pub struct Mutex<T>(sync::Mutex<T>);
 
-/// A synchronization primitive which can be used to run a one-time initialization.
-pub type Once = parking_lot::Once;
+impl<T> Mutex<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    pub fn new(value: T) -> Self {
+        Self(sync::Mutex::new(value))
+    }
+
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        let guard = self.0.lock().unwrap();
+
+        MutexGuard(guard)
+    }
+}
+
+/// An RAII implementation of a "scoped lock" of a mutex. When this structure is
+/// dropped (falls out of scope), the lock will be unlocked.
+pub struct MutexGuard<'a, T>(sync::MutexGuard<'a, T>);
+
+impl<'a, T> ops::Deref for MutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// A synchronous reader-writer lock.
+#[derive(Default)]
+pub struct RwLock<T>(sync::RwLock<T>);
+
+impl<T> RwLock<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    pub fn new(value: T) -> Self {
+        Self(sync::RwLock::new(value))
+    }
+
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        let guard = self.0.read().unwrap();
+
+        RwLockReadGuard(guard)
+    }
+
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        let guard = self.0.write().unwrap();
+
+        RwLockWriteGuard(guard)
+    }
+}
+
+/// RAII structure used to release the shared read access of a lock when
+/// dropped.
+pub struct RwLockReadGuard<'a, T>(sync::RwLockReadGuard<'a, T>);
+
+impl<'a, T> ops::Deref for RwLockReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// RAII structure used to release the shared read access of a lock when
+/// dropped.
+pub struct RwLockWriteGuard<'a, T>(sync::RwLockWriteGuard<'a, T>);
+
+impl<'a, T> ops::Deref for RwLockWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T> ops::DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -1,7 +1,7 @@
 use std::{ops, sync};
 
 /// A synchronous mutual exclusion primitive useful for protecting shared data.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Mutex<T>(sync::Mutex<T>);
 
 impl<T> Mutex<T> {
@@ -15,6 +15,11 @@ impl<T> Mutex<T> {
         let guard = self.0.lock().unwrap();
 
         MutexGuard(guard)
+    }
+
+    /// Consumes this mutex, returning the underlying data.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().unwrap()
     }
 }
 
@@ -37,7 +42,7 @@ impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
 }
 
 /// A synchronous reader-writer lock.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RwLock<T>(sync::RwLock<T>);
 
 impl<T> RwLock<T> {

--- a/util/src/vnet/conn.rs
+++ b/util/src/vnet/conn.rs
@@ -62,9 +62,7 @@ impl UdpConn {
 #[async_trait]
 impl Conn for UdpConn {
     async fn connect(&self, addr: SocketAddr) -> Result<()> {
-        {
-            self.rem_addr.write().replace(addr);
-        }
+        self.rem_addr.write().replace(addr);
 
         Ok(())
     }
@@ -82,7 +80,7 @@ impl Conn for UdpConn {
     /// the n > 0 bytes returned before considering the error err.
     async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
         let mut read_ch = self.read_ch_rx.lock().await;
-        let rem_addr = { *self.rem_addr.read() };
+        let rem_addr = *self.rem_addr.read();
         while let Some(chunk) = read_ch.recv().await {
             let user_data = chunk.user_data();
             let n = std::cmp::min(buf.len(), user_data.len());
@@ -102,7 +100,7 @@ impl Conn for UdpConn {
     }
 
     async fn send(&self, buf: &[u8]) -> Result<usize> {
-        let rem_addr = { *self.rem_addr.read() };
+        let rem_addr = *self.rem_addr.read();
         if let Some(rem_addr) = rem_addr {
             self.send_to(buf, rem_addr).await
         } else {

--- a/util/src/vnet/conn.rs
+++ b/util/src/vnet/conn.rs
@@ -11,6 +11,7 @@ use tokio::sync::{mpsc, Mutex};
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 
 const MAX_READ_QUEUE_SIZE: usize = 1024;
 
@@ -28,7 +29,7 @@ pub(crate) type ChunkChTx = mpsc::Sender<Box<dyn Chunk + Send + Sync>>;
 /// comatible with net.PacketConn and net.Conn
 pub(crate) struct UdpConn {
     loc_addr: SocketAddr,
-    rem_addr: Mutex<Option<SocketAddr>>,
+    rem_addr: StdMutex<Option<SocketAddr>>,
     read_ch_tx: Arc<Mutex<Option<ChunkChTx>>>,
     read_ch_rx: Mutex<mpsc::Receiver<Box<dyn Chunk + Send + Sync>>>,
     closed: AtomicBool,
@@ -45,7 +46,7 @@ impl UdpConn {
 
         UdpConn {
             loc_addr,
-            rem_addr: Mutex::new(rem_addr),
+            rem_addr: StdMutex::new(rem_addr),
             read_ch_tx: Arc::new(Mutex::new(Some(read_ch_tx))),
             read_ch_rx: Mutex::new(read_ch_rx),
             closed: AtomicBool::new(false),
@@ -61,8 +62,7 @@ impl UdpConn {
 #[async_trait]
 impl Conn for UdpConn {
     async fn connect(&self, addr: SocketAddr) -> Result<()> {
-        let mut rem_addr = self.rem_addr.lock().await;
-        *rem_addr = Some(addr);
+        self.rem_addr.lock().unwrap().replace(addr);
 
         Ok(())
     }
@@ -80,14 +80,14 @@ impl Conn for UdpConn {
     /// the n > 0 bytes returned before considering the error err.
     async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
         let mut read_ch = self.read_ch_rx.lock().await;
+        let rem_addr = { *self.rem_addr.lock().unwrap() };
         while let Some(chunk) = read_ch.recv().await {
             let user_data = chunk.user_data();
             let n = std::cmp::min(buf.len(), user_data.len());
             buf[..n].copy_from_slice(&user_data[..n]);
             let addr = chunk.source_addr();
             {
-                let rem_addr = self.rem_addr.lock().await;
-                if let Some(rem_addr) = &*rem_addr {
+                if let Some(rem_addr) = &rem_addr {
                     if &addr != rem_addr {
                         continue; // discard (shouldn't happen)
                     }
@@ -100,10 +100,7 @@ impl Conn for UdpConn {
     }
 
     async fn send(&self, buf: &[u8]) -> Result<usize> {
-        let rem_addr = {
-            let rem_addr = self.rem_addr.lock().await;
-            *rem_addr
-        };
+        let rem_addr = { *self.rem_addr.lock().unwrap() };
         if let Some(rem_addr) = rem_addr {
             self.send_to(buf, rem_addr).await
         } else {
@@ -135,13 +132,12 @@ impl Conn for UdpConn {
         Ok(buf.len())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.loc_addr)
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
-        let rem_addr = self.rem_addr.lock().await;
-        *rem_addr
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        *self.rem_addr.lock().unwrap()
     }
 
     async fn close(&self) -> Result<()> {

--- a/util/src/vnet/conn_map.rs
+++ b/util/src/vnet/conn_map.rs
@@ -25,7 +25,7 @@ impl UdpConnMap {
     }
 
     pub(crate) async fn insert(&self, conn: Arc<UdpConn>) -> Result<()> {
-        let addr = conn.local_addr().await?;
+        let addr = conn.local_addr()?;
 
         let mut port_map = self.port_map.lock().await;
         if let Some(conns) = port_map.get(&addr.port()) {
@@ -34,7 +34,7 @@ impl UdpConnMap {
             }
 
             for c in conns {
-                let laddr = c.local_addr().await?;
+                let laddr = c.local_addr()?;
                 if laddr.ip().is_unspecified() || laddr.ip() == addr.ip() {
                     return Err(Error::ErrAddressAlreadyInUse);
                 }
@@ -63,7 +63,7 @@ impl UdpConnMap {
 
             for c in conns {
                 let laddr = {
-                    match c.local_addr().await {
+                    match c.local_addr() {
                         Ok(laddr) => laddr,
                         Err(_) => return None,
                     }
@@ -83,7 +83,7 @@ impl UdpConnMap {
         if let Some(conns) = port_map.get(&addr.port()) {
             if !addr.ip().is_unspecified() {
                 for c in conns {
-                    let laddr = c.local_addr().await?;
+                    let laddr = c.local_addr()?;
                     if laddr.ip().is_unspecified() {
                         // This can't happen!
                         return Err(Error::ErrCannotRemoveUnspecifiedIp);

--- a/util/src/vnet/conn_map/conn_map_test.rs
+++ b/util/src/vnet/conn_map/conn_map_test.rs
@@ -37,25 +37,25 @@ async fn test_udp_conn_map_insert_remove() -> Result<()> {
 
     conn_map.insert(Arc::clone(&conn_in)).await?;
 
-    let conn_out = conn_map.find(&conn_in.local_addr().await?).await;
+    let conn_out = conn_map.find(&conn_in.local_addr()?).await;
     assert!(conn_out.is_some(), "should succeed");
     if let Some(conn_out) = conn_out {
         assert_eq!(
-            conn_in.local_addr().await?,
-            conn_out.local_addr().await?,
+            conn_in.local_addr()?,
+            conn_out.local_addr()?,
             "should match"
         );
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(1, port_map.len(), "should match");
     }
 
-    conn_map.delete(&conn_in.local_addr().await?).await?;
+    conn_map.delete(&conn_in.local_addr()?).await?;
     {
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(0, port_map.len(), "should match");
     }
 
-    let result = conn_map.delete(&conn_in.local_addr().await?).await;
+    let result = conn_map.delete(&conn_in.local_addr()?).await;
     assert!(result.is_err(), "should fail");
 
     Ok(())
@@ -76,25 +76,25 @@ async fn test_udp_conn_map_insert_0_remove() -> Result<()> {
 
     conn_map.insert(Arc::clone(&conn_in)).await?;
 
-    let conn_out = conn_map.find(&conn_in.local_addr().await?).await;
+    let conn_out = conn_map.find(&conn_in.local_addr()?).await;
     assert!(conn_out.is_some(), "should succeed");
     if let Some(conn_out) = conn_out {
         assert_eq!(
-            conn_in.local_addr().await?,
-            conn_out.local_addr().await?,
+            conn_in.local_addr()?,
+            conn_out.local_addr()?,
             "should match"
         );
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(1, port_map.len(), "should match");
     }
 
-    conn_map.delete(&conn_in.local_addr().await?).await?;
+    conn_map.delete(&conn_in.local_addr()?).await?;
     {
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(0, port_map.len(), "should match");
     }
 
-    let result = conn_map.delete(&conn_in.local_addr().await?).await;
+    let result = conn_map.delete(&conn_in.local_addr()?).await;
     assert!(result.is_err(), "should fail");
 
     Ok(())
@@ -119,8 +119,8 @@ async fn test_udp_conn_map_find_0() -> Result<()> {
     let conn_out = conn_map.find(&addr).await;
     assert!(conn_out.is_some(), "should succeed");
     if let Some(conn_out) = conn_out {
-        let addr_in = conn_in.local_addr().await?;
-        let addr_out = conn_out.local_addr().await?;
+        let addr_in = conn_in.local_addr()?;
+        let addr_out = conn_out.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(1, port_map.len(), "should match");
@@ -155,8 +155,8 @@ async fn test_udp_conn_map_insert_many_ips_with_same_port() -> Result<()> {
     let conn_out1 = conn_map.find(&addr1).await;
     assert!(conn_out1.is_some(), "should succeed");
     if let Some(conn_out1) = conn_out1 {
-        let addr_in = conn_in1.local_addr().await?;
-        let addr_out = conn_out1.local_addr().await?;
+        let addr_in = conn_in1.local_addr()?;
+        let addr_out = conn_out1.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(1, port_map.len(), "should match");
@@ -166,8 +166,8 @@ async fn test_udp_conn_map_insert_many_ips_with_same_port() -> Result<()> {
     let conn_out2 = conn_map.find(&addr2).await;
     assert!(conn_out2.is_some(), "should succeed");
     if let Some(conn_out2) = conn_out2 {
-        let addr_in = conn_in2.local_addr().await?;
-        let addr_out = conn_out2.local_addr().await?;
+        let addr_in = conn_in2.local_addr()?;
+        let addr_out = conn_out2.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
         assert_eq!(1, port_map.len(), "should match");
@@ -316,8 +316,8 @@ async fn test_udp_conn_map_insert_two_on_same_port_then_remove() -> Result<()> {
     conn_map.insert(Arc::clone(&conn_in1)).await?;
     conn_map.insert(Arc::clone(&conn_in2)).await?;
 
-    conn_map.delete(&conn_in1.local_addr().await?).await?;
-    conn_map.delete(&conn_in2.local_addr().await?).await?;
+    conn_map.delete(&conn_in1.local_addr()?).await?;
+    conn_map.delete(&conn_in2.local_addr()?).await?;
 
     Ok(())
 }

--- a/util/src/vnet/net/net_test.rs
+++ b/util/src/vnet/net/net_test.rs
@@ -59,7 +59,7 @@ async fn test_net_native_bind() -> Result<()> {
     assert!(!nw.is_virtual(), "should be false");
 
     let conn = nw.bind(SocketAddr::from_str("127.0.0.1:0")?).await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.ip().to_string(),
         "127.0.0.1",
@@ -76,7 +76,7 @@ async fn test_net_native_dail() -> Result<()> {
     assert!(!nw.is_virtual(), "should be false");
 
     let conn = nw.dail(true, "127.0.0.1:1234").await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.ip().to_string(),
         "127.0.0.1",
@@ -94,7 +94,7 @@ async fn test_net_native_loopback() -> Result<()> {
     assert!(!nw.is_virtual(), "should be false");
 
     let conn = nw.bind(SocketAddr::from_str("127.0.0.1:0")?).await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
 
     let msg = "PING!";
     let n = conn.send_to(msg.as_bytes(), laddr).await?;
@@ -414,7 +414,7 @@ async fn test_net_virtual_loopback1() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let conn = nw.bind(SocketAddr::from_str("127.0.0.1:0")?).await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
 
     let msg = "PING!";
     let n = conn.send_to(msg.as_bytes(), laddr).await?;
@@ -440,7 +440,7 @@ async fn test_net_virtual_bind_specific_port() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let conn = nw.bind(SocketAddr::from_str("127.0.0.1:50916")?).await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.ip().to_string().as_str(),
         "127.0.0.1",
@@ -458,7 +458,7 @@ async fn test_net_virtual_dail_lo0() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let conn = nw.dail(true, "127.0.0.1:1234").await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.ip().to_string().as_str(),
         "127.0.0.1",
@@ -490,7 +490,7 @@ async fn test_net_virtual_dail_eth0() -> Result<()> {
     };
 
     let conn = nw.dail(true, "27.3.4.5:1234").await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.ip().to_string().as_str(),
         "1.2.3.1",
@@ -536,7 +536,7 @@ async fn test_net_virtual_resolver() -> Result<()> {
             (nw.dail(true, "test.webrtc.rs:1234").await?, raddr)
         };
 
-        let laddr = conn.local_addr().await?;
+        let laddr = conn.local_addr()?;
         assert_eq!(
             laddr.ip().to_string().as_str(),
             "1.2.3.1",
@@ -566,7 +566,7 @@ async fn test_net_virtual_loopback2() -> Result<()> {
     let nw = Net::new(Some(NetConfig::default()));
 
     let conn = nw.bind(SocketAddr::from_str("127.0.0.1:50916")?).await?;
-    let laddr = conn.local_addr().await?;
+    let laddr = conn.local_addr()?;
     assert_eq!(
         laddr.to_string().as_str(),
         "127.0.0.1:50916",
@@ -770,7 +770,7 @@ async fn test_net_virtual_end2end() -> Result<()> {
     });
 
     log::debug!("conn1: sending");
-    let n = conn1.send_to(b"Hello!", conn2.local_addr().await?).await?;
+    let n = conn1.send_to(b"Hello!", conn2.local_addr()?).await?;
     assert_eq!(6, n, "should match");
 
     let _ = conn1_recv_ch_rx.recv().await;
@@ -902,7 +902,7 @@ async fn test_net_virtual_two_ips_on_a_nic() -> Result<()> {
     });
 
     log::debug!("conn1: sending");
-    let n = conn1.send_to(b"Hello!", conn2.local_addr().await?).await?;
+    let n = conn1.send_to(b"Hello!", conn2.local_addr()?).await?;
     assert_eq!(6, n, "should match");
 
     let _ = conn1_recv_ch_rx.recv().await;

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -63,7 +63,7 @@ change for MediaEngine::register_header_extension
 
 ### Changes
 
-### Breaking changes
+#### Breaking changes
 
 * The serialized format for `RTCIceCandidateInit` has changed to match what the specification i.e. keys are camelCase. [#153 Make RTCIceCandidateInit conform to WebRTC spec](https://github.com/webrtc-rs/webrtc/pull/153) contributed by [jmatss](https://github.com/jmatss).
 * Improved robustness when proposing RTP extension IDs and handling of collisions in these. This change is only breaking if you have assumed anything about the nature of these extension IDs. [#154 Fix RTP extension id collision](https://github.com/webrtc-rs/webrtc/pull/154) contributed by [k0nserv](https://github.com/k0nserv)

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -11,6 +11,35 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
 * Fixed a panic that would sometimes happen when collecting stats. [#327](https://github.com/webrtc-rs/webrtc/pull/327) by [@k0nserv](https://github.com/k0nserv).
 * Added new extension marshaller/unmarshaller for VideoOrientation, and made marshallers serializable via serde [#331](https://github.com/webrtc-rs/webrtc/pull/331) [#332](https://github.com/webrtc-rs/webrtc/pull/332)
 * Updated minimum rust version to `1.60.0`
+* Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
+    - `RTCDataChannel`:
+        - `on_open`;
+        - `on_close`;
+        - `on_message`;
+        - `on_error`.
+    - `RTCDtlsTransport::on_state_change`;
+    - `RTCIceCandidate::to_json`;
+    - `RTCIceGatherer`:
+        - `on_local_candidate`;
+        - `on_state_change`;
+        - `on_gathering_complete`.
+    - `RTCIceTransport`:
+        - `get_selected_candidate_pair`;
+        - `on_selected_candidate_pair_change`;
+        - `on_connection_state_change`.
+    - `RTCPeerConnection`:
+        - `on_signaling_state_change`;
+        - `on_data_channel`;
+        - `on_negotiation_needed`;
+        - `on_ice_candidate`;
+        - `on_ice_gathering_state_change`;
+        - `on_track`;
+        - `on_ice_connection_state_change`;
+        - `on_peer_connection_state_change`.
+    - `RTCSctpTransport`:
+        - `on_error`;
+        - `on_data_channel`;
+        - `on_data_channel_opened`.
 
 
 #### Breaking changes

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -13,6 +13,13 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
 * Updated minimum rust version to `1.60.0`
 * Added a new `write_rtp_with_extensions` method to `TrackLocalStaticSample` and `TrackLocalStatiRTP`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
 * Added a new `sample_writer` helper to `TrackLocalStaticSample`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
+
+
+#### Breaking changes
+
+* Allow one single direction for extmap matching. [#321](https://github.com/webrtc-rs/webrtc/pull/321). API
+change for MediaEngine::register_header_extension
+* Removes support for Plan-B. All major implementations of WebRTC now support unified and continuing support for plan-b is an undue maintenance burden when unified can be used. See [“Unified Plan” Transition Guide (JavaScript)](https://docs.google.com/document/d/1-ZfikoUtoJa9k-GZG1daN0BU3IjIanQ_JSscHxQesvU/) for an overview of the changes required to migrate. [#320](https://github.com/webrtc-rs/webrtc/pull/320) by [@algesten](https://github.com/algesten).
 * Make functions non-async [#338](https://github.com/webrtc-rs/webrtc/pull/338):
     - `RTCDataChannel`:
         - `on_open`;
@@ -42,14 +49,6 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
         - `on_error`;
         - `on_data_channel`;
         - `on_data_channel_opened`.
-
-
-#### Breaking changes
-
-* Allow one single direction for extmap matching. [#321](https://github.com/webrtc-rs/webrtc/pull/321). API
-change for MediaEngine::register_header_extension
-* Removes support for Plan-B. All major implementations of WebRTC now support unified and continuing support for plan-b is an undue maintenance burden when unified can be used. See [“Unified Plan” Transition Guide (JavaScript)](https://docs.google.com/document/d/1-ZfikoUtoJa9k-GZG1daN0BU3IjIanQ_JSscHxQesvU/) for an overview of the changes required to migrate. [#320](https://github.com/webrtc-rs/webrtc/pull/320) by [@algesten](https://github.com/algesten).
-
 
 ## 0.5.1
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -14,7 +14,7 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
 * Added a new `write_rtp_with_extensions` method to `TrackLocalStaticSample` and `TrackLocalStatiRTP`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
 * Added a new `sample_writer` helper to `TrackLocalStaticSample`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
 
-#### Breaking changes
+### Breaking changes
 
 * Allow one single direction for extmap matching. [#321](https://github.com/webrtc-rs/webrtc/pull/321). API
 change for MediaEngine::register_header_extension
@@ -63,7 +63,7 @@ change for MediaEngine::register_header_extension
 
 ### Changes
 
-#### Breaking changes
+### Breaking changes
 
 * The serialized format for `RTCIceCandidateInit` has changed to match what the specification i.e. keys are camelCase. [#153 Make RTCIceCandidateInit conform to WebRTC spec](https://github.com/webrtc-rs/webrtc/pull/153) contributed by [jmatss](https://github.com/jmatss).
 * Improved robustness when proposing RTP extension IDs and handling of collisions in these. This change is only breaking if you have assumed anything about the nature of these extension IDs. [#154 Fix RTP extension id collision](https://github.com/webrtc-rs/webrtc/pull/154) contributed by [k0nserv](https://github.com/k0nserv)

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -29,6 +29,7 @@ stun = { version = "0.4.3", path = "../stun" }
 turn = { version = "0.6.0", path = "../turn" }
 util = { version = "0.6.0", path = "../util", package = "webrtc-util" }
 
+arc-swap = "1.5.1"
 tokio = { version = "1.19", features = ["full"] }
 log = "0.4.16"
 async-trait = "0.1.56"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -29,7 +29,7 @@ stun = { version = "0.4.3", path = "../stun" }
 turn = { version = "0.6.0", path = "../turn" }
 util = { version = "0.6.0", path = "../util", package = "webrtc-util" }
 
-arc-swap = "1.5.1"
+arc-swap = "1.5"
 tokio = { version = "1.19", features = ["full"] }
 log = "0.4.16"
 async-trait = "0.1.56"

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -9,12 +9,17 @@ pub mod data_channel_state;
 use data_channel_message::*;
 use data_channel_parameters::*;
 
+use arc_swap::ArcSwapOption;
 use bytes::Bytes;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
-use std::time::SystemTime;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicU16, AtomicU8, AtomicUsize, Ordering},
+        Arc, Mutex as StdMutex, Weak,
+    },
+    time::SystemTime,
+};
 
 use data::message::message_channel_open::ChannelType;
 use sctp::stream::OnBufferedAmountLowFn;
@@ -67,10 +72,10 @@ pub struct RTCDataChannel {
     // is created, the binaryType attribute MUST be initialized to the string
     // "blob". This attribute controls how binary data is exposed to scripts.
     // binaryType                 string
-    pub(crate) on_message_handler: Arc<Mutex<Option<OnMessageHdlrFn>>>,
-    pub(crate) on_open_handler: Arc<Mutex<Option<OnOpenHdlrFn>>>,
-    pub(crate) on_close_handler: Arc<Mutex<Option<OnCloseHdlrFn>>>,
-    pub(crate) on_error_handler: Arc<Mutex<Option<OnErrorHdlrFn>>>,
+    pub(crate) on_message_handler: Arc<ArcSwapOption<Mutex<OnMessageHdlrFn>>>,
+    pub(crate) on_open_handler: StdMutex<Option<OnOpenHdlrFn>>,
+    pub(crate) on_close_handler: Arc<ArcSwapOption<Mutex<OnCloseHdlrFn>>>,
+    pub(crate) on_error_handler: Arc<ArcSwapOption<Mutex<OnErrorHdlrFn>>>,
 
     pub(crate) on_buffered_amount_low: Mutex<Option<OnBufferedAmountLowFn>>,
 
@@ -180,7 +185,7 @@ impl RTCDataChannel {
             {
                 let mut on_buffered_amount_low = self.on_buffered_amount_low.lock().await;
                 if let Some(f) = on_buffered_amount_low.take() {
-                    dc.on_buffered_amount_low(f).await;
+                    dc.on_buffered_amount_low(f);
                 }
             }
 
@@ -200,24 +205,24 @@ impl RTCDataChannel {
 
     /// on_open sets an event handler which is invoked when
     /// the underlying data transport has been established (or re-established).
-    pub async fn on_open(&self, f: OnOpenHdlrFn) {
-        {
-            let mut handler = self.on_open_handler.lock().await;
-            *handler = Some(f);
-        }
+    pub fn on_open(&self, f: OnOpenHdlrFn) {
+        let _ = self.on_open_handler.lock().unwrap().replace(f);
 
         if self.ready_state() == RTCDataChannelState::Open {
-            self.do_open().await;
+            self.do_open();
         }
     }
 
-    async fn do_open(&self) {
-        let on_open_handler = Arc::clone(&self.on_open_handler);
+    fn do_open(&self) {
+        let on_open_handler = self.on_open_handler.lock().unwrap().take();
+        if on_open_handler.is_none() {
+            return;
+        }
+
         let detach_data_channels = self.setting_engine.detach.data_channels;
         let detach_called = Arc::clone(&self.detach_called);
         tokio::spawn(async move {
-            let mut handler = on_open_handler.lock().await;
-            if let Some(f) = handler.take() {
+            if let Some(f) = on_open_handler {
                 f().await;
 
                 // self.check_detach_after_open();
@@ -234,9 +239,8 @@ impl RTCDataChannel {
 
     /// on_close sets an event handler which is invoked when
     /// the underlying data transport has been closed.
-    pub async fn on_close(&self, f: OnCloseHdlrFn) {
-        let mut handler = self.on_close_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_close(&self, f: OnCloseHdlrFn) {
+        self.on_close_handler.store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_message sets an event handler which is invoked on a binary
@@ -245,14 +249,13 @@ impl RTCDataChannel {
     /// in size. Check out the detach API if you want to use larger
     /// message sizes. Note that browser support for larger messages
     /// is also limited.
-    pub async fn on_message(&self, f: OnMessageHdlrFn) {
-        let mut handler = self.on_message_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_message(&self, f: OnMessageHdlrFn) {
+        self.on_message_handler.store(Some(Arc::new(Mutex::new(f))));
     }
 
     async fn do_message(&self, msg: DataChannelMessage) {
-        let mut handler = self.on_message_handler.lock().await;
-        if let Some(f) = &mut *handler {
+        if let Some(hndlr) = &*self.on_message_handler.load() {
+            let mut f = hndlr.lock().await;
             f(msg).await;
         }
     }
@@ -264,7 +267,7 @@ impl RTCDataChannel {
         }
         self.set_ready_state(RTCDataChannelState::Open);
 
-        self.do_open().await;
+        self.do_open();
 
         if !self.setting_engine.detach.data_channels {
             let ready_state = Arc::clone(&self.ready_state);
@@ -288,18 +291,17 @@ impl RTCDataChannel {
 
     /// on_error sets an event handler which is invoked when
     /// the underlying data transport cannot be read.
-    pub async fn on_error(&self, f: OnErrorHdlrFn) {
-        let mut handler = self.on_error_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_error(&self, f: OnErrorHdlrFn) {
+        self.on_error_handler.store(Some(Arc::new(Mutex::new(f))));
     }
 
     async fn read_loop(
         notify_rx: Arc<Notify>,
         data_channel: Arc<data::data_channel::DataChannel>,
         ready_state: Arc<AtomicU8>,
-        on_message_handler: Arc<Mutex<Option<OnMessageHdlrFn>>>,
-        on_close_handler: Arc<Mutex<Option<OnCloseHdlrFn>>>,
-        on_error_handler: Arc<Mutex<Option<OnErrorHdlrFn>>>,
+        on_message_handler: Arc<ArcSwapOption<Mutex<OnMessageHdlrFn>>>,
+        on_close_handler: Arc<ArcSwapOption<Mutex<OnCloseHdlrFn>>>,
+        on_error_handler: Arc<ArcSwapOption<Mutex<OnErrorHdlrFn>>>,
     ) {
         let mut buffer = vec![0u8; DATA_CHANNEL_BUFFER_SIZE as usize];
         loop {
@@ -315,8 +317,8 @@ impl RTCDataChannel {
 
                             let on_close_handler2 = Arc::clone(&on_close_handler);
                             tokio::spawn(async move {
-                                let mut handler = on_close_handler2.lock().await;
-                                if let Some(f) = &mut *handler {
+                                if let Some(hndlr) = &*on_close_handler2.load() {
+                                    let mut f = hndlr.lock().await;
                                     f().await;
                                 }
                             });
@@ -329,16 +331,16 @@ impl RTCDataChannel {
 
                             let on_error_handler2 = Arc::clone(&on_error_handler);
                             tokio::spawn(async move {
-                                let mut handler = on_error_handler2.lock().await;
-                                if let Some(f) = &mut *handler {
+                                if let Some(hndlr) = &*on_error_handler2.load() {
+                                    let mut f = hndlr.lock().await;
                                     f(err.into()).await;
                                 }
                             });
 
                             let on_close_handler2 = Arc::clone(&on_close_handler);
                             tokio::spawn(async move {
-                                let mut handler = on_close_handler2.lock().await;
-                                if let Some(f) = &mut *handler {
+                                if let Some(hndlr) = &*on_close_handler2.load() {
+                                    let mut f = hndlr.lock().await;
                                     f().await;
                                 }
                             });
@@ -349,15 +351,13 @@ impl RTCDataChannel {
                 }
             };
 
-            {
-                let mut handler = on_message_handler.lock().await;
-                if let Some(f) = &mut *handler {
-                    f(DataChannelMessage {
-                        is_string,
-                        data: Bytes::from(buffer[..n].to_vec()),
-                    })
-                    .await;
-                }
+            if let Some(hndlr) = &*on_message_handler.load() {
+                let mut f = hndlr.lock().await;
+                f(DataChannelMessage {
+                    is_string,
+                    data: Bytes::from(buffer[..n].to_vec()),
+                })
+                .await;
             }
         }
     }
@@ -538,7 +538,7 @@ impl RTCDataChannel {
     pub async fn on_buffered_amount_low(&self, f: OnBufferedAmountLowFn) {
         let data_channel = self.data_channel.lock().await;
         if let Some(dc) = &*data_channel {
-            dc.on_buffered_amount_low(f).await;
+            dc.on_buffered_amount_low(f);
         } else {
             let mut on_buffered_amount_low = self.on_buffered_amount_low.lock().await;
             *on_buffered_amount_low = Some(f);

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -207,9 +207,7 @@ impl RTCDataChannel {
     /// on_open sets an event handler which is invoked when
     /// the underlying data transport has been established (or re-established).
     pub fn on_open(&self, f: OnOpenHdlrFn) {
-        {
-            let _ = self.on_open_handler.lock().replace(f);
-        }
+        let _ = self.on_open_handler.lock().replace(f);
 
         if self.ready_state() == RTCDataChannelState::Open {
             self.do_open();
@@ -217,7 +215,7 @@ impl RTCDataChannel {
     }
 
     fn do_open(&self) {
-        let on_open_handler = { self.on_open_handler.lock().take() };
+        let on_open_handler = self.on_open_handler.lock().take();
         if on_open_handler.is_none() {
             return;
         }

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -119,8 +119,8 @@ impl RTCDtlsTransport {
     /// state_change requires the caller holds the lock
     async fn state_change(&self, state: RTCDtlsTransportState) {
         self.state.store(state as u8, Ordering::SeqCst);
-        if let Some(hndlr) = &*self.on_state_change_handler.load() {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = &*self.on_state_change_handler.load() {
+            let mut f = handler.lock().await;
             f(state).await;
         }
     }

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwapOption;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -67,7 +68,7 @@ pub struct RTCDtlsTransport {
     pub(crate) remote_certificate: Mutex<Bytes>,
     pub(crate) state: AtomicU8, //DTLSTransportState,
     pub(crate) srtp_protection_profile: Mutex<ProtectionProfile>,
-    pub(crate) on_state_change_handler: Arc<Mutex<Option<OnDTLSTransportStateChangeHdlrFn>>>,
+    pub(crate) on_state_change_handler: ArcSwapOption<Mutex<OnDTLSTransportStateChangeHdlrFn>>,
     pub(crate) conn: Mutex<Option<Arc<DTLSConn>>>,
 
     pub(crate) srtp_session: Mutex<Option<Arc<Session>>>,
@@ -118,17 +119,17 @@ impl RTCDtlsTransport {
     /// state_change requires the caller holds the lock
     async fn state_change(&self, state: RTCDtlsTransportState) {
         self.state.store(state as u8, Ordering::SeqCst);
-        let mut handler = self.on_state_change_handler.lock().await;
-        if let Some(f) = &mut *handler {
+        if let Some(hndlr) = &*self.on_state_change_handler.load() {
+            let mut f = hndlr.lock().await;
             f(state).await;
         }
     }
 
     /// on_state_change sets a handler that is fired when the DTLS
     /// connection state changes.
-    pub async fn on_state_change(&self, f: OnDTLSTransportStateChangeHdlrFn) {
-        let mut on_state_change_handler = self.on_state_change_handler.lock().await;
-        *on_state_change_handler = Some(f);
+    pub fn on_state_change(&self, f: OnDTLSTransportStateChangeHdlrFn) {
+        self.on_state_change_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// state returns the current dtls_transport transport state.

--- a/webrtc/src/error.rs
+++ b/webrtc/src/error.rs
@@ -347,7 +347,7 @@ pub enum Error {
     #[error("can't rollback from stable state")]
     ErrSignalingStateCannotRollback,
     #[error(
-        "invalid proposed signaling state transition from {} applying {} {}", 
+        "invalid proposed signaling state transition from {} applying {} {}",
         from,
         if *is_local { "local" } else {  "remote" },
         applying

--- a/webrtc/src/ice_transport/ice_candidate.rs
+++ b/webrtc/src/ice_transport/ice_candidate.rs
@@ -63,7 +63,7 @@ impl From<&Arc<dyn Candidate + Send + Sync>> for RTCIceCandidate {
 }
 
 impl RTCIceCandidate {
-    pub(crate) async fn to_ice(&self) -> Result<impl Candidate> {
+    pub(crate) fn to_ice(&self) -> Result<impl Candidate> {
         let candidate_id = self.stats_id.clone();
         let c = match self.typ {
             RTCIceCandidateType::Host => {
@@ -81,7 +81,7 @@ impl RTCIceCandidate {
                     },
                     ..Default::default()
                 };
-                config.new_candidate_host().await?
+                config.new_candidate_host()?
             }
             RTCIceCandidateType::Srflx => {
                 let config = CandidateServerReflexiveConfig {
@@ -98,7 +98,7 @@ impl RTCIceCandidate {
                     rel_addr: self.related_address.clone(),
                     rel_port: self.related_port,
                 };
-                config.new_candidate_server_reflexive().await?
+                config.new_candidate_server_reflexive()?
             }
             RTCIceCandidateType::Prflx => {
                 let config = CandidatePeerReflexiveConfig {
@@ -115,7 +115,7 @@ impl RTCIceCandidate {
                     rel_addr: self.related_address.clone(),
                     rel_port: self.related_port,
                 };
-                config.new_candidate_peer_reflexive().await?
+                config.new_candidate_peer_reflexive()?
             }
             RTCIceCandidateType::Relay => {
                 let config = CandidateRelayConfig {
@@ -133,7 +133,7 @@ impl RTCIceCandidate {
                     rel_port: self.related_port,
                     relay_client: None, //TODO?
                 };
-                config.new_candidate_relay().await?
+                config.new_candidate_relay()?
             }
             _ => return Err(Error::ErrICECandidateTypeUnknown),
         };
@@ -143,8 +143,8 @@ impl RTCIceCandidate {
 
     /// to_json returns an ICECandidateInit
     /// as indicated by the spec <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson>
-    pub async fn to_json(&self) -> Result<RTCIceCandidateInit> {
-        let candidate = self.to_ice().await?;
+    pub fn to_json(&self) -> Result<RTCIceCandidateInit> {
+        let candidate = self.to_ice()?;
 
         Ok(RTCIceCandidateInit {
             candidate: format!("candidate:{}", candidate.marshal()),

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -14,6 +14,7 @@ use ice::agent::Agent;
 use ice::candidate::{Candidate, CandidateType};
 use ice::url::Url;
 
+use arc_swap::ArcSwapOption;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -54,13 +55,13 @@ pub struct RTCIceGatherer {
     pub(crate) setting_engine: Arc<SettingEngine>,
 
     pub(crate) state: Arc<AtomicU8>, //ICEGathererState,
-    pub(crate) agent: Mutex<Option<Arc<ice::agent::Agent>>>,
+    pub(crate) agent: ArcSwapOption<ice::agent::Agent>,
 
-    pub(crate) on_local_candidate_handler: Arc<Mutex<Option<OnLocalCandidateHdlrFn>>>,
-    pub(crate) on_state_change_handler: Arc<Mutex<Option<OnICEGathererStateChangeHdlrFn>>>,
+    pub(crate) on_local_candidate_handler: Arc<ArcSwapOption<Mutex<OnLocalCandidateHdlrFn>>>,
+    pub(crate) on_state_change_handler: Arc<ArcSwapOption<Mutex<OnICEGathererStateChangeHdlrFn>>>,
 
     // Used for gathering_complete_promise
-    pub(crate) on_gathering_complete_handler: Arc<Mutex<Option<OnGatheringCompleteHdlrFn>>>,
+    pub(crate) on_gathering_complete_handler: Arc<ArcSwapOption<Mutex<OnGatheringCompleteHdlrFn>>>,
 }
 
 impl RTCIceGatherer {
@@ -84,8 +85,7 @@ impl RTCIceGatherer {
         // ensure we do not do anything expensive other than the actual agent
         // creation in this function.
 
-        let mut agent = self.agent.lock().await;
-        if agent.is_some() || self.state() != RTCIceGathererState::New {
+        if self.agent.load().is_some() || self.state() != RTCIceGathererState::New {
             return Ok(());
         }
 
@@ -149,7 +149,8 @@ impl RTCIceGatherer {
 
         config.network_types.extend(requested_network_types);
 
-        *agent = Some(Arc::new(ice::agent::Agent::new(config).await?));
+        self.agent
+            .store(Some(Arc::new(ice::agent::Agent::new(config).await?)));
 
         Ok(())
     }
@@ -159,63 +160,48 @@ impl RTCIceGatherer {
         self.create_agent().await?;
         self.set_state(RTCIceGathererState::Gathering).await;
 
-        if let Some(agent) = self.get_agent().await {
+        if let Some(agent) = self.get_agent() {
             let state = Arc::clone(&self.state);
             let on_local_candidate_handler = Arc::clone(&self.on_local_candidate_handler);
             let on_state_change_handler = Arc::clone(&self.on_state_change_handler);
             let on_gathering_complete_handler = Arc::clone(&self.on_gathering_complete_handler);
 
-            agent
-                .on_candidate(Box::new(
-                    move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
-                        let state_clone = Arc::clone(&state);
-                        let on_local_candidate_handler_clone =
-                            Arc::clone(&on_local_candidate_handler);
-                        let on_state_change_handler_clone = Arc::clone(&on_state_change_handler);
-                        let on_gathering_complete_handler_clone =
-                            Arc::clone(&on_gathering_complete_handler);
+            agent.on_candidate(Box::new(
+                move |candidate: Option<Arc<dyn Candidate + Send + Sync>>| {
+                    let state_clone = Arc::clone(&state);
+                    let on_local_candidate_handler_clone = Arc::clone(&on_local_candidate_handler);
+                    let on_state_change_handler_clone = Arc::clone(&on_state_change_handler);
+                    let on_gathering_complete_handler_clone =
+                        Arc::clone(&on_gathering_complete_handler);
 
-                        Box::pin(async move {
-                            if let Some(cand) = candidate {
-                                let c = RTCIceCandidate::from(&cand);
-
-                                let mut on_local_candidate_handler =
-                                    on_local_candidate_handler_clone.lock().await;
-                                if let Some(handler) = &mut *on_local_candidate_handler {
-                                    handler(Some(c)).await;
-                                }
-                            } else {
-                                state_clone
-                                    .store(RTCIceGathererState::Complete as u8, Ordering::SeqCst);
-
-                                {
-                                    let mut on_state_change_handler =
-                                        on_state_change_handler_clone.lock().await;
-                                    if let Some(handler) = &mut *on_state_change_handler {
-                                        handler(RTCIceGathererState::Complete).await;
-                                    }
-                                }
-
-                                {
-                                    let mut on_gathering_complete_handler =
-                                        on_gathering_complete_handler_clone.lock().await;
-                                    if let Some(handler) = &mut *on_gathering_complete_handler {
-                                        handler().await;
-                                    }
-                                }
-
-                                {
-                                    let mut on_local_candidate_handler =
-                                        on_local_candidate_handler_clone.lock().await;
-                                    if let Some(handler) = &mut *on_local_candidate_handler {
-                                        handler(None).await;
-                                    }
-                                }
+                    Box::pin(async move {
+                        if let Some(cand) = candidate {
+                            if let Some(hndlr) = &*on_local_candidate_handler_clone.load() {
+                                let mut f = hndlr.lock().await;
+                                f(Some(RTCIceCandidate::from(&cand))).await;
                             }
-                        })
-                    },
-                ))
-                .await;
+                        } else {
+                            state_clone
+                                .store(RTCIceGathererState::Complete as u8, Ordering::SeqCst);
+
+                            if let Some(hndlr) = &*on_state_change_handler_clone.load() {
+                                let mut f = hndlr.lock().await;
+                                f(RTCIceGathererState::Complete).await;
+                            }
+
+                            if let Some(hndlr) = &*on_gathering_complete_handler_clone.load() {
+                                let mut f = hndlr.lock().await;
+                                f().await;
+                            }
+
+                            if let Some(hndlr) = &*on_local_candidate_handler_clone.load() {
+                                let mut f = hndlr.lock().await;
+                                f(None).await;
+                            }
+                        }
+                    })
+                },
+            ));
 
             agent.gather_candidates().await?;
         }
@@ -227,10 +213,7 @@ impl RTCIceGatherer {
     pub async fn close(&self) -> Result<()> {
         self.set_state(RTCIceGathererState::Closed).await;
 
-        let agent = {
-            let mut agent_opt = self.agent.lock().await;
-            agent_opt.take()
-        };
+        let agent = self.agent.swap(None);
 
         if let Some(agent) = agent {
             agent.close().await?;
@@ -243,7 +226,7 @@ impl RTCIceGatherer {
     pub async fn get_local_parameters(&self) -> Result<RTCIceParameters> {
         self.create_agent().await?;
 
-        let (frag, pwd) = if let Some(agent) = self.get_agent().await {
+        let (frag, pwd) = if let Some(agent) = self.get_agent() {
             agent.get_local_user_credentials().await
         } else {
             return Err(Error::ErrICEAgentNotExist);
@@ -260,7 +243,7 @@ impl RTCIceGatherer {
     pub async fn get_local_candidates(&self) -> Result<Vec<RTCIceCandidate>> {
         self.create_agent().await?;
 
-        let ice_candidates = if let Some(agent) = self.get_agent().await {
+        let ice_candidates = if let Some(agent) = self.get_agent() {
             agent.get_local_candidates().await?
         } else {
             return Err(Error::ErrICEAgentNotExist);
@@ -271,21 +254,21 @@ impl RTCIceGatherer {
 
     /// on_local_candidate sets an event handler which fires when a new local ICE candidate is available
     /// Take note that the handler is gonna be called with a nil pointer when gathering is finished.
-    pub async fn on_local_candidate(&self, f: OnLocalCandidateHdlrFn) {
-        let mut on_local_candidate_handler = self.on_local_candidate_handler.lock().await;
-        *on_local_candidate_handler = Some(f);
+    pub fn on_local_candidate(&self, f: OnLocalCandidateHdlrFn) {
+        self.on_local_candidate_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_state_change sets an event handler which fires any time the ICEGatherer changes
-    pub async fn on_state_change(&self, f: OnICEGathererStateChangeHdlrFn) {
-        let mut on_state_change_handler = self.on_state_change_handler.lock().await;
-        *on_state_change_handler = Some(f);
+    pub fn on_state_change(&self, f: OnICEGathererStateChangeHdlrFn) {
+        self.on_state_change_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_gathering_complete sets an event handler which fires any time the ICEGatherer changes
-    pub async fn on_gathering_complete(&self, f: OnGatheringCompleteHdlrFn) {
-        let mut on_gathering_complete_handler = self.on_gathering_complete_handler.lock().await;
-        *on_gathering_complete_handler = Some(f);
+    pub fn on_gathering_complete(&self, f: OnGatheringCompleteHdlrFn) {
+        self.on_gathering_complete_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// State indicates the current state of the ICE gatherer.
@@ -296,19 +279,18 @@ impl RTCIceGatherer {
     pub async fn set_state(&self, s: RTCIceGathererState) {
         self.state.store(s as u8, Ordering::SeqCst);
 
-        let mut on_state_change_handler = self.on_state_change_handler.lock().await;
-        if let Some(handler) = &mut *on_state_change_handler {
-            handler(s).await;
+        if let Some(hndlr) = &*self.on_state_change_handler.load() {
+            let mut f = hndlr.lock().await;
+            f(s).await;
         }
     }
 
-    pub(crate) async fn get_agent(&self) -> Option<Arc<Agent>> {
-        let agent = self.agent.lock().await;
-        agent.clone()
+    pub(crate) fn get_agent(&self) -> Option<Arc<Agent>> {
+        self.agent.load().clone()
     }
 
     pub(crate) async fn collect_stats(&self, collector: &StatsCollector) {
-        if let Some(agent) = self.get_agent().await {
+        if let Some(agent) = self.get_agent() {
             let mut reports = HashMap::new();
 
             for stats in agent.get_candidate_pairs_stats().await {
@@ -363,17 +345,15 @@ mod test {
 
         let (gather_finished_tx, mut gather_finished_rx) = mpsc::channel::<()>(1);
         let gather_finished_tx = Arc::new(Mutex::new(Some(gather_finished_tx)));
-        gatherer
-            .on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-                let gather_finished_tx_clone = Arc::clone(&gather_finished_tx);
-                Box::pin(async move {
-                    if c.is_none() {
-                        let mut tx = gather_finished_tx_clone.lock().await;
-                        tx.take();
-                    }
-                })
-            }))
-            .await;
+        gatherer.on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
+            let gather_finished_tx_clone = Arc::clone(&gather_finished_tx);
+            Box::pin(async move {
+                if c.is_none() {
+                    let mut tx = gather_finished_tx_clone.lock().await;
+                    tx.take();
+                }
+            })
+        }));
 
         gatherer.gather().await?;
 
@@ -407,19 +387,17 @@ mod test {
 
         let (done_tx, mut done_rx) = mpsc::channel::<()>(1);
         let done_tx = Arc::new(Mutex::new(Some(done_tx)));
-        gatherer
-            .on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
-                let done_tx_clone = Arc::clone(&done_tx);
-                Box::pin(async move {
-                    if let Some(c) = c {
-                        if c.address.ends_with(".local") {
-                            let mut tx = done_tx_clone.lock().await;
-                            tx.take();
-                        }
+        gatherer.on_local_candidate(Box::new(move |c: Option<RTCIceCandidate>| {
+            let done_tx_clone = Arc::clone(&done_tx);
+            Box::pin(async move {
+                if let Some(c) = c {
+                    if c.address.ends_with(".local") {
+                        let mut tx = done_tx_clone.lock().await;
+                        tx.take();
                     }
-                })
-            }))
-            .await;
+                }
+            })
+        }));
 
         gatherer.gather().await?;
 

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -203,7 +203,7 @@ impl RTCIceGatherer {
                 },
             ));
 
-            agent.gather_candidates().await?;
+            agent.gather_candidates()?;
         }
 
         Ok(())

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -176,26 +176,26 @@ impl RTCIceGatherer {
 
                     Box::pin(async move {
                         if let Some(cand) = candidate {
-                            if let Some(hndlr) = &*on_local_candidate_handler_clone.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*on_local_candidate_handler_clone.load() {
+                                let mut f = handler.lock().await;
                                 f(Some(RTCIceCandidate::from(&cand))).await;
                             }
                         } else {
                             state_clone
                                 .store(RTCIceGathererState::Complete as u8, Ordering::SeqCst);
 
-                            if let Some(hndlr) = &*on_state_change_handler_clone.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*on_state_change_handler_clone.load() {
+                                let mut f = handler.lock().await;
                                 f(RTCIceGathererState::Complete).await;
                             }
 
-                            if let Some(hndlr) = &*on_gathering_complete_handler_clone.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*on_gathering_complete_handler_clone.load() {
+                                let mut f = handler.lock().await;
                                 f().await;
                             }
 
-                            if let Some(hndlr) = &*on_local_candidate_handler_clone.load() {
-                                let mut f = hndlr.lock().await;
+                            if let Some(handler) = &*on_local_candidate_handler_clone.load() {
+                                let mut f = handler.lock().await;
                                 f(None).await;
                             }
                         }
@@ -279,8 +279,8 @@ impl RTCIceGatherer {
     pub async fn set_state(&self, s: RTCIceGathererState) {
         self.state.store(s as u8, Ordering::SeqCst);
 
-        if let Some(hndlr) = &*self.on_state_change_handler.load() {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = &*self.on_state_change_handler.load() {
+            let mut f = handler.lock().await;
             f(s).await;
         }
     }

--- a/webrtc/src/ice_transport/ice_transport_test.rs
+++ b/webrtc/src/ice_transport/ice_transport_test.rs
@@ -83,14 +83,16 @@ async fn test_ice_transport_get_selected_candidate_pair() -> Result<()> {
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair();
+        .get_selected_candidate_pair()
+        .await;
     assert!(offerer_selected_pair.is_none());
 
     let answerer_selected_pair = answerer
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair();
+        .get_selected_candidate_pair()
+        .await;
     assert!(answerer_selected_pair.is_none());
 
     signal_pair(&mut offerer, &mut answerer).await?;
@@ -101,14 +103,16 @@ async fn test_ice_transport_get_selected_candidate_pair() -> Result<()> {
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair();
+        .get_selected_candidate_pair()
+        .await;
     assert!(offerer_selected_pair.is_some());
 
     let answerer_selected_pair = answerer
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair();
+        .get_selected_candidate_pair()
+        .await;
     assert!(answerer_selected_pair.is_some());
 
     close_pair_now(&offerer, &answerer).await;

--- a/webrtc/src/ice_transport/ice_transport_test.rs
+++ b/webrtc/src/ice_transport/ice_transport_test.rs
@@ -83,16 +83,14 @@ async fn test_ice_transport_get_selected_candidate_pair() -> Result<()> {
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair()
-        .await;
+        .get_selected_candidate_pair();
     assert!(offerer_selected_pair.is_none());
 
     let answerer_selected_pair = answerer
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair()
-        .await;
+        .get_selected_candidate_pair();
     assert!(answerer_selected_pair.is_none());
 
     signal_pair(&mut offerer, &mut answerer).await?;
@@ -103,16 +101,14 @@ async fn test_ice_transport_get_selected_candidate_pair() -> Result<()> {
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair()
-        .await;
+        .get_selected_candidate_pair();
     assert!(offerer_selected_pair.is_some());
 
     let answerer_selected_pair = answerer
         .sctp()
         .transport()
         .ice_transport()
-        .get_selected_candidate_pair()
-        .await;
+        .get_selected_candidate_pair();
     assert!(answerer_selected_pair.is_some());
 
     close_pair_now(&offerer, &answerer).await;

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -85,8 +85,8 @@ impl RTCIceTransport {
 
     /// get_selected_candidate_pair returns the selected candidate pair on which packets are sent
     /// if there is no selected pair nil is returned
-    pub fn get_selected_candidate_pair(&self) -> Option<RTCIceCandidatePair> {
-        if let Some(agent) = self.gatherer.get_agent() {
+    pub async fn get_selected_candidate_pair(&self) -> Option<RTCIceCandidatePair> {
+        if let Some(agent) = self.gatherer.get_agent().await {
             if let Some(ice_pair) = agent.get_selected_candidate_pair() {
                 let local = RTCIceCandidate::from(&ice_pair.local);
                 let remote = RTCIceCandidate::from(&ice_pair.remote);
@@ -104,7 +104,7 @@ impl RTCIceTransport {
 
         self.ensure_gatherer().await?;
 
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             let state = Arc::clone(&self.state);
 
             let on_connection_state_change_handler =
@@ -199,7 +199,7 @@ impl RTCIceTransport {
     /// restart is not exposed currently because ORTC has users create a whole new ICETransport
     /// so for now lets keep it private so we don't cause ORTC users to depend on non-standard APIs
     pub(crate) async fn restart(&self) -> Result<()> {
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             agent
                 .restart(
                     self.gatherer
@@ -265,7 +265,7 @@ impl RTCIceTransport {
     pub async fn set_remote_candidates(&self, remote_candidates: &[RTCIceCandidate]) -> Result<()> {
         self.ensure_gatherer().await?;
 
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             for rc in remote_candidates {
                 let c: Arc<dyn Candidate + Send + Sync> = Arc::new(rc.to_ice()?);
                 agent.add_remote_candidate(&c)?;
@@ -283,7 +283,7 @@ impl RTCIceTransport {
     ) -> Result<()> {
         self.ensure_gatherer().await?;
 
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             if let Some(r) = remote_candidate {
                 let c: Arc<dyn Candidate + Send + Sync> = Arc::new(r.to_ice()?);
                 agent.add_remote_candidate(&c)?;
@@ -314,7 +314,7 @@ impl RTCIceTransport {
     }
 
     pub(crate) async fn ensure_gatherer(&self) -> Result<()> {
-        if self.gatherer.get_agent().is_none() {
+        if self.gatherer.get_agent().await.is_none() {
             self.gatherer.create_agent().await
         } else {
             Ok(())
@@ -322,7 +322,7 @@ impl RTCIceTransport {
     }
 
     pub(crate) async fn collect_stats(&self, collector: &StatsCollector) {
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             let stats = ICETransportStats::new("ice_transport".to_string(), agent);
 
             collector.insert("ice_transport".to_string(), Transport(stats));
@@ -334,7 +334,7 @@ impl RTCIceTransport {
         new_ufrag: &str,
         new_pwd: &str,
     ) -> bool {
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             let (ufrag, upwd) = agent.get_remote_user_credentials().await;
             ufrag != new_ufrag || upwd != new_pwd
         } else {
@@ -347,7 +347,7 @@ impl RTCIceTransport {
         new_ufrag: String,
         new_pwd: String,
     ) -> Result<()> {
-        if let Some(agent) = self.gatherer.get_agent() {
+        if let Some(agent) = self.gatherer.get_agent().await {
             Ok(agent.set_remote_credentials(new_ufrag, new_pwd).await?)
         } else {
             Err(Error::ErrICEAgentNotExist)

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -115,8 +115,8 @@ impl RTCIceTransport {
                     Arc::clone(&on_connection_state_change_handler);
                 state.store(s as u8, Ordering::SeqCst);
                 Box::pin(async move {
-                    if let Some(hndlr) = &*on_connection_state_change_handler_clone.load() {
-                        let mut f = hndlr.lock().await;
+                    if let Some(handler) = &*on_connection_state_change_handler_clone.load() {
+                        let mut f = handler.lock().await;
                         f(s).await;
                     }
                 })
@@ -132,10 +132,10 @@ impl RTCIceTransport {
                     let local = RTCIceCandidate::from(local);
                     let remote = RTCIceCandidate::from(remote);
                     Box::pin(async move {
-                        if let Some(hndlr) =
+                        if let Some(handler) =
                             &*on_selected_candidate_pair_change_handler_clone.load()
                         {
-                            let mut f = hndlr.lock().await;
+                            let mut f = handler.lock().await;
                             f(RTCIceCandidatePair::new(local, remote)).await;
                         }
                     })

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -1,9 +1,9 @@
-use arc_swap::ArcSwapOption;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
+use arc_swap::ArcSwapOption;
 use ice::candidate::Candidate;
 use ice::state::ConnectionState;
 use tokio::sync::{mpsc, Mutex};

--- a/webrtc/src/mux/endpoint.rs
+++ b/webrtc/src/mux/endpoint.rs
@@ -58,12 +58,12 @@ impl Conn for Endpoint {
         Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
-        self.next_conn.local_addr().await
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.next_conn.local_addr()
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
-        self.next_conn.remote_addr().await
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.next_conn.remote_addr()
     }
 
     async fn close(&self) -> Result<()> {

--- a/webrtc/src/mux/mux_test.rs
+++ b/webrtc/src/mux/mux_test.rs
@@ -80,11 +80,11 @@ impl Conn for MuxErrorConn {
         Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn local_addr(&self) -> Result<SocketAddr> {
+    fn local_addr(&self) -> Result<SocketAddr> {
         Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
     }
 
-    async fn remote_addr(&self) -> Option<SocketAddr> {
+    fn remote_addr(&self) -> Option<SocketAddr> {
         None
     }
 

--- a/webrtc/src/peer_connection/certificate.rs
+++ b/webrtc/src/peer_connection/certificate.rs
@@ -130,8 +130,8 @@ impl RTCCertificate {
         }
         let mut bytes = [0u8; 8];
         bytes.copy_from_slice(&expires_pem.contents[..8]);
-        let expires = if let Some(e) = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_secs(u64::from_le_bytes(bytes)).into())
+        let expires = if let Some(e) =
+            SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(u64::from_le_bytes(bytes)))
         {
             e
         } else {

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -295,8 +295,8 @@ impl RTCPeerConnection {
 
     async fn do_signaling_state_change(&self, new_state: RTCSignalingState) {
         log::info!("signaling state changed to {}", new_state);
-        if let Some(hndlr) = &*self.internal.on_signaling_state_change_handler.load() {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = &*self.internal.on_signaling_state_change_handler.load() {
+            let mut f = handler.lock().await;
             f(new_state).await;
         }
     }
@@ -415,8 +415,8 @@ impl RTCPeerConnection {
         params.is_negotiation_needed.store(true, Ordering::SeqCst);
 
         // Step 2.7
-        if let Some(hndlr) = handler {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = handler {
+            let mut f = handler.lock().await;
             f().await;
         }
 
@@ -595,8 +595,8 @@ impl RTCPeerConnection {
 
         if t.is_some() {
             tokio::spawn(async move {
-                if let Some(hndlr) = &*on_track_handler.load() {
-                    let mut f = hndlr.lock().await;
+                if let Some(handler) = &*on_track_handler.load() {
+                    let mut f = handler.lock().await;
                     f(t, r).await;
                 } else {
                     log::warn!("on_track unset, unable to handle incoming media streams");
@@ -621,8 +621,8 @@ impl RTCPeerConnection {
         ice_connection_state.store(cs as u8, Ordering::SeqCst);
 
         log::info!("ICE connection state changed: {}", cs);
-        if let Some(hndlr) = &*handler.load() {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = &*handler.load() {
+            let mut f = handler.lock().await;
             f(cs).await;
         }
     }
@@ -639,8 +639,8 @@ impl RTCPeerConnection {
         handler: &Arc<ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>>,
         cs: RTCPeerConnectionState,
     ) {
-        if let Some(hndlr) = &*handler.load() {
-            let mut f = hndlr.lock().await;
+        if let Some(handler) = &*handler.load() {
+            let mut f = handler.lock().await;
             f(cs).await;
         }
     }

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -72,6 +72,7 @@ use ::ice::candidate::candidate_base::unmarshal_candidate;
 use ::ice::candidate::Candidate;
 use ::sdp::description::session::*;
 use ::sdp::util::ConnectionRole;
+use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use interceptor::{stats, Attributes, Interceptor, RTCPWriter};
 use peer_connection_internal::*;
@@ -168,7 +169,7 @@ struct CheckNegotiationNeededParams {
 
 #[derive(Clone)]
 struct NegotiationNeededParams {
-    on_negotiation_needed_handler: Arc<Mutex<Option<OnNegotiationNeededHdlrFn>>>,
+    on_negotiation_needed_handler: Arc<ArcSwapOption<Mutex<OnNegotiationNeededHdlrFn>>>,
     is_closed: Arc<AtomicBool>,
     ops: Arc<Operations>,
     negotiation_needed_state: Arc<AtomicU8>,
@@ -286,33 +287,34 @@ impl RTCPeerConnection {
 
     /// on_signaling_state_change sets an event handler which is invoked when the
     /// peer connection's signaling state changes
-    pub async fn on_signaling_state_change(&self, f: OnSignalingStateChangeHdlrFn) {
-        let mut on_signaling_state_change_handler =
-            self.internal.on_signaling_state_change_handler.lock().await;
-        *on_signaling_state_change_handler = Some(f);
+    pub fn on_signaling_state_change(&self, f: OnSignalingStateChangeHdlrFn) {
+        self.internal
+            .on_signaling_state_change_handler
+            .store(Some(Arc::new(Mutex::new(f))))
     }
 
     async fn do_signaling_state_change(&self, new_state: RTCSignalingState) {
         log::info!("signaling state changed to {}", new_state);
-        let mut handler = self.internal.on_signaling_state_change_handler.lock().await;
-        if let Some(f) = &mut *handler {
+        if let Some(hndlr) = &*self.internal.on_signaling_state_change_handler.load() {
+            let mut f = hndlr.lock().await;
             f(new_state).await;
         }
     }
 
     /// on_data_channel sets an event handler which is invoked when a data
     /// channel message arrives from a remote peer.
-    pub async fn on_data_channel(&self, f: OnDataChannelHdlrFn) {
-        let mut on_data_channel_handler = self.internal.on_data_channel_handler.lock().await;
-        *on_data_channel_handler = Some(f);
+    pub fn on_data_channel(&self, f: OnDataChannelHdlrFn) {
+        self.internal
+            .on_data_channel_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_negotiation_needed sets an event handler which is invoked when
     /// a change has occurred which requires session negotiation
-    pub async fn on_negotiation_needed(&self, f: OnNegotiationNeededHdlrFn) {
-        let mut on_negotiation_needed_handler =
-            self.internal.on_negotiation_needed_handler.lock().await;
-        *on_negotiation_needed_handler = Some(f);
+    pub fn on_negotiation_needed(&self, f: OnNegotiationNeededHdlrFn) {
+        self.internal
+            .on_negotiation_needed_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     fn do_negotiation_needed_inner(params: &NegotiationNeededParams) -> bool {
@@ -372,11 +374,9 @@ impl RTCPeerConnection {
 
     async fn negotiation_needed_op(params: NegotiationNeededParams) -> bool {
         // Don't run NegotiatedNeeded checks if on_negotiation_needed is not set
-        {
-            let handler = params.on_negotiation_needed_handler.lock().await;
-            if handler.is_none() {
-                return false;
-            }
+        let handler = &*params.on_negotiation_needed_handler.load();
+        if handler.is_none() {
+            return false;
         }
 
         // https://www.w3.org/TR/webrtc/#updating-the-negotiation-needed-flag
@@ -415,11 +415,9 @@ impl RTCPeerConnection {
         params.is_negotiation_needed.store(true, Ordering::SeqCst);
 
         // Step 2.7
-        {
-            let mut handler = params.on_negotiation_needed_handler.lock().await;
-            if let Some(f) = &mut *handler {
-                f().await;
-            }
+        if let Some(hndlr) = handler {
+            let mut f = hndlr.lock().await;
+            f().await;
         }
 
         RTCPeerConnection::after_negotiation_needed_op(params).await
@@ -570,25 +568,26 @@ impl RTCPeerConnection {
     /// candidate is found.
     /// Take note that the handler is gonna be called with a nil pointer when
     /// gathering is finished.
-    pub async fn on_ice_candidate(&self, f: OnLocalCandidateHdlrFn) {
-        self.internal.ice_gatherer.on_local_candidate(f).await
+    pub fn on_ice_candidate(&self, f: OnLocalCandidateHdlrFn) {
+        self.internal.ice_gatherer.on_local_candidate(f)
     }
 
     /// on_ice_gathering_state_change sets an event handler which is invoked when the
     /// ICE candidate gathering state has changed.
-    pub async fn on_ice_gathering_state_change(&self, f: OnICEGathererStateChangeHdlrFn) {
-        self.internal.ice_gatherer.on_state_change(f).await
+    pub fn on_ice_gathering_state_change(&self, f: OnICEGathererStateChangeHdlrFn) {
+        self.internal.ice_gatherer.on_state_change(f)
     }
 
     /// on_track sets an event handler which is called when remote track
     /// arrives from a remote peer.
-    pub async fn on_track(&self, f: OnTrackHdlrFn) {
-        let mut on_track_handler = self.internal.on_track_handler.lock().await;
-        *on_track_handler = Some(f);
+    pub fn on_track(&self, f: OnTrackHdlrFn) {
+        self.internal
+            .on_track_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     async fn do_track(
-        on_track_handler: Arc<Mutex<Option<OnTrackHdlrFn>>>,
+        on_track_handler: Arc<ArcSwapOption<Mutex<OnTrackHdlrFn>>>,
         t: Option<Arc<TrackRemote>>,
         r: Option<Arc<RTCRtpReceiver>>,
     ) {
@@ -596,8 +595,8 @@ impl RTCPeerConnection {
 
         if t.is_some() {
             tokio::spawn(async move {
-                let mut handler = on_track_handler.lock().await;
-                if let Some(f) = &mut *handler {
+                if let Some(hndlr) = &*on_track_handler.load() {
+                    let mut f = hndlr.lock().await;
                     f(t, r).await;
                 } else {
                     log::warn!("on_track unset, unable to handle incoming media streams");
@@ -608,50 +607,40 @@ impl RTCPeerConnection {
 
     /// on_ice_connection_state_change sets an event handler which is called
     /// when an ICE connection state is changed.
-    pub async fn on_ice_connection_state_change(&self, f: OnICEConnectionStateChangeHdlrFn) {
-        let mut on_ice_connection_state_change_handler = self
-            .internal
+    pub fn on_ice_connection_state_change(&self, f: OnICEConnectionStateChangeHdlrFn) {
+        self.internal
             .on_ice_connection_state_change_handler
-            .lock()
-            .await;
-        *on_ice_connection_state_change_handler = Some(f);
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     async fn do_ice_connection_state_change(
-        on_ice_connection_state_change_handler: &Arc<
-            Mutex<Option<OnICEConnectionStateChangeHdlrFn>>,
-        >,
+        handler: Arc<ArcSwapOption<Mutex<OnICEConnectionStateChangeHdlrFn>>>,
         ice_connection_state: &Arc<AtomicU8>,
         cs: RTCIceConnectionState,
     ) {
         ice_connection_state.store(cs as u8, Ordering::SeqCst);
 
         log::info!("ICE connection state changed: {}", cs);
-        let mut handler = on_ice_connection_state_change_handler.lock().await;
-        if let Some(f) = &mut *handler {
+        if let Some(hndlr) = &*handler.load() {
+            let mut f = hndlr.lock().await;
             f(cs).await;
         }
     }
 
     /// on_peer_connection_state_change sets an event handler which is called
     /// when the PeerConnectionState has changed
-    pub async fn on_peer_connection_state_change(&self, f: OnPeerConnectionStateChangeHdlrFn) {
-        let mut on_peer_connection_state_change_handler = self
-            .internal
+    pub fn on_peer_connection_state_change(&self, f: OnPeerConnectionStateChangeHdlrFn) {
+        self.internal
             .on_peer_connection_state_change_handler
-            .lock()
-            .await;
-        *on_peer_connection_state_change_handler = Some(f);
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     async fn do_peer_connection_state_change(
-        on_peer_connection_state_change_handler: &Arc<
-            Mutex<Option<OnPeerConnectionStateChangeHdlrFn>>,
-        >,
+        handler: Arc<ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>>,
         cs: RTCPeerConnectionState,
     ) {
-        let mut handler = on_peer_connection_state_change_handler.lock().await;
-        if let Some(f) = &mut *handler {
+        if let Some(hndlr) = &*handler.load() {
+            let mut f = hndlr.lock().await;
             f(cs).await;
         }
     }
@@ -876,36 +865,36 @@ impl RTCPeerConnection {
     /// Update the PeerConnectionState given the state of relevant transports
     /// <https://www.w3.org/TR/webrtc/#rtcpeerconnectionstate-enum>
     async fn update_connection_state(
-        on_peer_connection_state_change_handler: &Arc<
-            Mutex<Option<OnPeerConnectionStateChangeHdlrFn>>,
+        on_peer_connection_state_change_handler: Arc<
+            ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>,
         >,
         is_closed: &Arc<AtomicBool>,
         peer_connection_state: &Arc<AtomicU8>,
         ice_connection_state: RTCIceConnectionState,
         dtls_transport_state: RTCDtlsTransportState,
     ) {
-        let  connection_state =
-        // The RTCPeerConnection object's [[IsClosed]] slot is true.
-        if is_closed.load(Ordering::SeqCst) {
-             RTCPeerConnectionState::Closed
-        }else if ice_connection_state == RTCIceConnectionState::Failed || dtls_transport_state == RTCDtlsTransportState::Failed {
-            // Any of the RTCIceTransports or RTCDtlsTransports are in a "failed" state.
-             RTCPeerConnectionState::Failed
-        }else if ice_connection_state == RTCIceConnectionState::Disconnected {
-            // Any of the RTCIceTransports or RTCDtlsTransports are in the "disconnected"
-            // state and none of them are in the "failed" or "connecting" or "checking" state.
-            RTCPeerConnectionState::Disconnected
-        }else if ice_connection_state == RTCIceConnectionState::Connected && dtls_transport_state == RTCDtlsTransportState::Connected {
-            // All RTCIceTransports and RTCDtlsTransports are in the "connected", "completed" or "closed"
-            // state and at least one of them is in the "connected" or "completed" state.
-            RTCPeerConnectionState::Connected
-        }else if ice_connection_state == RTCIceConnectionState::Checking && dtls_transport_state == RTCDtlsTransportState::Connecting{
-        //  Any of the RTCIceTransports or RTCDtlsTransports are in the "connecting" or
-        // "checking" state and none of them is in the "failed" state.
-             RTCPeerConnectionState::Connecting
-        }else{
-            RTCPeerConnectionState::New
-        };
+        let connection_state =
+            // The RTCPeerConnection object's [[IsClosed]] slot is true.
+            if is_closed.load(Ordering::SeqCst) {
+                RTCPeerConnectionState::Closed
+            } else if ice_connection_state == RTCIceConnectionState::Failed || dtls_transport_state == RTCDtlsTransportState::Failed {
+                // Any of the RTCIceTransports or RTCDtlsTransports are in a "failed" state.
+                RTCPeerConnectionState::Failed
+            } else if ice_connection_state == RTCIceConnectionState::Disconnected {
+                // Any of the RTCIceTransports or RTCDtlsTransports are in the "disconnected"
+                // state and none of them are in the "failed" or "connecting" or "checking" state.
+                RTCPeerConnectionState::Disconnected
+            } else if ice_connection_state == RTCIceConnectionState::Connected && dtls_transport_state == RTCDtlsTransportState::Connected {
+                // All RTCIceTransports and RTCDtlsTransports are in the "connected", "completed" or "closed"
+                // state and at least one of them is in the "connected" or "completed" state.
+                RTCPeerConnectionState::Connected
+            } else if ice_connection_state == RTCIceConnectionState::Checking && dtls_transport_state == RTCDtlsTransportState::Connecting {
+                //  Any of the RTCIceTransports or RTCDtlsTransports are in the "connecting" or
+                // "checking" state and none of them is in the "failed" state.
+                RTCPeerConnectionState::Connecting
+            } else {
+                RTCPeerConnectionState::New
+            };
 
         if peer_connection_state.load(Ordering::SeqCst) == connection_state as u8 {
             return;
@@ -1623,7 +1612,7 @@ impl RTCPeerConnection {
 
         let ice_candidate = if !candidate_value.is_empty() {
             let candidate: Arc<dyn Candidate + Send + Sync> =
-                Arc::new(unmarshal_candidate(candidate_value).await?);
+                Arc::new(unmarshal_candidate(candidate_value)?);
 
             Some(RTCIceCandidate::from(&candidate))
         } else {
@@ -1969,7 +1958,7 @@ impl RTCPeerConnection {
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #11)
         RTCPeerConnection::update_connection_state(
-            &self.internal.on_peer_connection_state_change_handler,
+            Arc::clone(&self.internal.on_peer_connection_state_change_handler),
             &self.internal.is_closed,
             &self.internal.peer_connection_state,
             self.ice_connection_state(),
@@ -2082,16 +2071,14 @@ impl RTCPeerConnection {
         // state has changed to complete so that we don't block the caller forever.
         let done = Arc::new(Mutex::new(Some(gathering_complete_tx)));
         let done2 = Arc::clone(&done);
-        self.internal
-            .set_gather_complete_handler(Box::new(move || {
-                log::trace!("setGatherCompleteHandler");
-                let done3 = Arc::clone(&done2);
-                Box::pin(async move {
-                    let mut d = done3.lock().await;
-                    d.take();
-                })
-            }))
-            .await;
+        self.internal.set_gather_complete_handler(Box::new(move || {
+            log::trace!("setGatherCompleteHandler");
+            let done3 = Arc::clone(&done2);
+            Box::pin(async move {
+                let mut d = done3.lock().await;
+                d.take();
+            })
+        }));
 
         if self.ice_gathering_state() == RTCIceGatheringState::Complete {
             log::trace!("ICEGatheringState::Complete");

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -614,7 +614,7 @@ impl RTCPeerConnection {
     }
 
     async fn do_ice_connection_state_change(
-        handler: Arc<ArcSwapOption<Mutex<OnICEConnectionStateChangeHdlrFn>>>,
+        handler: &Arc<ArcSwapOption<Mutex<OnICEConnectionStateChangeHdlrFn>>>,
         ice_connection_state: &Arc<AtomicU8>,
         cs: RTCIceConnectionState,
     ) {
@@ -636,7 +636,7 @@ impl RTCPeerConnection {
     }
 
     async fn do_peer_connection_state_change(
-        handler: Arc<ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>>,
+        handler: &Arc<ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>>,
         cs: RTCPeerConnectionState,
     ) {
         if let Some(hndlr) = &*handler.load() {
@@ -865,7 +865,7 @@ impl RTCPeerConnection {
     /// Update the PeerConnectionState given the state of relevant transports
     /// <https://www.w3.org/TR/webrtc/#rtcpeerconnectionstate-enum>
     async fn update_connection_state(
-        on_peer_connection_state_change_handler: Arc<
+        on_peer_connection_state_change_handler: &Arc<
             ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>,
         >,
         is_closed: &Arc<AtomicBool>,
@@ -1958,7 +1958,7 @@ impl RTCPeerConnection {
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #11)
         RTCPeerConnection::update_connection_state(
-            Arc::clone(&self.internal.on_peer_connection_state_change_handler),
+            &self.internal.on_peer_connection_state_change_handler,
             &self.internal.is_closed,
             &self.internal.peer_connection_state,
             self.ice_connection_state(),

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -9,6 +9,7 @@ use crate::stats::{
 };
 use crate::track::TrackStream;
 use crate::{SDES_REPAIR_RTP_STREAM_ID_URI, SDP_ATTRIBUTE_RID};
+use arc_swap::ArcSwapOption;
 use std::sync::atomic::AtomicIsize;
 use std::sync::Weak;
 
@@ -22,7 +23,7 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) last_offer: Mutex<String>,
     pub(super) last_answer: Mutex<String>,
 
-    pub(super) on_negotiation_needed_handler: Arc<Mutex<Option<OnNegotiationNeededHdlrFn>>>,
+    pub(super) on_negotiation_needed_handler: Arc<ArcSwapOption<Mutex<OnNegotiationNeededHdlrFn>>>,
     pub(super) is_closed: Arc<AtomicBool>,
 
     /// ops is an operations queue which will ensure the enqueued actions are
@@ -36,18 +37,19 @@ pub(crate) struct PeerConnectionInternal {
     pub(super) ice_transport: Arc<RTCIceTransport>,
     pub(super) dtls_transport: Arc<RTCDtlsTransport>,
     pub(super) on_peer_connection_state_change_handler:
-        Arc<Mutex<Option<OnPeerConnectionStateChangeHdlrFn>>>,
+        Arc<ArcSwapOption<Mutex<OnPeerConnectionStateChangeHdlrFn>>>,
     pub(super) peer_connection_state: Arc<AtomicU8>,
     pub(super) ice_connection_state: Arc<AtomicU8>,
 
     pub(super) sctp_transport: Arc<RTCSctpTransport>,
     pub(super) rtp_transceivers: Arc<Mutex<Vec<Arc<RTCRtpTransceiver>>>>,
 
-    pub(super) on_track_handler: Arc<Mutex<Option<OnTrackHdlrFn>>>,
-    pub(super) on_signaling_state_change_handler: Arc<Mutex<Option<OnSignalingStateChangeHdlrFn>>>,
+    pub(super) on_track_handler: Arc<ArcSwapOption<Mutex<OnTrackHdlrFn>>>,
+    pub(super) on_signaling_state_change_handler:
+        ArcSwapOption<Mutex<OnSignalingStateChangeHdlrFn>>,
     pub(super) on_ice_connection_state_change_handler:
-        Arc<Mutex<Option<OnICEConnectionStateChangeHdlrFn>>>,
-    pub(super) on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
+        Arc<ArcSwapOption<Mutex<OnICEConnectionStateChangeHdlrFn>>>,
+    pub(super) on_data_channel_handler: Arc<ArcSwapOption<Mutex<OnDataChannelHdlrFn>>>,
 
     pub(super) ice_gatherer: Arc<RTCIceGatherer>,
 
@@ -76,7 +78,7 @@ impl PeerConnectionInternal {
             last_offer: Mutex::new("".to_owned()),
             last_answer: Mutex::new("".to_owned()),
 
-            on_negotiation_needed_handler: Arc::new(Default::default()),
+            on_negotiation_needed_handler: Arc::new(ArcSwapOption::empty()),
             ops: Arc::new(Operations::new()),
             is_closed: Arc::new(AtomicBool::new(false)),
             is_negotiation_needed: Arc::new(AtomicBool::new(false)),
@@ -87,9 +89,9 @@ impl PeerConnectionInternal {
             ice_connection_state: Arc::new(AtomicU8::new(RTCIceConnectionState::New as u8)),
             sctp_transport: Arc::new(Default::default()),
             rtp_transceivers: Arc::new(Default::default()),
-            on_track_handler: Arc::new(Default::default()),
-            on_signaling_state_change_handler: Arc::new(Default::default()),
-            on_ice_connection_state_change_handler: Arc::new(Default::default()),
+            on_track_handler: Arc::new(ArcSwapOption::empty()),
+            on_signaling_state_change_handler: ArcSwapOption::empty(),
+            on_ice_connection_state_change_handler: Arc::new(ArcSwapOption::empty()),
             on_data_channel_handler: Arc::new(Default::default()),
             ice_gatherer: Arc::new(Default::default()),
             current_local_description: Arc::new(Default::default()),
@@ -105,7 +107,7 @@ impl PeerConnectionInternal {
             },
             interceptor,
             stats_interceptor,
-            on_peer_connection_state_change_handler: Arc::new(Default::default()),
+            on_peer_connection_state_change_handler: Arc::new(ArcSwapOption::empty()),
             pending_remote_description: Arc::new(Default::default()),
         };
 
@@ -132,13 +134,12 @@ impl PeerConnectionInternal {
             .on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
                 let on_data_channel_handler2 = Arc::clone(&on_data_channel_handler);
                 Box::pin(async move {
-                    let mut handler = on_data_channel_handler2.lock().await;
-                    if let Some(f) = &mut *handler {
+                    if let Some(hndlr) = &*on_data_channel_handler2.load() {
+                        let mut f = hndlr.lock().await;
                         f(d).await;
                     }
                 })
-            }))
-            .await;
+            }));
 
         Ok((Arc::new(pc), configuration))
     }
@@ -599,8 +600,8 @@ impl PeerConnectionInternal {
         }
     }
 
-    pub(super) async fn set_gather_complete_handler(&self, f: OnGatheringCompleteHdlrFn) {
-        self.ice_gatherer.on_gathering_complete(f).await;
+    pub(super) fn set_gather_complete_handler(&self, f: OnGatheringCompleteHdlrFn) {
+        self.ice_gatherer.on_gathering_complete(f);
     }
 
     /// Start all transports. PeerConnection now has enough state
@@ -642,7 +643,7 @@ impl PeerConnectionInternal {
             })
             .await;
         RTCPeerConnection::update_connection_state(
-            &self.on_peer_connection_state_change_handler,
+            Arc::clone(&self.on_peer_connection_state_change_handler),
             &self.is_closed,
             &self.peer_connection_state,
             self.ice_connection_state.load(Ordering::SeqCst).into(),
@@ -1075,7 +1076,7 @@ impl PeerConnectionInternal {
         receive_mtu: usize,
         incoming: &TrackDetails,
         receiver: Arc<RTCRtpReceiver>,
-        on_track_handler: Arc<Mutex<Option<OnTrackHdlrFn>>>,
+        on_track_handler: Arc<ArcSwapOption<Mutex<OnTrackHdlrFn>>>,
     ) {
         receiver.start(incoming).await;
         for t in receiver.tracks().await {
@@ -1132,49 +1133,47 @@ impl PeerConnectionInternal {
         let on_peer_connection_state_change_handler =
             Arc::clone(&self.on_peer_connection_state_change_handler);
 
-        ice_transport
-            .on_connection_state_change(Box::new(move |state: RTCIceTransportState| {
-                let cs = match state {
-                    RTCIceTransportState::New => RTCIceConnectionState::New,
-                    RTCIceTransportState::Checking => RTCIceConnectionState::Checking,
-                    RTCIceTransportState::Connected => RTCIceConnectionState::Connected,
-                    RTCIceTransportState::Completed => RTCIceConnectionState::Completed,
-                    RTCIceTransportState::Failed => RTCIceConnectionState::Failed,
-                    RTCIceTransportState::Disconnected => RTCIceConnectionState::Disconnected,
-                    RTCIceTransportState::Closed => RTCIceConnectionState::Closed,
-                    _ => {
-                        log::warn!("on_connection_state_change: unhandled ICE state: {}", state);
-                        return Box::pin(async {});
-                    }
-                };
+        ice_transport.on_connection_state_change(Box::new(move |state: RTCIceTransportState| {
+            let cs = match state {
+                RTCIceTransportState::New => RTCIceConnectionState::New,
+                RTCIceTransportState::Checking => RTCIceConnectionState::Checking,
+                RTCIceTransportState::Connected => RTCIceConnectionState::Connected,
+                RTCIceTransportState::Completed => RTCIceConnectionState::Completed,
+                RTCIceTransportState::Failed => RTCIceConnectionState::Failed,
+                RTCIceTransportState::Disconnected => RTCIceConnectionState::Disconnected,
+                RTCIceTransportState::Closed => RTCIceConnectionState::Closed,
+                _ => {
+                    log::warn!("on_connection_state_change: unhandled ICE state: {}", state);
+                    return Box::pin(async {});
+                }
+            };
 
-                let ice_connection_state2 = Arc::clone(&ice_connection_state);
-                let on_ice_connection_state_change_handler2 =
-                    Arc::clone(&on_ice_connection_state_change_handler);
-                let on_peer_connection_state_change_handler2 =
-                    Arc::clone(&on_peer_connection_state_change_handler);
-                let is_closed2 = Arc::clone(&is_closed);
-                let dtls_transport_state = dtls_transport.state();
-                let peer_connection_state2 = Arc::clone(&peer_connection_state);
-                Box::pin(async move {
-                    RTCPeerConnection::do_ice_connection_state_change(
-                        &on_ice_connection_state_change_handler2,
-                        &ice_connection_state2,
-                        cs,
-                    )
-                    .await;
+            let ice_connection_state2 = Arc::clone(&ice_connection_state);
+            let on_ice_connection_state_change_handler2 =
+                Arc::clone(&on_ice_connection_state_change_handler);
+            let on_peer_connection_state_change_handler2 =
+                Arc::clone(&on_peer_connection_state_change_handler);
+            let is_closed2 = Arc::clone(&is_closed);
+            let dtls_transport_state = dtls_transport.state();
+            let peer_connection_state2 = Arc::clone(&peer_connection_state);
+            Box::pin(async move {
+                RTCPeerConnection::do_ice_connection_state_change(
+                    on_ice_connection_state_change_handler2,
+                    &ice_connection_state2,
+                    cs,
+                )
+                .await;
 
-                    RTCPeerConnection::update_connection_state(
-                        &on_peer_connection_state_change_handler2,
-                        &is_closed2,
-                        &peer_connection_state2,
-                        cs,
-                        dtls_transport_state,
-                    )
-                    .await;
-                })
-            }))
-            .await;
+                RTCPeerConnection::update_connection_state(
+                    on_peer_connection_state_change_handler2,
+                    &is_closed2,
+                    &peer_connection_state2,
+                    cs,
+                    dtls_transport_state,
+                )
+                .await;
+            })
+        }));
 
         ice_transport
     }

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -643,7 +643,7 @@ impl PeerConnectionInternal {
             })
             .await;
         RTCPeerConnection::update_connection_state(
-            Arc::clone(&self.on_peer_connection_state_change_handler),
+            &self.on_peer_connection_state_change_handler,
             &self.is_closed,
             &self.peer_connection_state,
             self.ice_connection_state.load(Ordering::SeqCst).into(),
@@ -1158,14 +1158,14 @@ impl PeerConnectionInternal {
             let peer_connection_state2 = Arc::clone(&peer_connection_state);
             Box::pin(async move {
                 RTCPeerConnection::do_ice_connection_state_change(
-                    on_ice_connection_state_change_handler2,
+                    &on_ice_connection_state_change_handler2,
                     &ice_connection_state2,
                     cs,
                 )
                 .await;
 
                 RTCPeerConnection::update_connection_state(
-                    on_peer_connection_state_change_handler2,
+                    &on_peer_connection_state_change_handler2,
                     &is_closed2,
                     &peer_connection_state2,
                     cs,

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -134,8 +134,8 @@ impl PeerConnectionInternal {
             .on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
                 let on_data_channel_handler2 = Arc::clone(&on_data_channel_handler);
                 Box::pin(async move {
-                    if let Some(hndlr) = &*on_data_channel_handler2.load() {
-                        let mut f = hndlr.lock().await;
+                    if let Some(handler) = &*on_data_channel_handler2.load() {
+                        let mut f = handler.lock().await;
                         f(d).await;
                     }
                 })

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -269,7 +269,7 @@ pub(crate) async fn add_candidates_to_media_descriptions(
     };
 
     for c in candidates {
-        let candidate = c.to_ice().await?;
+        let candidate = c.to_ice()?;
 
         candidate.set_component(1);
         m = append_candidate_if_new(&candidate, m);
@@ -810,8 +810,7 @@ pub(crate) async fn extract_ice_details(
         for a in &m.attributes {
             if a.is_ice_candidate() {
                 if let Some(value) = &a.value {
-                    let c: Arc<dyn Candidate + Send + Sync> =
-                        Arc::new(unmarshal_candidate(value).await?);
+                    let c: Arc<dyn Candidate + Send + Sync> = Arc::new(unmarshal_candidate(value)?);
                     let candidate = RTCIceCandidate::from(&c);
                     candidates.push(candidate);
                 }

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -248,14 +248,12 @@ async fn test_rtp_transceiver_set_direction_causing_negotiation() -> Result<()> 
 
     {
         let count = count.clone();
-        offer_pc
-            .on_negotiation_needed(Box::new(move || {
-                let count = count.clone();
-                Box::pin(async move {
-                    count.fetch_add(1, Ordering::SeqCst);
-                })
-            }))
-            .await;
+        offer_pc.on_negotiation_needed(Box::new(move || {
+            let count = count.clone();
+            Box::pin(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+            })
+        }));
     }
 
     let offer_transceiver = offer_pc

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -387,7 +387,7 @@ impl RTCSctpTransport {
         reports.insert(peer_connection_id, PeerConnection(peer_connection_stats));
 
         // conn
-        if let Some(agent) = dtls_transport.ice_transport.gatherer.get_agent() {
+        if let Some(agent) = dtls_transport.ice_transport.gatherer.get_agent().await {
             let stats = ICETransportStats::new("sctp_transport".to_owned(), agent);
             reports.insert(stats.id.clone(), SCTPTransport(stats));
         }

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -23,7 +23,6 @@ use sctp::association::Association;
 
 use crate::data_channel::data_channel_parameters::DataChannelParameters;
 
-use arc_swap::access::Access;
 use arc_swap::ArcSwapOption;
 use data::data_channel::DataChannel;
 use std::collections::HashMap;

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -235,8 +235,8 @@ impl RTCSctpTransport {
                         Err(err) => {
                             if data::Error::ErrStreamClosed == err {
                                 log::error!("Failed to accept data channel: {}", err);
-                                if let Some(hndlr) = &*param.on_error_handler.load() {
-                                    let mut f = hndlr.lock().await;
+                                if let Some(handler) = &*param.on_error_handler.load() {
+                                    let mut f = handler.lock().await;
                                     f(err.into()).await;
                                 }
                             }
@@ -293,8 +293,8 @@ impl RTCSctpTransport {
                 Arc::clone(&param.setting_engine),
             ));
 
-            if let Some(hndlr) = &*param.on_data_channel_handler.load() {
-                let mut f = hndlr.lock().await;
+            if let Some(handler) = &*param.on_data_channel_handler.load() {
+                let mut f = handler.lock().await;
                 f(Arc::clone(&rtc_dc)).await;
 
                 param.data_channels_accepted.fetch_add(1, Ordering::SeqCst);
@@ -305,8 +305,8 @@ impl RTCSctpTransport {
 
             rtc_dc.handle_open(Arc::new(dc)).await;
 
-            if let Some(hndlr) = &*param.on_data_channel_opened_handler.load() {
-                let mut f = hndlr.lock().await;
+            if let Some(handler) = &*param.on_data_channel_opened_handler.load() {
+                let mut f = handler.lock().await;
                 f(rtc_dc).await;
                 param.data_channels_opened.fetch_add(1, Ordering::SeqCst);
             }

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -23,6 +23,8 @@ use sctp::association::Association;
 
 use crate::data_channel::data_channel_parameters::DataChannelParameters;
 
+use arc_swap::access::Access;
+use arc_swap::ArcSwapOption;
 use data::data_channel::DataChannel;
 use std::collections::HashMap;
 use std::future::Future;
@@ -50,9 +52,9 @@ struct AcceptDataChannelParams {
     notify_rx: Arc<Notify>,
     sctp_association: Arc<Association>,
     data_channels: Arc<Mutex<Vec<Arc<RTCDataChannel>>>>,
-    on_error_handler: Arc<Mutex<Option<OnErrorHdlrFn>>>,
-    on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
-    on_data_channel_opened_handler: Arc<Mutex<Option<OnDataChannelOpenedHdlrFn>>>,
+    on_error_handler: Arc<ArcSwapOption<Mutex<OnErrorHdlrFn>>>,
+    on_data_channel_handler: Arc<ArcSwapOption<Mutex<OnDataChannelHdlrFn>>>,
+    on_data_channel_opened_handler: Arc<ArcSwapOption<Mutex<OnDataChannelOpenedHdlrFn>>>,
     data_channels_opened: Arc<AtomicU32>,
     data_channels_accepted: Arc<AtomicU32>,
     setting_engine: Arc<SettingEngine>,
@@ -80,9 +82,9 @@ pub struct RTCSctpTransport {
 
     sctp_association: Mutex<Option<Arc<Association>>>,
 
-    on_error_handler: Arc<Mutex<Option<OnErrorHdlrFn>>>,
-    on_data_channel_handler: Arc<Mutex<Option<OnDataChannelHdlrFn>>>,
-    on_data_channel_opened_handler: Arc<Mutex<Option<OnDataChannelOpenedHdlrFn>>>,
+    on_error_handler: Arc<ArcSwapOption<Mutex<OnErrorHdlrFn>>>,
+    on_data_channel_handler: Arc<ArcSwapOption<Mutex<OnDataChannelHdlrFn>>>,
+    on_data_channel_opened_handler: Arc<ArcSwapOption<Mutex<OnDataChannelOpenedHdlrFn>>>,
 
     // DataChannels
     pub(crate) data_channels: Arc<Mutex<Vec<Arc<RTCDataChannel>>>>,
@@ -107,9 +109,9 @@ impl RTCSctpTransport {
             max_message_size: RTCSctpTransport::calc_message_size(65536, 65536),
             max_channels: SCTP_MAX_CHANNELS,
             sctp_association: Mutex::new(None),
-            on_error_handler: Arc::new(Mutex::new(None)),
-            on_data_channel_handler: Arc::new(Mutex::new(None)),
-            on_data_channel_opened_handler: Arc::new(Mutex::new(None)),
+            on_error_handler: Arc::new(ArcSwapOption::empty()),
+            on_data_channel_handler: Arc::new(ArcSwapOption::empty()),
+            on_data_channel_opened_handler: Arc::new(ArcSwapOption::empty()),
 
             data_channels: Arc::new(Mutex::new(vec![])),
             data_channels_opened: Arc::new(AtomicU32::new(0)),
@@ -234,8 +236,8 @@ impl RTCSctpTransport {
                         Err(err) => {
                             if data::Error::ErrStreamClosed == err {
                                 log::error!("Failed to accept data channel: {}", err);
-                                let mut handler = param.on_error_handler.lock().await;
-                                if let Some(f) = &mut *handler {
+                                if let Some(hndlr) = &*param.on_error_handler.load() {
+                                    let mut f = hndlr.lock().await;
                                     f(err.into()).await;
                                 }
                             }
@@ -292,48 +294,44 @@ impl RTCSctpTransport {
                 Arc::clone(&param.setting_engine),
             ));
 
-            {
-                let mut handler = param.on_data_channel_handler.lock().await;
-                if let Some(f) = &mut *handler {
-                    f(Arc::clone(&rtc_dc)).await;
-                    param.data_channels_accepted.fetch_add(1, Ordering::SeqCst);
+            if let Some(hndlr) = &*param.on_data_channel_handler.load() {
+                let mut f = hndlr.lock().await;
+                f(Arc::clone(&rtc_dc)).await;
 
-                    let mut dcs = param.data_channels.lock().await;
-                    dcs.push(Arc::clone(&rtc_dc));
-                }
+                param.data_channels_accepted.fetch_add(1, Ordering::SeqCst);
+
+                let mut dcs = param.data_channels.lock().await;
+                dcs.push(Arc::clone(&rtc_dc));
             }
 
             rtc_dc.handle_open(Arc::new(dc)).await;
 
-            {
-                let mut handler = param.on_data_channel_opened_handler.lock().await;
-                if let Some(f) = &mut *handler {
-                    f(rtc_dc).await;
-                    param.data_channels_opened.fetch_add(1, Ordering::SeqCst);
-                }
+            if let Some(hndlr) = &*param.on_data_channel_opened_handler.load() {
+                let mut f = hndlr.lock().await;
+                f(rtc_dc).await;
+                param.data_channels_opened.fetch_add(1, Ordering::SeqCst);
             }
         }
     }
 
     /// on_error sets an event handler which is invoked when
     /// the SCTP connection error occurs.
-    pub async fn on_error(&self, f: OnErrorHdlrFn) {
-        let mut handler = self.on_error_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_error(&self, f: OnErrorHdlrFn) {
+        self.on_error_handler.store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_data_channel sets an event handler which is invoked when a data
     /// channel message arrives from a remote peer.
-    pub async fn on_data_channel(&self, f: OnDataChannelHdlrFn) {
-        let mut handler = self.on_data_channel_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_data_channel(&self, f: OnDataChannelHdlrFn) {
+        self.on_data_channel_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     /// on_data_channel_opened sets an event handler which is invoked when a data
     /// channel is opened
-    pub async fn on_data_channel_opened(&self, f: OnDataChannelOpenedHdlrFn) {
-        let mut handler = self.on_data_channel_opened_handler.lock().await;
-        *handler = Some(f);
+    pub fn on_data_channel_opened(&self, f: OnDataChannelOpenedHdlrFn) {
+        self.on_data_channel_opened_handler
+            .store(Some(Arc::new(Mutex::new(f))));
     }
 
     fn calc_message_size(remote_max_message_size: usize, can_send_size: usize) -> usize {
@@ -390,8 +388,8 @@ impl RTCSctpTransport {
         reports.insert(peer_connection_id, PeerConnection(peer_connection_stats));
 
         // conn
-        if let Some(agent) = dtls_transport.ice_transport.gatherer.get_agent().await {
-            let stats = ICETransportStats::new("sctp_transport".to_owned(), agent).await;
+        if let Some(agent) = dtls_transport.ice_transport.gatherer.get_agent() {
+            let stats = ICETransportStats::new("sctp_transport".to_owned(), agent);
             reports.insert(stats.id.clone(), SCTPTransport(stats));
         }
 

--- a/webrtc/src/stats/mod.rs
+++ b/webrtc/src/stats/mod.rs
@@ -271,11 +271,11 @@ pub struct ICETransportStats {
 }
 
 impl ICETransportStats {
-    pub(crate) async fn new(id: String, agent: Arc<Agent>) -> Self {
+    pub(crate) fn new(id: String, agent: Arc<Agent>) -> Self {
         ICETransportStats {
             id,
-            bytes_received: agent.get_bytes_received().await,
-            bytes_sent: agent.get_bytes_sent().await,
+            bytes_received: agent.get_bytes_received(),
+            bytes_sent: agent.get_bytes_sent(),
             stats_type: RTCStatsType::Transport,
             timestamp: Instant::now(),
         }

--- a/webrtc/src/stats/stats_collector.rs
+++ b/webrtc/src/stats/stats_collector.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
 
 use super::StatsReportType;
+
+use util::sync::Mutex;
 
 #[derive(Debug, Default)]
 pub struct StatsCollector {
@@ -16,16 +17,16 @@ impl StatsCollector {
     }
 
     pub(crate) fn insert(&self, id: String, stats: StatsReportType) {
-        let mut reports = self.reports.lock().unwrap();
+        let mut reports = self.reports.lock();
         reports.insert(id, stats);
     }
 
     pub(crate) fn merge(&self, stats: HashMap<String, StatsReportType>) {
-        let mut reports = self.reports.lock().unwrap();
+        let mut reports = self.reports.lock();
         reports.extend(stats)
     }
 
     pub(crate) fn into_reports(self) -> HashMap<String, StatsReportType> {
-        self.reports.into_inner().unwrap()
+        self.reports.into_inner()
     }
 }

--- a/webrtc/src/track/track_local/track_local_static_test.rs
+++ b/webrtc/src/track/track_local/track_local_static_test.rs
@@ -257,24 +257,22 @@ async fn test_track_local_static_payload_type() -> Result<()> {
 
     let (on_track_fired_tx, on_track_fired_rx) = mpsc::channel::<()>(1);
     let on_track_fired_tx = Arc::new(Mutex::new(Some(on_track_fired_tx)));
-    offerer
-        .on_track(Box::new(
-            move |track: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
-                let on_track_fired_tx2 = Arc::clone(&on_track_fired_tx);
-                Box::pin(async move {
-                    if let Some(t) = &track {
-                        assert_eq!(t.payload_type(), 100);
-                        assert_eq!(t.codec().await.capability.mime_type, MIME_TYPE_VP8);
-                    }
-                    {
-                        log::debug!("onTrackFiredFunc!!!");
-                        let mut done = on_track_fired_tx2.lock().await;
-                        done.take();
-                    }
-                })
-            },
-        ))
-        .await;
+    offerer.on_track(Box::new(
+        move |track: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
+            let on_track_fired_tx2 = Arc::clone(&on_track_fired_tx);
+            Box::pin(async move {
+                if let Some(t) = &track {
+                    assert_eq!(t.payload_type(), 100);
+                    assert_eq!(t.codec().await.capability.mime_type, MIME_TYPE_VP8);
+                }
+                {
+                    log::debug!("onTrackFiredFunc!!!");
+                    let mut done = on_track_fired_tx2.lock().await;
+                    done.take();
+                }
+            })
+        },
+    ));
 
     signal_pair(&mut offerer, &mut answerer).await?;
 


### PR DESCRIPTION
> mind if i create a PR that makes all callback setters (e.g. RTCPeerConnection::on_ice_candidate()) non async? Currently callbacks are stored behind tokio::Mutex'es, i believe that ArcSwap can be used here, so we can use atomic load/store. It wont affect performance in any way, just some quality of life improvements.

> All good with me. I'd like to get rid of  tokio::Mutex, replacing it with sync variants, where that's possible

So i've refactored all public callback setters here. 

Regarding removing `tokio::Mutex`es that you've mentioned, well, i've replaced some of those, but i don't want this PR to become even bigger, and it would be nice if you provide some feedback first. I've used both `ArcSwap` and `std::Mutex`, i guess its ok to use blocking mutex in simple cases, when you don't need to hold it, e.g. copy, store, swap, take one-liners. I will prepare follow-up PRs on this issue if this PR looks good to you.

And one more thing regarding the callbacks, maybe it makes sense to make them just dumb `Box<dyn Fn(_)>`? So `Box<dyn (FnMut(ConnectionState) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync>` => `Box<dyn (Fn(ConnectionState)) + Send + Sync>`.  Yeah, that might hurt users in some rare cases, but it would make everything simpler.

ack @k0nserv 