### PR TITLE
[PollStream/PollDataChannel] do not loose bytes

### DIFF
--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
-* Fixed a potential bug in `PollDataChannel::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
+* Do not loose data in `PollDataChannel::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 * `PollDataChannel::poll_shutdown`: make sure to flush any writes before shutting down [#340](https://github.com/webrtc-rs/webrtc/pull/340)
 
 ## 0.5.0

--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+* Fixed a potential bug in `PollDataChannel::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 
 ## 0.5.0
 

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -584,15 +584,15 @@ impl AsyncWrite for PollDataChannel {
                     // `Poll::Pending` can't be returned because that would mean the `PollStream`
                     // is not ready for writing. And this is not true since we've just created a
                     // future, which is going to write the buf to the underlying stream.
-                    continue;
+                    continue
                 }
                 Poll::Ready(Err(e)) => {
                     self.write_fut = None;
-                    Poll::Ready(Err(e.into()))
+                    return Poll::Ready(Err(e.into()));
                 }
                 Poll::Ready(Ok(n)) => {
                     self.write_fut = None;
-                    Poll::Ready(Ok(n))
+                    return Poll::Ready(Ok(n));
                 }
             }
         }

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -597,9 +597,9 @@ impl AsyncWrite for PollDataChannel {
 
             match fut.as_mut().poll(cx) {
                 // If it's the first time we're polling the future, `Poll::Pending` can't be
-                // returned because that would mean the `PollStream` is not ready for writing. And
-                // this is not true since we've just created a future, which is going to write the
-                // buf to the underlying stream.
+                // returned because that would mean the `PollDataChannel` is not ready for writing.
+                // And this is not true since we've just created a future, which is going to write
+                // the buf to the underlying stream.
                 //
                 // It's okay to return `Poll::Ready` if the data is buffered (this is what the
                 // buffered writer and `File` do).

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -566,44 +566,34 @@ impl AsyncWrite for PollDataChannel {
             return Poll::Ready(Ok(0));
         }
 
-        let (fut, fut_is_new) = match self.write_fut.as_mut() {
-            Some(fut) => (fut, false),
+        let fut = match self.write_fut.as_mut() {
+            Some(fut) => fut,
             None => {
                 let data_channel = self.data_channel.clone();
                 let bytes = Bytes::copy_from_slice(buf);
-                (
-                    self.write_fut
-                        .get_or_insert(Box::pin(async move { data_channel.write(&bytes).await })),
-                    true,
-                )
+                self.write_fut
+                    .get_or_insert(Box::pin(async move { data_channel.write(&bytes).await }))
             }
         };
 
-        match fut.as_mut().poll(cx) {
-            Poll::Pending => {
-                // If it's the first time we're polling the future, `Poll::Pending` can't be
-                // returned because that would mean the `PollStream` is not ready for writing. And
-                // this is not true since we've just created a future, which is going to write the
-                // buf to the underlying stream.
-                //
-                // It's okay to return `Poll::Ready` if the data is buffered (this is what the
-                // buffered writer and `File` do).
-                if fut_is_new {
-                    Poll::Ready(Ok(buf.len()))
-                } else {
-                    // If it's the subsequent poll, it's okay to return `Poll::Pending` as it
-                    // indicates that the `PollStream` is not ready for writing. Only one future
-                    // can be in progress at the time.
-                    Poll::Pending
+        // It's okay to loop here since the data is buffered by the data channel (IO is happening
+        // in a separate thread).
+        loop {
+            match fut.as_mut().poll(cx) {
+                Poll::Pending => {
+                    // `Poll::Pending` can't be returned because that would mean the `PollStream`
+                    // is not ready for writing. And this is not true since we've just created a
+                    // future, which is going to write the buf to the underlying stream.
+                    continue;
                 }
-            }
-            Poll::Ready(Err(e)) => {
-                self.write_fut = None;
-                Poll::Ready(Err(e.into()))
-            }
-            Poll::Ready(Ok(n)) => {
-                self.write_fut = None;
-                Poll::Ready(Ok(n))
+                Poll::Ready(Err(e)) => {
+                    self.write_fut = None;
+                    Poll::Ready(Err(e.into()))
+                }
+                Poll::Ready(Ok(n)) => {
+                    self.write_fut = None;
+                    Poll::Ready(Ok(n))
+                }
             }
         }
     }

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -584,7 +584,7 @@ impl AsyncWrite for PollDataChannel {
                     // `Poll::Pending` can't be returned because that would mean the `PollStream`
                     // is not ready for writing. And this is not true since we've just created a
                     // future, which is going to write the buf to the underlying stream.
-                    continue
+                    continue;
                 }
                 Poll::Ready(Err(e)) => {
                     self.write_fut = None;

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -566,33 +566,51 @@ impl AsyncWrite for PollDataChannel {
             return Poll::Ready(Ok(0));
         }
 
-        let fut = match self.write_fut.as_mut() {
-            Some(fut) => fut,
-            None => {
-                let data_channel = self.data_channel.clone();
-                let bytes = Bytes::copy_from_slice(buf);
-                self.write_fut
-                    .get_or_insert(Box::pin(async move { data_channel.write(&bytes).await }))
-            }
-        };
-
-        // It's okay to loop here since the data is buffered by the data channel (IO is happening
-        // in a separate thread).
-        loop {
+        if let Some(fut) = self.write_fut.as_mut() {
             match fut.as_mut().poll(cx) {
-                Poll::Pending => {
-                    // `Poll::Pending` can't be returned because that would mean the `PollStream`
-                    // is not ready for writing. And this is not true since we've just created a
-                    // future, which is going to write the buf to the underlying stream.
-                    continue;
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(e)) => {
+                    let data_channel = self.data_channel.clone();
+                    let bytes = Bytes::copy_from_slice(buf);
+                    self.write_fut =
+                        Some(Box::pin(async move { data_channel.write(&bytes).await }));
+                    Poll::Ready(Err(e.into()))
                 }
+                // Given the data is buffered, it's okay to ignore the number of written bytes.
+                //
+                // TODO: In the long term, `data_channel.write` should be made sync. Then we could
+                // remove the whole `if` condition and just call `data_channel.write`.
+                Poll::Ready(Ok(_)) => {
+                    let data_channel = self.data_channel.clone();
+                    let bytes = Bytes::copy_from_slice(buf);
+                    self.write_fut =
+                        Some(Box::pin(async move { data_channel.write(&bytes).await }));
+                    Poll::Ready(Ok(buf.len()))
+                }
+            }
+        } else {
+            let data_channel = self.data_channel.clone();
+            let bytes = Bytes::copy_from_slice(buf);
+            let fut = self
+                .write_fut
+                .insert(Box::pin(async move { data_channel.write(&bytes).await }));
+
+            match fut.as_mut().poll(cx) {
+                // If it's the first time we're polling the future, `Poll::Pending` can't be
+                // returned because that would mean the `PollStream` is not ready for writing. And
+                // this is not true since we've just created a future, which is going to write the
+                // buf to the underlying stream.
+                //
+                // It's okay to return `Poll::Ready` if the data is buffered (this is what the
+                // buffered writer and `File` do).
+                Poll::Pending => Poll::Ready(Ok(buf.len())),
                 Poll::Ready(Err(e)) => {
                     self.write_fut = None;
-                    return Poll::Ready(Err(e.into()));
+                    Poll::Ready(Err(e.into()))
                 }
                 Poll::Ready(Ok(n)) => {
                     self.write_fut = None;
-                    return Poll::Ready(Ok(n));
+                    Poll::Ready(Ok(n))
                 }
             }
         }

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
-* Fixed a potential bug in `PollStream::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
+* Do not loose data in `PollStream::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 * `PollStream::poll_shutdown`: make sure to flush any writes before shutting down [#340](https://github.com/webrtc-rs/webrtc/pull/340)
 
 ## v0.6.1

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Increased minimum support rust version to `1.60.0`.
+* Fixed a potential bug in `PollStream::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 
 ## v0.6.1
 

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -718,15 +718,15 @@ impl AsyncWrite for PollStream {
                     // `Poll::Pending` can't be returned because that would mean the `PollStream` is
                     // not ready for writing. And this is not true since we've just created a future,
                     // which is going to write the buf to the underlying stream.
-                    continue;
+                    continue
                 }
                 Poll::Ready(Err(e)) => {
                     self.write_fut = None;
-                    Poll::Ready(Err(e.into()))
+                    return Poll::Ready(Err(e.into()));
                 }
                 Poll::Ready(Ok(n)) => {
                     self.write_fut = None;
-                    Poll::Ready(Ok(n))
+                    return Poll::Ready(Ok(n));
                 }
             }
         }

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -700,44 +700,34 @@ impl AsyncWrite for PollStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let (fut, fut_is_new) = match self.write_fut.as_mut() {
-            Some(fut) => (fut, false),
+        let fut = match self.write_fut.as_mut() {
+            Some(fut) => fut,
             None => {
                 let stream = self.stream.clone();
                 let bytes = Bytes::copy_from_slice(buf);
-                (
-                    self.write_fut
-                        .get_or_insert(Box::pin(async move { stream.write(&bytes).await })),
-                    true,
-                )
+                self.write_fut
+                    .get_or_insert(Box::pin(async move { stream.write(&bytes).await }))
             }
         };
 
-        match fut.as_mut().poll(cx) {
-            Poll::Pending => {
-                // If it's the first time we're polling the future, `Poll::Pending` can't be
-                // returned because that would mean the `PollStream` is not ready for writing. And
-                // this is not true since we've just created a future, which is going to write the
-                // buf to the underlying stream.
-                //
-                // It's okay to return `Poll::Ready` if the data is buffered (this is what the
-                // buffered writer and `File` do).
-                if fut_is_new {
-                    Poll::Ready(Ok(buf.len()))
-                } else {
-                    // If it's the subsequent poll, it's okay to return `Poll::Pending` as it
-                    // indicates that the `PollStream` is not ready for writing. Only one future
-                    // can be in progress at the time.
-                    Poll::Pending
+        // It's okay to loop here since the data is buffered by the data channel (IO is happening
+        // in a separate thread).
+        loop {
+            match fut.as_mut().poll(cx) {
+                Poll::Pending => {
+                    // `Poll::Pending` can't be returned because that would mean the `PollStream` is
+                    // not ready for writing. And this is not true since we've just created a future,
+                    // which is going to write the buf to the underlying stream.
+                    continue;
                 }
-            }
-            Poll::Ready(Err(e)) => {
-                self.write_fut = None;
-                Poll::Ready(Err(e.into()))
-            }
-            Poll::Ready(Ok(n)) => {
-                self.write_fut = None;
-                Poll::Ready(Ok(n))
+                Poll::Ready(Err(e)) => {
+                    self.write_fut = None;
+                    Poll::Ready(Err(e.into()))
+                }
+                Poll::Ready(Ok(n)) => {
+                    self.write_fut = None;
+                    Poll::Ready(Ok(n))
+                }
             }
         }
     }

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -718,7 +718,7 @@ impl AsyncWrite for PollStream {
                     // `Poll::Pending` can't be returned because that would mean the `PollStream` is
                     // not ready for writing. And this is not true since we've just created a future,
                     // which is going to write the buf to the underlying stream.
-                    continue
+                    continue;
                 }
                 Poll::Ready(Err(e)) => {
                     self.write_fut = None;

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -13,7 +13,6 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
 * Updated minimum rust version to `1.60.0`
 * Added a new `write_rtp_with_extensions` method to `TrackLocalStaticSample` and `TrackLocalStatiRTP`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
 * Added a new `sample_writer` helper to `TrackLocalStaticSample`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
-* Fixed a potential bug in `PollDataChannel::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 
 #### Breaking changes
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -13,6 +13,7 @@ directions that should not send. [#316](https://github.com/webrtc-rs/webrtc/pull
 * Updated minimum rust version to `1.60.0`
 * Added a new `write_rtp_with_extensions` method to `TrackLocalStaticSample` and `TrackLocalStatiRTP`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
 * Added a new `sample_writer` helper to `TrackLocalStaticSample`. [#336](https://github.com/webrtc-rs/webrtc/pull/336) by [@k0nserv](https://github.com/k0nserv).
+* Fixed a potential bug in `PollDataChannel::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 
 #### Breaking changes
 


### PR DESCRIPTION
Returning `Poll::Ready(Ok(n))` when `write_fut` is `Some` is incorrect since `buf` already contains new data and we should instead always return `Poll::Ready(Ok(buf.len()))` and update `write_fut`.

In the future, if/when we make `write` synchronous, this whole block could be simplified to just contain a single call (1 line) to `write`. See #344 