### PR TITLE
Adjust logging levels in mDNS

### DIFF
--- a/mdns/CHANGELOG.md
+++ b/mdns/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Change log level for packet reception [#366](https://github.com/webrtc-rs/webrtc/pull/366).
 * Increased minimum support rust version to `1.60.0`.
 * Increased required `webrtc-util` version to `0.7.0`.
 

--- a/mdns/src/conn/mod.rs
+++ b/mdns/src/conn/mod.rs
@@ -267,7 +267,7 @@ impl DnsConn {
                         Ok((len, addr)) => {
                             n = len;
                             src = addr;
-                            log::info!("Received new connection from {:?}", addr);
+                            log::trace!("Received new connection from {:?}", addr);
                         },
 
                         Err(err) => {


### PR DESCRIPTION
Before this module would `info` log and every packet it received. It has been updated to match the `ice` module and use the trace level for incoming packets.