### PR TITLE
[sctp] make `write` sync

### DIFF
--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -119,8 +119,7 @@ impl DataChannel {
             .marshal()?;
 
             stream
-                .write_sctp(&msg, PayloadProtocolIdentifier::Dcep)
-                .await?;
+                .write_sctp(&msg, PayloadProtocolIdentifier::Dcep)?;
         }
         Ok(DataChannel::new(stream, config))
     }
@@ -288,11 +287,10 @@ impl DataChannel {
         let n = if data_len == 0 {
             let _ = self
                 .stream
-                .write_sctp(&Bytes::from_static(&[0]), ppi)
-                .await?;
+                .write_sctp(&Bytes::from_static(&[0]), ppi)?;
             0
         } else {
-            let n = self.stream.write_sctp(data, ppi).await?;
+            let n = self.stream.write_sctp(data, ppi)?;
             self.bytes_sent.fetch_add(n, Ordering::SeqCst);
             n
         };
@@ -305,8 +303,7 @@ impl DataChannel {
         let ack = Message::DataChannelAck(DataChannelAck {}).marshal()?;
         Ok(self
             .stream
-            .write_sctp(&ack, PayloadProtocolIdentifier::Dcep)
-            .await?)
+            .write_sctp(&ack, PayloadProtocolIdentifier::Dcep)?)
     }
 
     /// Close closes the DataChannel and the underlying SCTP stream.

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Unreleased
 
