### PR TITLE
implement from and tryfrom string traits for SessionDescription

### DIFF
--- a/sdp/CHANGELOG.md
+++ b/sdp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Implement from and tryfrom string traits for SessionDescription.
+
 ## v0.5.3
 
 * Increased minimum support rust version to `1.60.0`.

--- a/sdp/src/description/session.rs
+++ b/sdp/src/description/session.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fmt, io};
 use url::Url;
@@ -560,6 +561,21 @@ impl SessionDescription {
         }
 
         Ok(lexer.desc)
+    }
+}
+
+impl From<SessionDescription> for String {
+    fn from(sdp: SessionDescription) -> String {
+        sdp.marshal()
+    }
+}
+
+impl TryFrom<String> for SessionDescription {
+    type Error = Error;
+    fn try_from(sdp_string: String) -> Result<Self> {
+        let mut reader = io::Cursor::new(sdp_string.as_bytes());
+        let session_description = SessionDescription::unmarshal(&mut reader)?;
+        Ok(session_description)
     }
 }
 


### PR DESCRIPTION
Nice to have implement traits to convert to and from string

let sdp_string = String::from(sdp);
let sdp = SessionDescription::TryFrom(sdp_string).unwrap();
