### PR TITLE
Make `RTCPeerConnection::on_track` spec-compliant

### DIFF
--- a/examples/examples/save-to-disk-vpx/save-to-disk-vpx.rs
+++ b/examples/examples/save-to-disk-vpx/save-to-disk-vpx.rs
@@ -20,7 +20,6 @@ use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndicat
 use webrtc::rtp_transceiver::rtp_codec::{
     RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType,
 };
-use webrtc::rtp_transceiver::rtp_receiver::RTCRtpReceiver;
 use webrtc::track::track_remote::TrackRemote;
 
 async fn save_to_disk(
@@ -230,63 +229,55 @@ async fn main() -> Result<()> {
     // an ivf file, since we could have multiple video tracks we provide a counter.
     // In your application this is where you would handle/process video
     let pc = Arc::downgrade(&peer_connection);
-    peer_connection.on_track(Box::new(
-        move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
-            if let Some(track) = track {
-                // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
-                let media_ssrc = track.ssrc();
-                let pc2 = pc.clone();
-                tokio::spawn(async move {
-                    let mut result = Result::<usize>::Ok(0);
-                    while result.is_ok() {
-                        let timeout = tokio::time::sleep(Duration::from_secs(3));
-                        tokio::pin!(timeout);
+    peer_connection.on_track(Box::new(move |track, _, _| {
+        // Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+        let media_ssrc = track.ssrc();
+        let pc2 = pc.clone();
+        tokio::spawn(async move {
+            let mut result = Result::<usize>::Ok(0);
+            while result.is_ok() {
+                let timeout = tokio::time::sleep(Duration::from_secs(3));
+                tokio::pin!(timeout);
 
-                        tokio::select! {
-                            _ = timeout.as_mut() =>{
-                                if let Some(pc) = pc2.upgrade(){
-                                    result = pc.write_rtcp(&[Box::new(PictureLossIndication{
-                                        sender_ssrc: 0,
-                                        media_ssrc,
-                                    })]).await.map_err(Into::into);
-                                }else{
-                                    break;
-                                }
-                            }
-                        };
+                tokio::select! {
+                    _ = timeout.as_mut() =>{
+                        if let Some(pc) = pc2.upgrade(){
+                            result = pc.write_rtcp(&[Box::new(PictureLossIndication{
+                                sender_ssrc: 0,
+                                media_ssrc,
+                            })]).await.map_err(Into::into);
+                        }else{
+                            break;
+                        }
                     }
-                });
-
-                let notify_rx2 = Arc::clone(&notify_rx);
-                let ivf_writer2 = Arc::clone(&ivf_writer);
-                let ogg_writer2 = Arc::clone(&ogg_writer);
-                Box::pin(async move {
-                    let codec = track.codec().await;
-                    let mime_type = codec.capability.mime_type.to_lowercase();
-                    if mime_type == MIME_TYPE_OPUS.to_lowercase() {
-                        println!(
-                            "Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)"
-                        );
-                        tokio::spawn(async move {
-                            let _ = save_to_disk(ogg_writer2, track, notify_rx2).await;
-                        });
-                    } else if mime_type == MIME_TYPE_VP8.to_lowercase()
-                        || mime_type == MIME_TYPE_VP9.to_lowercase()
-                    {
-                        println!(
-                            "Got {} track, saving to disk as output.ivf",
-                            if is_vp9 { "VP9" } else { "VP8" }
-                        );
-                        tokio::spawn(async move {
-                            let _ = save_to_disk(ivf_writer2, track, notify_rx2).await;
-                        });
-                    }
-                })
-            } else {
-                Box::pin(async {})
+                };
             }
-        },
-    ));
+        });
+
+        let notify_rx2 = Arc::clone(&notify_rx);
+        let ivf_writer2 = Arc::clone(&ivf_writer);
+        let ogg_writer2 = Arc::clone(&ogg_writer);
+        Box::pin(async move {
+            let codec = track.codec().await;
+            let mime_type = codec.capability.mime_type.to_lowercase();
+            if mime_type == MIME_TYPE_OPUS.to_lowercase() {
+                println!("Got Opus track, saving to disk as output.opus (48 kHz, 2 channels)");
+                tokio::spawn(async move {
+                    let _ = save_to_disk(ogg_writer2, track, notify_rx2).await;
+                });
+            } else if mime_type == MIME_TYPE_VP8.to_lowercase()
+                || mime_type == MIME_TYPE_VP9.to_lowercase()
+            {
+                println!(
+                    "Got {} track, saving to disk as output.ivf",
+                    if is_vp9 { "VP9" } else { "VP8" }
+                );
+                tokio::spawn(async move {
+                    let _ = save_to_disk(ivf_writer2, track, notify_rx2).await;
+                });
+            }
+        })
+    }));
 
     let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);
 

--- a/examples/examples/simulcast/simulcast.rs
+++ b/examples/examples/simulcast/simulcast.rs
@@ -16,10 +16,8 @@ use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndicat
 use webrtc::rtp_transceiver::rtp_codec::{
     RTCRtpCodecCapability, RTCRtpHeaderExtensionCapability, RTPCodecType,
 };
-use webrtc::rtp_transceiver::rtp_receiver::RTCRtpReceiver;
 use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
 use webrtc::track::track_local::{TrackLocal, TrackLocalWriter};
-use webrtc::track::track_remote::TrackRemote;
 use webrtc::Error;
 
 #[tokio::main]
@@ -154,67 +152,64 @@ async fn main() -> Result<()> {
 
     // Set a handler for when a new remote track starts
     let pc = Arc::downgrade(&peer_connection);
-    peer_connection.on_track(Box::new(
-        move |track: Option<Arc<TrackRemote>>, _receiver: Option<Arc<RTCRtpReceiver>>| {
-            if let Some(track) = track {
-                println!("Track has started");
+    peer_connection.on_track(Box::new(move |track, _, _| {
+        println!("Track has started");
 
-                let rid = track.rid().to_owned();
-                let output_track = if let Some(output_track) = output_tracks.get(&rid) {
-                    Arc::clone(output_track)
-                } else {
-                    println!("output_track not found for rid = {}", rid);
-                    return Box::pin(async {});
-                };
+        let rid = track.rid().to_owned();
+        let output_track = if let Some(output_track) = output_tracks.get(&rid) {
+            Arc::clone(output_track)
+        } else {
+            println!("output_track not found for rid = {}", rid);
+            return Box::pin(async {});
+        };
 
-                // Start reading from all the streams and sending them to the related output track
-                let media_ssrc = track.ssrc();
-                let pc2 = pc.clone();
-                tokio::spawn(async move {
-                    let mut result = Result::<usize>::Ok(0);
-                    while result.is_ok() {
-                        println!(
-                            "Sending pli for stream with rid: {}, ssrc: {}",
-                            rid, media_ssrc
-                        );
+        // Start reading from all the streams and sending them to the related output track
+        let media_ssrc = track.ssrc();
+        let pc2 = pc.clone();
+        tokio::spawn(async move {
+            let mut result = Result::<usize>::Ok(0);
+            while result.is_ok() {
+                println!(
+                    "Sending pli for stream with rid: {}, ssrc: {}",
+                    rid, media_ssrc
+                );
 
-                        let timeout = tokio::time::sleep(Duration::from_secs(3));
-                        tokio::pin!(timeout);
+                let timeout = tokio::time::sleep(Duration::from_secs(3));
+                tokio::pin!(timeout);
 
-                        tokio::select! {
-                            _ = timeout.as_mut() =>{
-                                if let Some(pc) = pc2.upgrade(){
-                                    result = pc.write_rtcp(&[Box::new(PictureLossIndication{
-                                        sender_ssrc: 0,
-                                        media_ssrc,
-                                    })]).await.map_err(Into::into);
-                                }else{
-                                    break;
-                                }
-                            }
-                        };
-                    }
-                });
-
-                tokio::spawn(async move {
-                    // Read RTP packets being sent to webrtc-rs
-                    println!("enter track loop {}", track.rid());
-                    while let Ok((rtp, _)) = track.read_rtp().await {
-                        if let Err(err) = output_track.write_rtp(&rtp).await {
-                            if Error::ErrClosedPipe != err {
-                                println!("output track write_rtp got error: {} and break", err);
-                                break;
-                            } else {
-                                println!("output track write_rtp got error: {}", err);
-                            }
+                tokio::select! {
+                    _ = timeout.as_mut() =>{
+                        if let Some(pc) = pc2.upgrade(){
+                            result = pc.write_rtcp(&[Box::new(PictureLossIndication{
+                                sender_ssrc: 0,
+                                media_ssrc,
+                            })]).await.map_err(Into::into);
+                        }else{
+                            break;
                         }
                     }
-                    println!("exit track loop {}", track.rid());
-                });
+                };
             }
-            Box::pin(async {})
-        },
-    ));
+        });
+
+        tokio::spawn(async move {
+            // Read RTP packets being sent to webrtc-rs
+            println!("enter track loop {}", track.rid());
+            while let Ok((rtp, _)) = track.read_rtp().await {
+                if let Err(err) = output_track.write_rtp(&rtp).await {
+                    if Error::ErrClosedPipe != err {
+                        println!("output track write_rtp got error: {} and break", err);
+                        break;
+                    } else {
+                        println!("output track write_rtp got error: {}", err);
+                    }
+                }
+            }
+            println!("exit track loop {}", track.rid());
+        });
+
+        Box::pin(async {})
+    }));
 
     let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Make RTCRtpCodecCapability::payloader_for_codec public API [#349](https://github.com/webrtc-rs/webrtc/pull/349).
 * Fixed a panic in `calculate_rtt_ms` [#350](https://github.com/webrtc-rs/webrtc/pull/350).
 
+### Breaking changes
+
+* Change `RTCPeerConnection::on_track` callback signature to `|track: Arc<TrackRemote>, receiver: Arc<RTCRtpReceiver>, transceiver: Arc<RTCRtpTransceiver>|` [#355](https://github.com/webrtc-rs/webrtc/pull/355).
+
 ## v0.6.0
 
 * Added more stats to `RemoteInboundRTPStats` and `RemoteOutboundRTPStats` [#282](https://github.com/webrtc-rs/webrtc/pull/282) by [@k0nserv](https://github.com/k0nserv).

--- a/webrtc/src/peer_connection/peer_connection_test.rs
+++ b/webrtc/src/peer_connection/peer_connection_test.rs
@@ -303,30 +303,22 @@ async fn test_get_stats() -> Result<()> {
         .expect("Failed to add track");
     let (packet_tx, packet_rx) = mpsc::channel(1);
 
-    pc_answer.on_track(Box::new(
-        move |track: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
-            let packet_tx = packet_tx.clone();
-            let result = Box::pin(async move {});
-            let track = match track {
-                Some(t) => t,
-                None => return result,
-            };
+    pc_answer.on_track(Box::new(move |track, _, _| {
+        let packet_tx = packet_tx.clone();
+        tokio::spawn(async move {
+            while let Ok((pkt, _)) = track.read_rtp().await {
+                dbg!(&pkt);
+                let last = pkt.payload[pkt.payload.len() - 1];
 
-            tokio::spawn(async move {
-                while let Ok((pkt, _)) = track.read_rtp().await {
-                    dbg!(&pkt);
-                    let last = pkt.payload[pkt.payload.len() - 1];
-
-                    if last == 0xAA {
-                        let _ = packet_tx.send(()).await;
-                        break;
-                    }
+                if last == 0xAA {
+                    let _ = packet_tx.send(()).await;
+                    break;
                 }
-            });
+            }
+        });
 
-            Box::pin(async move {})
-        },
-    ));
+        Box::pin(async move {})
+    }));
 
     signal_pair(&mut pc_offer, &mut pc_answer).await?;
 

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -16,6 +16,7 @@ use interceptor::{
 
 use log::trace;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
@@ -474,6 +475,21 @@ impl RTCRtpTransceiver {
         ));
 
         Ok(())
+    }
+}
+
+impl fmt::Debug for RTCRtpTransceiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RTCRtpTransceiver")
+            .field("mid", &self.mid)
+            .field("sender", &self.sender)
+            .field("receiver", &self.receiver)
+            .field("direction", &self.direction)
+            .field("current_direction", &self.current_direction)
+            .field("codecs", &self.codecs)
+            .field("stopped", &self.stopped)
+            .field("kind", &self.kind)
+            .finish()
     }
 }
 

--- a/webrtc/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
@@ -86,48 +86,44 @@ async fn test_set_rtp_parameters() -> Result<()> {
 
     let (seen_packet_tx, mut seen_packet_rx) = mpsc::channel::<()>(1);
     let seen_packet_tx = Arc::new(Mutex::new(Some(seen_packet_tx)));
-    receiver.on_track(Box::new(
-        move |_: Option<Arc<TrackRemote>>, receiver: Option<Arc<RTCRtpReceiver>>| {
-            let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
-            Box::pin(async move {
-                if let Some(r) = &receiver {
-                    r.set_rtp_parameters(P.clone()).await;
+    receiver.on_track(Box::new(move |_, receiver, _| {
+        let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
+        Box::pin(async move {
+            receiver.set_rtp_parameters(P.clone()).await;
 
-                    if let Some(t) = r.track().await {
-                        let incoming_track_codecs = t.codec().await;
+            if let Some(t) = receiver.track().await {
+                let incoming_track_codecs = t.codec().await;
 
-                        assert_eq!(P.header_extensions, t.params().await.header_extensions);
-                        assert_eq!(
-                            P.codecs[0].capability.mime_type,
-                            incoming_track_codecs.capability.mime_type
-                        );
-                        assert_eq!(
-                            P.codecs[0].capability.clock_rate,
-                            incoming_track_codecs.capability.clock_rate
-                        );
-                        assert_eq!(
-                            P.codecs[0].capability.channels,
-                            incoming_track_codecs.capability.channels
-                        );
-                        assert_eq!(
-                            P.codecs[0].capability.sdp_fmtp_line,
-                            incoming_track_codecs.capability.sdp_fmtp_line
-                        );
-                        assert_eq!(
-                            P.codecs[0].capability.rtcp_feedback,
-                            incoming_track_codecs.capability.rtcp_feedback
-                        );
-                        assert_eq!(P.codecs[0].payload_type, incoming_track_codecs.payload_type);
+                assert_eq!(P.header_extensions, t.params().await.header_extensions);
+                assert_eq!(
+                    P.codecs[0].capability.mime_type,
+                    incoming_track_codecs.capability.mime_type
+                );
+                assert_eq!(
+                    P.codecs[0].capability.clock_rate,
+                    incoming_track_codecs.capability.clock_rate
+                );
+                assert_eq!(
+                    P.codecs[0].capability.channels,
+                    incoming_track_codecs.capability.channels
+                );
+                assert_eq!(
+                    P.codecs[0].capability.sdp_fmtp_line,
+                    incoming_track_codecs.capability.sdp_fmtp_line
+                );
+                assert_eq!(
+                    P.codecs[0].capability.rtcp_feedback,
+                    incoming_track_codecs.capability.rtcp_feedback
+                );
+                assert_eq!(P.codecs[0].payload_type, incoming_track_codecs.payload_type);
 
-                        {
-                            let mut done = seen_packet_tx2.lock().await;
-                            done.take();
-                        }
-                    }
+                {
+                    let mut done = seen_packet_tx2.lock().await;
+                    done.take();
                 }
-            })
-        },
-    ));
+            }
+        })
+    }));
 
     let wg = WaitGroup::new();
 
@@ -181,36 +177,28 @@ async fn test_rtp_receiver_set_read_deadline() -> Result<()> {
 
     let (seen_packet_tx, mut seen_packet_rx) = mpsc::channel::<()>(1);
     let seen_packet_tx = Arc::new(Mutex::new(Some(seen_packet_tx)));
-    receiver.on_track(Box::new(
-        move |track_remote: Option<Arc<TrackRemote>>, receiver: Option<Arc<RTCRtpReceiver>>| {
-            let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
-            Box::pin(async move {
-                // First call will not error because we cache for probing
-                if let Some(track) = &track_remote {
-                    let result =
-                        tokio::time::timeout(Duration::from_secs(1), track.read_rtp()).await;
-                    assert!(
-                        result.is_ok(),
-                        " First call will not error because we cache for probing"
-                    );
+    receiver.on_track(Box::new(move |track, receiver, _| {
+        let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
+        Box::pin(async move {
+            // First call will not error because we cache for probing
+            let result = tokio::time::timeout(Duration::from_secs(1), track.read_rtp()).await;
+            assert!(
+                result.is_ok(),
+                " First call will not error because we cache for probing"
+            );
 
-                    let result =
-                        tokio::time::timeout(Duration::from_secs(1), track.read_rtp()).await;
-                    assert!(result.is_err());
-                }
+            let result = tokio::time::timeout(Duration::from_secs(1), track.read_rtp()).await;
+            assert!(result.is_err());
 
-                if let Some(r) = &receiver {
-                    let result = tokio::time::timeout(Duration::from_secs(1), r.read_rtcp()).await;
-                    assert!(result.is_err());
-                }
+            let result = tokio::time::timeout(Duration::from_secs(1), receiver.read_rtcp()).await;
+            assert!(result.is_err());
 
-                {
-                    let mut done = seen_packet_tx2.lock().await;
-                    done.take();
-                }
-            })
-        },
-    ));
+            {
+                let mut done = seen_packet_tx2.lock().await;
+                done.take();
+            }
+        })
+    }));
 
     let wg = WaitGroup::new();
     until_connection_state(&mut sender, &wg, RTCPeerConnectionState::Connected).await;

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -9,9 +9,7 @@ use crate::peer_connection::peer_connection_test::{
     until_connection_state,
 };
 use crate::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
-use crate::rtp_transceiver::rtp_receiver::RTCRtpReceiver;
 use crate::track::track_local::track_local_static_sample::TrackLocalStaticSample;
-use crate::track::track_remote::TrackRemote;
 use bytes::Bytes;
 use std::sync::atomic::AtomicU64;
 use tokio::time::Duration;
@@ -60,36 +58,32 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
     let seen_packet_a_tx = Arc::new(seen_packet_a_tx);
     let seen_packet_b_tx = Arc::new(seen_packet_b_tx);
     let on_track_count = Arc::new(AtomicU64::new(0));
-    receiver.on_track(Box::new(
-        move |track: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
-            assert_eq!(0, on_track_count.fetch_add(1, Ordering::SeqCst));
-            let seen_packet_a_tx2 = Arc::clone(&seen_packet_a_tx);
-            let seen_packet_b_tx2 = Arc::clone(&seen_packet_b_tx);
-            Box::pin(async move {
-                while let Some(t) = &track {
-                    let pkt = match t.read_rtp().await {
-                        Ok((pkt, _)) => pkt,
-                        Err(err) => {
-                            //assert!(errors.Is(io.EOF, err))
-                            log::debug!("{}", err);
-                            return;
-                        }
-                    };
-
-                    let last = pkt.payload[pkt.payload.len() - 1];
-                    if last == 0xAA {
-                        assert_eq!(t.codec().await.capability.mime_type, MIME_TYPE_VP8);
-                        let _ = seen_packet_a_tx2.send(()).await;
-                    } else if last == 0xBB {
-                        assert_eq!(t.codec().await.capability.mime_type, MIME_TYPE_H264);
-                        let _ = seen_packet_b_tx2.send(()).await;
-                    } else {
-                        assert!(false, "Unexpected RTP Data {:02x}", last);
-                    }
+    receiver.on_track(Box::new(move |track, _, _| {
+        assert_eq!(0, on_track_count.fetch_add(1, Ordering::SeqCst));
+        let seen_packet_a_tx2 = Arc::clone(&seen_packet_a_tx);
+        let seen_packet_b_tx2 = Arc::clone(&seen_packet_b_tx);
+        Box::pin(async move {
+            let pkt = match track.read_rtp().await {
+                Ok((pkt, _)) => pkt,
+                Err(err) => {
+                    //assert!(errors.Is(io.EOF, err))
+                    log::debug!("{}", err);
+                    return;
                 }
-            })
-        },
-    ));
+            };
+
+            let last = pkt.payload[pkt.payload.len() - 1];
+            if last == 0xAA {
+                assert_eq!(track.codec().await.capability.mime_type, MIME_TYPE_VP8);
+                let _ = seen_packet_a_tx2.send(()).await;
+            } else if last == 0xBB {
+                assert_eq!(track.codec().await.capability.mime_type, MIME_TYPE_H264);
+                let _ = seen_packet_b_tx2.send(()).await;
+            } else {
+                assert!(false, "Unexpected RTP Data {:02x}", last);
+            }
+        })
+    }));
 
     signal_pair(&mut sender, &mut receiver).await?;
 
@@ -233,14 +227,12 @@ async fn test_rtp_sender_replace_track_invalid_track_kind_change() -> Result<()>
 
     let (seen_packet_tx, seen_packet_rx) = mpsc::channel::<()>(1);
     let seen_packet_tx = Arc::new(seen_packet_tx);
-    receiver.on_track(Box::new(
-        move |_: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
-            let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
-            Box::pin(async move {
-                let _ = seen_packet_tx2.send(()).await;
-            })
-        },
-    ));
+    receiver.on_track(Box::new(move |_, _, _| {
+        let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
+        Box::pin(async move {
+            let _ = seen_packet_tx2.send(()).await;
+        })
+    }));
 
     tokio::spawn(async move {
         send_video_until_done(
@@ -317,14 +309,12 @@ async fn test_rtp_sender_replace_track_invalid_codec_change() -> Result<()> {
 
     let (seen_packet_tx, seen_packet_rx) = mpsc::channel::<()>(1);
     let seen_packet_tx = Arc::new(seen_packet_tx);
-    receiver.on_track(Box::new(
-        move |_: Option<Arc<TrackRemote>>, _: Option<Arc<RTCRtpReceiver>>| {
-            let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
-            Box::pin(async move {
-                let _ = seen_packet_tx2.send(()).await;
-            })
-        },
-    ));
+    receiver.on_track(Box::new(move |_, _, _| {
+        let seen_packet_tx2 = Arc::clone(&seen_packet_tx);
+        Box::pin(async move {
+            let _ = seen_packet_tx2.send(()).await;
+        })
+    }));
 
     tokio::spawn(async move {
         send_video_until_done(


### PR DESCRIPTION
Currently `RTCPeerConnection::on_track` accepts `OnTrackHdlrFn` which is:

```rust
pub type OnTrackHdlrFn = Box<
    dyn (FnMut(
            Option<Arc<TrackRemote>>,
            Option<Arc<RTCRtpReceiver>>,
        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
        + Send
        + Sync,
>;
```

When according to the WebRTc spec `RTCTrackEvent` is supposed to be:
```webidl
interface RTCTrackEvent : Event {
  readonly attribute RTCRtpReceiver receiver;
  readonly attribute MediaStreamTrack track;
  [SameObject] readonly attribute FrozenArray<MediaStream> streams;
  readonly attribute RTCRtpTransceiver transceiver;
};
```

So, excluding `MediaStream`s, since i don't see it being used anywhere, this callback is supposed to look like this: 
```rust
pub type OnTrackHdlrFn = Box<
    dyn (FnMut(
            Arc<TrackRemote>,
            Arc<RTCRtpReceiver>,
            Arc<RTCRtpTransceiver>,
        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>)
        + Send
        + Sync,
>;
```