+### Breaking
+
+* Make `sctp::Stream::write` & `sctp::Stream::write_sctp` sync [#344](https://github.com/webrtc-rs/webrtc/pull/344)
+
 ## v0.6.2
 
 * Increased minimum support rust version to `1.60.0`.
 * Do not loose data in `PollStream::poll_write` [#341](https://github.com/webrtc-rs/webrtc/pull/341).
 * `PollStream::poll_shutdown`: make sure to flush any writes before shutting down [#340](https://github.com/webrtc-rs/webrtc/pull/340)
 * Fixed a possible bug when adding chunks to pending queue [#345](https://github.com/webrtc-rs/webrtc/pull/345)
-
-### Breaking
-
-* Make `sctp::Stream::write` & `sctp::Stream::write_sctp` sync [#344](https://github.com/webrtc-rs/webrtc/pull/344)
 
 ## v0.6.1
 

--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Increased minimum support rust version to `1.60.0`.
 * `PollStream::poll_shutdown`: make sure to flush any writes before shutting down [#340](https://github.com/webrtc-rs/webrtc/pull/340)
 
+### Breaking
+
+* Make `sctp::Stream::write` & `sctp::Stream::write_sctp` sync [#344](https://github.com/webrtc-rs/webrtc/pull/344)
+
 ## v0.6.1
 
 * Increased min verison of `log` dependency to `0.4.16`. [#250 Fix log at ^0.4.16 to make tests compile](https://github.com/webrtc-rs/webrtc/pull/250) by [@k0nserv](https://github.com/k0nserv).

--- a/sctp/examples/ping.rs
+++ b/sctp/examples/ping.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Error> {
         while ping_seq_num < 10 {
             let ping_msg = format!("ping {}", ping_seq_num);
             println!("sent: {}", ping_msg);
-            stream_tx.write(&Bytes::from(ping_msg)).await?;
+            stream_tx.write(&Bytes::from(ping_msg))?;
 
             ping_seq_num += 1;
         }

--- a/sctp/examples/pong.rs
+++ b/sctp/examples/pong.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), Error> {
 
             let pong_msg = format!("pong [{}]", ping_msg);
             println!("sent: {}", pong_msg);
-            stream2.write(&Bytes::from(pong_msg)).await?;
+            stream2.write(&Bytes::from(pong_msg))?;
 
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/sctp/src/association/association_internal.rs
+++ b/sctp/src/association/association_internal.rs
@@ -351,7 +351,7 @@ impl AssociationInternal {
     ) -> Vec<Bytes> {
         // Pop unsent data chunks from the pending queue to send as much as
         // cwnd and rwnd allow.
-        let (chunks, sis_to_reset) = self.pop_pending_data_chunks_to_send().await;
+        let (chunks, sis_to_reset) = self.pop_pending_data_chunks_to_send();
         if !chunks.is_empty() {
             // Start timer. (noop if already started)
             log::trace!("[{}] T3-rtx timer start (pt1)", self.name);
@@ -1771,7 +1771,7 @@ impl AssociationInternal {
         self.handle_peer_last_tsn_and_acknowledgement(false)
     }
 
-    async fn send_reset_request(&mut self, stream_identifier: u16) -> Result<()> {
+    fn send_reset_request(&mut self, stream_identifier: u16) -> Result<()> {
         let state = self.get_state();
         if state != AssociationState::Established {
             return Err(Error::ErrResetPacketInStateNotExist);
@@ -1787,7 +1787,7 @@ impl AssociationInternal {
             ..Default::default()
         };
 
-        self.pending_queue.push(c).await;
+        self.pending_queue.push(c);
         self.awake_write_loop();
 
         Ok(())
@@ -1852,12 +1852,12 @@ impl AssociationInternal {
     }
 
     /// Move the chunk peeked with self.pending_queue.peek() to the inflight_queue.
-    async fn move_pending_data_chunk_to_inflight_queue(
+    fn move_pending_data_chunk_to_inflight_queue(
         &mut self,
         beginning_fragment: bool,
         unordered: bool,
     ) -> Option<ChunkPayloadData> {
-        if let Some(mut c) = self.pending_queue.pop(beginning_fragment, unordered).await {
+        if let Some(mut c) = self.pending_queue.pop(beginning_fragment, unordered) {
             // Mark all fragements are in-flight now
             if c.ending_fragment {
                 c.set_all_inflight();
@@ -1894,7 +1894,7 @@ impl AssociationInternal {
 
     /// pop_pending_data_chunks_to_send pops chunks from the pending queues as many as
     /// the cwnd and rwnd allows to send.
-    async fn pop_pending_data_chunks_to_send(&mut self) -> (Vec<ChunkPayloadData>, Vec<u16>) {
+    fn pop_pending_data_chunks_to_send(&mut self) -> (Vec<ChunkPayloadData>, Vec<u16>) {
         let mut chunks = vec![];
         let mut sis_to_reset = vec![]; // stream identifiers to reset
 
@@ -1909,7 +1909,7 @@ impl AssociationInternal {
         //      6.2.1).  However, regardless of the value of rwnd (including if it
         //      is 0), the data sender can always have one DATA chunk in flight to
         //      the receiver if allowed by cwnd (see rule B, below).
-        while let Some(c) = self.pending_queue.peek().await {
+        while let Some(c) = self.pending_queue.peek() {
             let (beginning_fragment, unordered, data_len, stream_identifier) = (
                 c.beginning_fragment,
                 c.unordered,
@@ -1922,7 +1922,6 @@ impl AssociationInternal {
                 if self
                     .pending_queue
                     .pop(beginning_fragment, unordered)
-                    .await
                     .is_none()
                 {
                     log::error!("failed to pop from pending queue");
@@ -1940,9 +1939,8 @@ impl AssociationInternal {
 
             self.rwnd -= data_len as u32;
 
-            if let Some(chunk) = self
-                .move_pending_data_chunk_to_inflight_queue(beginning_fragment, unordered)
-                .await
+            if let Some(chunk) =
+                self.move_pending_data_chunk_to_inflight_queue(beginning_fragment, unordered)
             {
                 chunks.push(chunk);
             }
@@ -1951,12 +1949,11 @@ impl AssociationInternal {
         // the data sender can always have one DATA chunk in flight to the receiver
         if chunks.is_empty() && self.inflight_queue.is_empty() {
             // Send zero window probe
-            if let Some(c) = self.pending_queue.peek().await {
+            if let Some(c) = self.pending_queue.peek() {
                 let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
-                if let Some(chunk) = self
-                    .move_pending_data_chunk_to_inflight_queue(beginning_fragment, unordered)
-                    .await
+                if let Some(chunk) =
+                    self.move_pending_data_chunk_to_inflight_queue(beginning_fragment, unordered)
                 {
                     chunks.push(chunk);
                 }
@@ -1995,22 +1992,6 @@ impl AssociationInternal {
         }
 
         packets
-    }
-
-    /// send_payload_data sends the data chunks.
-    async fn send_payload_data(&mut self, chunks: Vec<ChunkPayloadData>) -> Result<()> {
-        let state = self.get_state();
-        if state != AssociationState::Established {
-            return Err(Error::ErrPayloadDataStateNotExist);
-        }
-
-        // Push the chunks into the pending queue first.
-        for c in chunks {
-            self.pending_queue.push(c).await;
-        }
-
-        self.awake_write_loop();
-        Ok(())
     }
 
     fn check_partial_reliability_status(&self, c: &ChunkPayloadData) {

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -437,8 +437,8 @@ async fn test_assoc_handle_init() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_assoc_max_message_size_default() -> Result<()> {
+#[test]
+fn test_assoc_max_message_size_default() -> Result<()> {
     let mut a = create_association_internal(Config {
         net_conn: Arc::new(DumbConn {}),
         max_receive_buffer_size: 0,
@@ -458,7 +458,7 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
         let p = Bytes::from(vec![0u8; 65537]);
         let ppi = PayloadProtocolIdentifier::from(s.default_payload_type.load(Ordering::SeqCst));
 
-        if let Err(err) = s.write_sctp(&p.slice(..65536), ppi).await {
+        if let Err(err) = s.write_sctp(&p.slice(..65536), ppi) {
             assert_ne!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -468,7 +468,7 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
             assert!(false, "should be error");
         }
 
-        if let Err(err) = s.write_sctp(&p.slice(..65537), ppi).await {
+        if let Err(err) = s.write_sctp(&p.slice(..65537), ppi) {
             assert_eq!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -482,8 +482,8 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_assoc_max_message_size_explicit() -> Result<()> {
+#[test]
+fn test_assoc_max_message_size_explicit() -> Result<()> {
     let mut a = create_association_internal(Config {
         net_conn: Arc::new(DumbConn {}),
         max_receive_buffer_size: 0,
@@ -504,7 +504,7 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
         let p = Bytes::from(vec![0u8; 30001]);
         let ppi = PayloadProtocolIdentifier::from(s.default_payload_type.load(Ordering::SeqCst));
 
-        if let Err(err) = s.write_sctp(&p.slice(..30000), ppi).await {
+        if let Err(err) = s.write_sctp(&p.slice(..30000), ppi) {
             assert_ne!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -514,7 +514,7 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
             assert!(false, "should be error");
         }
 
-        if let Err(err) = s.write_sctp(&p.slice(..30001), ppi).await {
+        if let Err(err) = s.write_sctp(&p.slice(..30001), ppi) {
             assert_eq!(
                 Error::ErrOutboundPacketTooLarge,
                 err,

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -185,9 +185,7 @@ async fn establish_session_pair(
     let s0 = client
         .open_stream(si, PayloadProtocolIdentifier::Binary)
         .await?;
-    let _ = s0
-        .write_sctp(&hello_msg, PayloadProtocolIdentifier::Dcep)
-        .await?;
+    let _ = s0.write_sctp(&hello_msg, PayloadProtocolIdentifier::Dcep)?;
 
     flush_buffers(br, client, server).await;
 
@@ -253,9 +251,7 @@ async fn test_assoc_reliable_simple() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = s0
-        .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG.len(), n, "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
@@ -329,21 +325,17 @@ async fn test_assoc_reliable_ordered_reordered() -> Result<()> {
     }
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -421,12 +413,10 @@ async fn test_assoc_reliable_ordered_fragmented_then_defragmented() -> Result<()
     s0.set_reliability_params(false, ReliabilityType::Reliable, 0);
     s1.set_reliability_params(false, ReliabilityType::Reliable, 0);
 
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbufl.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbufl.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbufl.len(), n, "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
@@ -488,12 +478,10 @@ async fn test_assoc_reliable_unordered_fragmented_then_defragmented() -> Result<
     s0.set_reliability_params(true, ReliabilityType::Reliable, 0);
     s1.set_reliability_params(true, ReliabilityType::Reliable, 0);
 
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbufl.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbufl.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbufl.len(), n, "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
@@ -558,21 +546,17 @@ async fn test_assoc_reliable_unordered_ordered() -> Result<()> {
     br.reorder_next_nwrites(0, 2).await;
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
@@ -646,14 +630,10 @@ async fn test_assoc_reliable_retransmission() -> Result<()> {
 
     let (s0, s1) = establish_session_pair(&br, &a0, &mut a1, SI).await?;
 
-    let n = s0
-        .write_sctp(&MSG1, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG1, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG1.len(), n, "unexpected length of received data");
 
-    let n = s0
-        .write_sctp(&MSG2, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG2, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG2.len(), n, "unexpected length of received data");
 
     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -724,9 +704,7 @@ async fn test_assoc_reliable_short_buffer() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = s0
-        .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG.len(), n, "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
@@ -801,21 +779,17 @@ async fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
     br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     log::debug!("flush_buffers");
@@ -891,21 +865,17 @@ async fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     //log::debug!("flush_buffers");
@@ -976,21 +946,17 @@ async fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
     br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     //log::debug!("flush_buffers");
@@ -1062,21 +1028,17 @@ async fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
     s1.set_reliability_params(true, ReliabilityType::Rexmit, 0); // doesn't matter
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     //log::debug!("flush_buffers");
@@ -1159,21 +1121,17 @@ async fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     //log::debug!("flush_buffers");
@@ -1244,21 +1202,17 @@ async fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
     br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
-    let n = s0
-        .write_sctp(
-            &Bytes::from(sbuf.clone()),
-            PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+    let n = s0.write_sctp(
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     //log::debug!("flush_buffers");
@@ -1343,12 +1297,10 @@ async fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
 
     for i in 0..4u32 {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
-        let n = s0
-            .write_sctp(
-                &Bytes::from(sbuf.clone()),
-                PayloadProtocolIdentifier::Binary,
-            )
-            .await?;
+        let n = s0.write_sctp(
+            &Bytes::from(sbuf.clone()),
+            PayloadProtocolIdentifier::Binary,
+        )?;
         assert_eq!(sbuf.len(), n, "unexpected length of received data");
     }
 
@@ -1448,12 +1400,10 @@ async fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
 
     for i in 0..N_PACKETS_TO_SEND {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
-        let n = s0
-            .write_sctp(
-                &Bytes::from(sbuf.clone()),
-                PayloadProtocolIdentifier::Binary,
-            )
-            .await?;
+        let n = s0.write_sctp(
+            &Bytes::from(sbuf.clone()),
+            PayloadProtocolIdentifier::Binary,
+        )?;
         assert_eq!(sbuf.len(), n, "unexpected length of received data");
     }
 
@@ -1583,12 +1533,10 @@ async fn test_assoc_congestion_control_slow_reader() -> Result<()> {
 
     for i in 0..N_PACKETS_TO_SEND {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
-        let n = s0
-            .write_sctp(
-                &Bytes::from(sbuf.clone()),
-                PayloadProtocolIdentifier::Binary,
-            )
-            .await?;
+        let n = s0.write_sctp(
+            &Bytes::from(sbuf.clone()),
+            PayloadProtocolIdentifier::Binary,
+        )?;
         assert_eq!(sbuf.len(), n, "unexpected length of received data");
     }
 
@@ -1716,8 +1664,7 @@ async fn test_assoc_delayed_ack() -> Result<()> {
         .write_sctp(
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
-        )
-        .await?;
+        )?;
     assert_eq!(sbuf.len(), n, "unexpected length of received data");
 
     // Repeat calling br.Tick() until the buffered amount becomes 0
@@ -1821,9 +1768,7 @@ async fn test_assoc_reset_close_one_way() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = s0
-        .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG.len(), n, "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
@@ -1921,9 +1866,7 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = s0
-        .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s0.write_sctp(&MSG, PayloadProtocolIdentifier::Binary)?;
     assert_eq!(MSG.len(), n, "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
@@ -2318,7 +2261,7 @@ async fn test_association_shutdown() -> Result<()> {
 
     let test_data = Bytes::from_static(b"test");
 
-    let n = s11.write(&test_data).await?;
+    let n = s11.write(&test_data)?;
     assert_eq!(test_data.len(), n);
 
     let mut buf = vec![0u8; test_data.len()];
@@ -2379,7 +2322,7 @@ async fn test_association_shutdown_during_write() -> Result<()> {
     let ss21 = Arc::clone(&s21);
     tokio::spawn(async move {
         let mut i = 0;
-        while ss21.write(&Bytes::from(vec![i])).await.is_ok() {
+        while ss21.write(&Bytes::from(vec![i])).is_ok() {
             if i == 255 {
                 i = 0;
             } else {
@@ -2396,7 +2339,7 @@ async fn test_association_shutdown_during_write() -> Result<()> {
 
     let test_data = Bytes::from_static(b"test");
 
-    let n = s11.write(&test_data).await?;
+    let n = s11.write(&test_data)?;
     assert_eq!(test_data.len(), n);
 
     let mut buf = vec![0u8; test_data.len()];

--- a/sctp/src/queue/pending_queue.rs
+++ b/sctp/src/queue/pending_queue.rs
@@ -89,11 +89,9 @@ impl PendingQueue {
                     let mut unordered_queue = self.unordered_queue.lock().await;
                     unordered_queue.pop_front()
                 };
-                if let Some(p) = &popped {
-                    if !p.ending_fragment {
-                        self.selected.store(true, Ordering::SeqCst);
-                        self.unordered_is_selected.store(true, Ordering::SeqCst);
-                    }
+                if let Some(p) = &popped && !p.ending_fragment {
+                    self.selected.store(true, Ordering::SeqCst);
+                    self.unordered_is_selected.store(true, Ordering::SeqCst);
                 }
                 popped
             } else {
@@ -101,11 +99,9 @@ impl PendingQueue {
                     let mut ordered_queue = self.ordered_queue.lock().await;
                     ordered_queue.pop_front()
                 };
-                if let Some(p) = &popped {
-                    if !p.ending_fragment {
-                        self.selected.store(true, Ordering::SeqCst);
-                        self.unordered_is_selected.store(false, Ordering::SeqCst);
-                    }
+                if let Some(p) = &popped && !p.ending_fragment {
+                    self.selected.store(true, Ordering::SeqCst);
+                    self.unordered_is_selected.store(false, Ordering::SeqCst);
                 }
                 popped
             }

--- a/sctp/src/queue/pending_queue.rs
+++ b/sctp/src/queue/pending_queue.rs
@@ -91,9 +91,11 @@ impl PendingQueue {
                     let mut unordered_queue = self.unordered_queue.write().unwrap();
                     unordered_queue.pop_front()
                 };
-                if let Some(p) = &popped && !p.ending_fragment {
-                    self.selected.store(true, Ordering::SeqCst);
-                    self.unordered_is_selected.store(true, Ordering::SeqCst);
+                if let Some(p) = &popped {
+                    if !p.ending_fragment {
+                        self.selected.store(true, Ordering::SeqCst);
+                        self.unordered_is_selected.store(true, Ordering::SeqCst);
+                    }
                 }
                 popped
             } else {
@@ -101,9 +103,11 @@ impl PendingQueue {
                     let mut ordered_queue = self.ordered_queue.write().unwrap();
                     ordered_queue.pop_front()
                 };
-                if let Some(p) = &popped && !p.ending_fragment {
-                    self.selected.store(true, Ordering::SeqCst);
-                    self.unordered_is_selected.store(false, Ordering::SeqCst);
+                if let Some(p) = &popped {
+                    if !p.ending_fragment {
+                        self.selected.store(true, Ordering::SeqCst);
+                        self.unordered_is_selected.store(false, Ordering::SeqCst);
+                    }
                 }
                 popped
             }

--- a/sctp/src/queue/queue_test.rs
+++ b/sctp/src/queue/queue_test.rs
@@ -272,42 +272,42 @@ fn test_pending_base_queue_out_of_bounce() -> Result<()> {
 
 // NOTE: TSN is not used in pendingQueue in the actual usage.
 //       Following tests use TSN field as a chunk ID.
-#[tokio::test]
-async fn test_pending_queue_push_and_pop() -> Result<()> {
+#[test]
+fn test_pending_queue_push_and_pop() -> Result<()> {
     let pq = PendingQueue::new();
-    pq.push(make_data_chunk(0, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(0, false, NO_FRAGMENT));
     assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(1, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(1, false, NO_FRAGMENT));
     assert_eq!(20, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(2, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(2, false, NO_FRAGMENT));
     assert_eq!(30, pq.get_num_bytes(), "total bytes mismatch");
 
     for i in 0..3 {
-        let c = pq.peek().await;
+        let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
         assert_eq!(i, c.tsn, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
-        let result = pq.pop(beginning_fragment, unordered).await;
+        let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", i);
     }
 
     assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
 
-    pq.push(make_data_chunk(3, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(3, false, NO_FRAGMENT));
     assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(4, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(4, false, NO_FRAGMENT));
     assert_eq!(20, pq.get_num_bytes(), "total bytes mismatch");
 
     for i in 3..5 {
-        let c = pq.peek().await;
+        let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
         assert_eq!(i, c.tsn, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
-        let result = pq.pop(beginning_fragment, unordered).await;
+        let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", i);
     }
 
@@ -316,49 +316,49 @@ async fn test_pending_queue_push_and_pop() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_pending_queue_unordered_wins() -> Result<()> {
+#[test]
+fn test_pending_queue_unordered_wins() -> Result<()> {
     let pq = PendingQueue::new();
 
-    pq.push(make_data_chunk(0, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(0, false, NO_FRAGMENT));
     assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(1, true, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(1, true, NO_FRAGMENT));
     assert_eq!(20, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(2, false, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(2, false, NO_FRAGMENT));
     assert_eq!(30, pq.get_num_bytes(), "total bytes mismatch");
-    pq.push(make_data_chunk(3, true, NO_FRAGMENT)).await;
+    pq.push(make_data_chunk(3, true, NO_FRAGMENT));
     assert_eq!(40, pq.get_num_bytes(), "total bytes mismatch");
 
-    let c = pq.peek().await;
+    let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
     assert_eq!(1, c.tsn, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-    let result = pq.pop(beginning_fragment, unordered).await;
+    let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
 
-    let c = pq.peek().await;
+    let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
     assert_eq!(3, c.tsn, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-    let result = pq.pop(beginning_fragment, unordered).await;
+    let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
 
-    let c = pq.peek().await;
+    let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
     assert_eq!(0, c.tsn, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-    let result = pq.pop(beginning_fragment, unordered).await;
+    let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
 
-    let c = pq.peek().await;
+    let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
     assert_eq!(2, c.tsn, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-    let result = pq.pop(beginning_fragment, unordered).await;
+    let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
 
     assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
@@ -366,25 +366,25 @@ async fn test_pending_queue_unordered_wins() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_pending_queue_fragments() -> Result<()> {
+#[test]
+fn test_pending_queue_fragments() -> Result<()> {
     let pq = PendingQueue::new();
-    pq.push(make_data_chunk(0, false, FRAG_BEGIN)).await;
-    pq.push(make_data_chunk(1, false, FRAG_MIDDLE)).await;
-    pq.push(make_data_chunk(2, false, FRAG_END)).await;
-    pq.push(make_data_chunk(3, true, FRAG_BEGIN)).await;
-    pq.push(make_data_chunk(4, true, FRAG_MIDDLE)).await;
-    pq.push(make_data_chunk(5, true, FRAG_END)).await;
+    pq.push(make_data_chunk(0, false, FRAG_BEGIN));
+    pq.push(make_data_chunk(1, false, FRAG_MIDDLE));
+    pq.push(make_data_chunk(2, false, FRAG_END));
+    pq.push(make_data_chunk(3, true, FRAG_BEGIN));
+    pq.push(make_data_chunk(4, true, FRAG_MIDDLE));
+    pq.push(make_data_chunk(5, true, FRAG_END));
 
     let expects = vec![3, 4, 5, 0, 1, 2];
 
     for exp in expects {
-        let c = pq.peek().await;
+        let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
         assert_eq!(exp, c.tsn, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-        let result = pq.pop(beginning_fragment, unordered).await;
+        let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", exp);
     }
 
@@ -393,32 +393,32 @@ async fn test_pending_queue_fragments() -> Result<()> {
 
 // Once decided ordered or unordered, the decision should persist until
 // it pops a chunk with ending_fragment flags set to true.
-#[tokio::test]
-async fn test_pending_queue_selection_persistence() -> Result<()> {
+#[test]
+fn test_pending_queue_selection_persistence() -> Result<()> {
     let pq = PendingQueue::new();
-    pq.push(make_data_chunk(0, false, FRAG_BEGIN)).await;
+    pq.push(make_data_chunk(0, false, FRAG_BEGIN));
 
-    let c = pq.peek().await;
+    let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
     assert_eq!(0, c.tsn, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-    let result = pq.pop(beginning_fragment, unordered).await;
+    let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error: {}", 0);
 
-    pq.push(make_data_chunk(1, true, NO_FRAGMENT)).await;
-    pq.push(make_data_chunk(2, false, FRAG_MIDDLE)).await;
-    pq.push(make_data_chunk(3, false, FRAG_END)).await;
+    pq.push(make_data_chunk(1, true, NO_FRAGMENT));
+    pq.push(make_data_chunk(2, false, FRAG_MIDDLE));
+    pq.push(make_data_chunk(3, false, FRAG_END));
 
     let expects = vec![2, 3, 1];
 
     for exp in expects {
-        let c = pq.peek().await;
+        let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
         assert_eq!(exp, c.tsn, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
-        let result = pq.pop(beginning_fragment, unordered).await;
+        let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", exp);
     }
 

--- a/sctp/src/stream/stream_test.rs
+++ b/sctp/src/stream/stream_test.rs
@@ -95,12 +95,10 @@ async fn test_stream() -> std::result::Result<(), io::Error> {
     s.set_reliability_params(true, ReliabilityType::Reliable, 0);
 
     // write
-    let n = s.write(&Bytes::from("Hello ")).await?;
+    let n = s.write(&Bytes::from("Hello "))?;
     assert_eq!(6, n);
     assert_eq!(6, s.buffered_amount());
-    let n = s
-        .write_sctp(&Bytes::from("world"), PayloadProtocolIdentifier::Binary)
-        .await?;
+    let n = s.write_sctp(&Bytes::from("world"), PayloadProtocolIdentifier::Binary)?;
     assert_eq!(5, n);
     assert_eq!(11, s.buffered_amount());
 
@@ -123,7 +121,7 @@ async fn test_stream() -> std::result::Result<(), io::Error> {
     // shutdown write
     s.shutdown(Shutdown::Write).await?;
     // write must fail
-    assert!(s.write(&Bytes::from("error")).await.is_err());
+    assert!(s.write(&Bytes::from("error")).is_err());
     // read should continue working
     s.handle_data(ChunkPayloadData {
         unordered: true,


### PR DESCRIPTION
There's no reason for it to be async because it just buffers the data in memory (actual IO is happening in a separate thread).