### PR TITLE
[SCTP] Optimize sctp packet marshalling

### DIFF
--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Performance improvements
+  * reuse as many allocations as possible when marshaling [#364](https://github.com/webrtc-rs/webrtc/pull/364)
+
 ## v0.7.0
 
 * Increased minimum support rust version to `1.60.0`.

--- a/sctp/src/chunk/chunk_payload_data.rs
+++ b/sctp/src/chunk/chunk_payload_data.rs
@@ -233,7 +233,7 @@ impl Chunk for ChunkPayloadData {
         writer.put_u16(self.stream_identifier);
         writer.put_u16(self.stream_sequence_number);
         writer.put_u32(self.payload_type as u32);
-        writer.extend(self.user_data.clone());
+        writer.extend_from_slice(&self.user_data);
 
         Ok(writer.len())
     }

--- a/sctp/src/packet.rs
+++ b/sctp/src/packet.rs
@@ -155,30 +155,30 @@ impl Packet {
         writer.put_u16(self.destination_port);
         writer.put_u32(self.verification_tag);
 
-        // Populate chunks
-        let mut raw = BytesMut::new();
-        for c in &self.chunks {
-            let chunk_raw = c.marshal()?;
-            raw.extend(chunk_raw);
+        // This is where the checksum will be written
+        let checksum_pos = writer.len();
+        writer.extend_from_slice(&[0, 0, 0, 0]);
 
-            let padding_needed = get_padding_size(raw.len());
+        // Populate chunks
+        for c in &self.chunks {
+            c.marshal_to(writer)?;
+
+            let padding_needed = get_padding_size(writer.len());
             if padding_needed != 0 {
-                raw.extend(vec![0u8; padding_needed]);
+                // padding needed is < 4 because we pad to 4
+                writer.extend_from_slice(&[0u8; 16][..padding_needed]);
             }
         }
-        let raw = raw.freeze();
 
         let hasher = Crc::<u32>::new(&CRC_32_ISCSI);
         let mut digest = hasher.digest();
         digest.update(writer);
-        digest.update(&FOUR_ZEROES);
-        digest.update(&raw[..]);
         let checksum = digest.finalize();
 
         // Checksum is already in BigEndian
         // Using LittleEndian stops it from being flipped
-        writer.put_u32_le(checksum);
-        writer.extend(raw);
+        let checksum_place = &mut writer[checksum_pos..checksum_pos + 4];
+        checksum_place.copy_from_slice(&checksum.to_le_bytes());
 
         Ok(writer.len())
     }

--- a/sctp/src/packet.rs
+++ b/sctp/src/packet.rs
@@ -20,7 +20,6 @@ use crate::util::*;
 
 use crate::chunk::chunk_unknown::ChunkUnknown;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use crc::{Crc, CRC_32_ISCSI};
 use std::fmt;
 
 ///Packet represents an SCTP packet, defined in https://tools.ietf.org/html/rfc4960#section-3
@@ -170,8 +169,7 @@ impl Packet {
             }
         }
 
-        let hasher = Crc::<u32>::new(&CRC_32_ISCSI);
-        let mut digest = hasher.digest();
+        let mut digest = ISCSI_CRC.digest();
         digest.update(writer);
         let checksum = digest.finalize();
 

--- a/sctp/src/packet.rs
+++ b/sctp/src/packet.rs
@@ -164,7 +164,7 @@ impl Packet {
 
             let padding_needed = get_padding_size(writer.len());
             if padding_needed != 0 {
-                // padding needed is < 4 because we pad to 4
+                // padding needed if < 4 because we pad to 4
                 writer.extend_from_slice(&[0u8; 16][..padding_needed]);
             }
         }

--- a/sctp/src/util.rs
+++ b/sctp/src/util.rs
@@ -11,10 +11,11 @@ pub(crate) fn get_padding_size(len: usize) -> usize {
 /// We need to use it for the checksum and don't want to allocate/clear each time.
 pub(crate) static FOUR_ZEROES: Bytes = Bytes::from_static(&[0, 0, 0, 0]);
 
+pub(crate) const ISCSI_CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+
 /// Fastest way to do a crc32 without allocating.
 pub(crate) fn generate_packet_checksum(raw: &Bytes) -> u32 {
-    let hasher = Crc::<u32>::new(&CRC_32_ISCSI);
-    let mut digest = hasher.digest();
+    let mut digest = ISCSI_CRC.digest();
     digest.update(&raw[0..8]);
     digest.update(&FOUR_ZEROES[..]);
     digest.update(&raw[12..]);

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Make RTCRtpCodecCapability::payloader_for_codec public API [#349](https://github.com/webrtc-rs/webrtc/pull/349).
 * Fixed a panic in `calculate_rtt_ms` [#350](https://github.com/webrtc-rs/webrtc/pull/350).
 * SCTP performance improvements
-  * reuse as many allocations as possible when marshaling
+  * reuse as many allocations as possible when marshaling [#364](https://github.com/webrtc-rs/webrtc/pull/364)
 
 ### Breaking changes
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -5,8 +5,6 @@
 * Added support for insecure/deprecated signature verification algorithms, opt in via `SettingsEngine::allow_insecure_verification_algorithm` [#342](https://github.com/webrtc-rs/webrtc/pull/342).
 * Make RTCRtpCodecCapability::payloader_for_codec public API [#349](https://github.com/webrtc-rs/webrtc/pull/349).
 * Fixed a panic in `calculate_rtt_ms` [#350](https://github.com/webrtc-rs/webrtc/pull/350).
-* SCTP performance improvements
-  * reuse as many allocations as possible when marshaling [#364](https://github.com/webrtc-rs/webrtc/pull/364)
 
 ### Breaking changes
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added support for insecure/deprecated signature verification algorithms, opt in via `SettingsEngine::allow_insecure_verification_algorithm` [#342](https://github.com/webrtc-rs/webrtc/pull/342).
 * Make RTCRtpCodecCapability::payloader_for_codec public API [#349](https://github.com/webrtc-rs/webrtc/pull/349).
 * Fixed a panic in `calculate_rtt_ms` [#350](https://github.com/webrtc-rs/webrtc/pull/350).
+* SCTP performance improvements
+  * reuse as many allocations as possible when marshaling
 
 ### Breaking changes
 


### PR DESCRIPTION
As discussed in #360 the marshalling code has become a bottle neck in high bandwidth sending situations. I found two places that had a big effect on the performance, the hot path for this situation is marshalling packets with exactly one data chunk in them.

After this PR the marshalling is largely dominated by the CRC32 calculation which is... not easy to speed up.