### PR TITLE
[examples] Add an example of how to stream h264 from a webcam

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,7 +23,7 @@ env_logger = "0.9"
 clap = "3.0"
 hyper = { version = "0.14", features = ["full"] }
 signal = { path = "examples/signal" }
-tokio-util = { version="0.6", features = ["codec"] }
+tokio-util = { version="0.7", features = ["codec", "rt"] }
 anyhow = "1.0"
 chrono = "0.4"
 log = "0.4.16"
@@ -32,6 +32,7 @@ serde_json = "1.0"
 bytes = "1.1"
 lazy_static = "1.4"
 rand = "0.8"
+h264_webcam_stream = "0.1.0"
 
 
 [[example]]
@@ -42,6 +43,11 @@ bench = false
 [[example]]
 name = "broadcast"
 path = "examples/broadcast/broadcast.rs"
+bench = false
+
+[[example]]
+name = "capture-webcam-h264"
+path = "examples/capture-webcam-h264/capture-webcam-h264.rs"
 bench = false
 
 [[example]]

--- a/examples/examples/capture-webcam-h264/README.md
+++ b/examples/examples/capture-webcam-h264/README.md
@@ -1,0 +1,28 @@
+# capture-webcam-h264
+capture-webcam-h264 demonstrates how to send h264 video to your browser from a webcam on your webrtc-rs server (Linux Only).
+
+## Instructions
+### Build capture-webcam-h264
+```
+cargo build --example capture-webcam-h264
+```
+
+### Open capture-webcam-h264 example page
+[jsfiddle.net](https://jsfiddle.net/9s10amwL/) you should see two text-areas and a 'Start Session' button
+
+### Run capture-webcam-h264 with your browsers SessionDescription as stdin
+In the jsfiddle the top textarea is your browser, copy that and:
+
+#### Linux
+Run `echo $BROWSER_SDP | ./target/debug/examples/capture-webcam-h264 -- -v /dev/video0`
+
+### MacOS & Windows
+MacOS and Windows are not supported by the h264_webcam_stream crate used in this example at this time.
+
+### Input capture-webcam-h264's SessionDescription into your browser
+Copy the text that `capture-webcam-h264` just emitted and copy into second text area
+
+### Hit 'Start Session' in jsfiddle
+A video stream of your webcam should start playing in your browser above the input boxes. `capture-webcam-h264` will exit when the file reaches the end
+
+Congrats, you have used WebRTC.rs!

--- a/examples/examples/capture-webcam-h264/capture-webcam-h264.rs
+++ b/examples/examples/capture-webcam-h264/capture-webcam-h264.rs
@@ -1,0 +1,280 @@
+use anyhow::Result;
+use bytes::Bytes;
+use clap::{AppSettings, Arg, Command};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::time::Duration;
+use webrtc::api::interceptor_registry::register_default_interceptors;
+use webrtc::api::media_engine::{MediaEngine, MIME_TYPE_H264};
+use webrtc::api::setting_engine::SettingEngine;
+use webrtc::api::APIBuilder;
+use webrtc::ice::udp_network::{EphemeralUDP, UDPNetwork};
+use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::interceptor::registry::Registry;
+use webrtc::media::Sample;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
+use webrtc::track::track_local::track_local_static_sample::TrackLocalStaticSample;
+use webrtc::track::track_local::TrackLocal;
+use webrtc::Error;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut app = Command::new("play-from-disk-h264")
+        .version("0.1.0")
+        .author("Rain Liu <yliu@webrtc.rs>")
+        .about("An example of play-from-disk-h264.")
+        .setting(AppSettings::DeriveDisplayOrder)
+        .subcommand_negates_reqs(true)
+        .arg(
+            Arg::new("FULLHELP")
+                .help("Prints more detailed help information")
+                .long("fullhelp"),
+        )
+        .arg(
+            Arg::new("debug")
+                .long("debug")
+                .short('d')
+                .help("Prints debug log information"),
+        )
+        .arg(
+            Arg::new("device")
+                .required_unless_present("FULLHELP")
+                .takes_value(true)
+                .short('v')
+                .long("device")
+                .help("Video capture device to stream from. Eg. /dev/video0"),
+        );
+
+    let matches = app.clone().get_matches();
+
+    if matches.is_present("FULLHELP") {
+        app.print_long_help().unwrap();
+        std::process::exit(0);
+    }
+
+    let debug = matches.is_present("debug");
+    if debug {
+        env_logger::Builder::new()
+            .format(|buf, record| {
+                writeln!(
+                    buf,
+                    "{}:{} [{}] {} - {}",
+                    record.file().unwrap_or("unknown"),
+                    record.line().unwrap_or(0),
+                    record.level(),
+                    chrono::Local::now().format("%H:%M:%S.%6f"),
+                    record.args()
+                )
+            })
+            .filter(None, log::LevelFilter::Trace)
+            .init();
+    }
+
+    let device_path = matches.value_of("device");
+    let device_path = if let Some(device_path) = &device_path {
+        let device_path: PathBuf = device_path.into();
+        if !device_path.exists() {
+            return Err(Error::new(format!(
+                "video capture device: '{}' not exist",
+                device_path.display()
+            ))
+            .into());
+        }
+
+        device_path
+    } else {
+        return Err(Error::new(format!("video capture device not selected").into()).into());
+    };
+
+    let max_fps = 60;
+
+    // Create a video track
+    let video_track = Arc::new(TrackLocalStaticSample::new(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_H264.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+
+    println!("stream video from camera: {:?}", device_path);
+
+    let device_path_clone = device_path.clone();
+    let video_track_clone = Arc::clone(&video_track);
+
+    let pool = tokio_util::task::LocalPoolHandle::new(1);
+
+    pool.spawn_pinned(move || {
+        async move {
+            // Connect to the webcam
+            let mut device = h264_webcam_stream::get_device(&device_path_clone).unwrap();
+            let mut stream = h264_webcam_stream::stream(&mut device, max_fps).unwrap();
+
+            // It is important to use a time.Ticker instead of time.Sleep because
+            // * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
+            // * works around latency issues with Sleep
+            let mut ticker = tokio::time::interval(Duration::from_millis(33));
+
+            loop {
+                let (h264_bitstream, _) = stream.next(false).unwrap();
+
+                // Convert the video bitstream into WebRTC's format
+                let samples = h264_webcam_stream::openh264::nal_units(&h264_bitstream[..])
+                    .map(|nal| Sample {
+                        data: Bytes::copy_from_slice(nal),
+                        duration: Duration::from_secs(1),
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>();
+
+                // Send the video to WebRTC clients
+                for sample in samples {
+                    video_track_clone.write_sample(&sample).await?;
+                }
+
+                let _ = ticker.tick().await;
+            }
+
+            #[allow(unreachable_code)]
+            Result::<()>::Ok(())
+        }
+    });
+
+    // Create a MediaEngine object to configure the supported codec
+    let mut m = MediaEngine::default();
+
+    m.register_default_codecs()?;
+
+    // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
+    // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
+    // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
+    // for each PeerConnection.
+    let mut registry = Registry::new();
+
+    // Use the default set of Interceptors
+    registry = register_default_interceptors(registry, &mut m)?;
+
+    let mut ephemeral_udp = EphemeralUDP::default();
+    ephemeral_udp.set_ports(4300, 4500)?;
+
+    let mut setting_engine = SettingEngine::default();
+    setting_engine.set_udp_network(UDPNetwork::Ephemeral(ephemeral_udp));
+
+    // Create the API object with the MediaEngine
+    let api = APIBuilder::new()
+        .with_media_engine(m)
+        .with_interceptor_registry(registry)
+        .with_setting_engine(setting_engine)
+        .build();
+
+    // Prepare the configuration
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Create a new RTCPeerConnection
+    let peer_connection = Arc::new(api.new_peer_connection(config).await?);
+
+    let notify_tx = Arc::new(Notify::new());
+    // let notify_video = notify_tx.clone();
+
+    let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);
+
+    // Add this newly created track to the PeerConnection
+    let rtp_sender = peer_connection
+        .add_track(Arc::clone(&video_track) as Arc<dyn TrackLocal + Send + Sync>)
+        .await?;
+
+    // Read incoming RTCP packets
+    // Before these packets are returned they are processed by interceptors. For things
+    // like NACK this needs to be called.
+    tokio::spawn(async move {
+        let mut rtcp_buf = vec![0u8; 1500];
+        while let Ok((_, _)) = rtp_sender.read(&mut rtcp_buf).await {}
+        Result::<()>::Ok(())
+    });
+
+    // Set the handler for ICE connection state
+    // This will notify you when the peer has connected/disconnected
+    peer_connection.on_ice_connection_state_change(Box::new(
+        move |connection_state: RTCIceConnectionState| {
+            println!("Connection State has changed {}", connection_state);
+            if connection_state == RTCIceConnectionState::Connected {
+                notify_tx.notify_waiters();
+            }
+            Box::pin(async {})
+        },
+    ));
+
+    // Set the handler for Peer connection state
+    // This will notify you when the peer has connected/disconnected
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        println!("Peer Connection State has changed: {}", s);
+
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+            println!("Peer Connection has gone to failed exiting");
+            let _ = done_tx.try_send(());
+        }
+
+        Box::pin(async {})
+    }));
+
+    // Wait for the offer to be pasted
+    let line = signal::must_read_stdin()?;
+    let desc_data = signal::decode(dbg!(line).as_str())?;
+    let offer = serde_json::from_str::<RTCSessionDescription>(&desc_data)?;
+
+    // Set the remote SessionDescription
+    peer_connection.set_remote_description(offer).await?;
+
+    // Create an answer
+    let answer = peer_connection.create_answer(None).await?;
+
+    // Create channel that is blocked until ICE Gathering is complete
+    let mut gather_complete = peer_connection.gathering_complete_promise().await;
+
+    // Sets the LocalDescription, and starts our UDP listeners
+    peer_connection.set_local_description(answer).await?;
+
+    // Block until ICE Gathering is complete, disabling trickle ICE
+    // we do this because we only can exchange one signaling message
+    // in a production application you should exchange ICE Candidates via OnICECandidate
+    let _ = gather_complete.recv().await;
+
+    // Output the answer in base64 so we can paste it in browser
+    if let Some(local_desc) = peer_connection.local_description().await {
+        let json_str = serde_json::to_string(&local_desc)?;
+        let b64 = signal::encode(&json_str);
+        println!("{}", b64);
+    } else {
+        println!("generate local_description failed!");
+    }
+
+    println!("Press ctrl-c to stop");
+    tokio::select! {
+        _ = done_rx.recv() => {
+            println!("received done signal!");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            println!("");
+        }
+    };
+
+    peer_connection.close().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds an example of how to stream from a server-side webcam. Not having experience in `v4l2`, I initially had some trouble learning how to do this so I figured an example might be useful to future developers who find themselves in a similar position.

Note the `capture-webcam-h264` dependency is my own work - it provides a common abstraction over webcam hardware differences (specifically, native h264 cameras and mjpeg-only cameras).