### PR TITLE
Make RTCRtpTransceiver.mid spec-compliant

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Change `RTCPeerConnection::on_track` callback signature to `|track: Arc<TrackRemote>, receiver: Arc<RTCRtpReceiver>, transceiver: Arc<RTCRtpTransceiver>|` [#355](https://github.com/webrtc-rs/webrtc/pull/355).
 
+* Change `RTCPeerConnection::mid` signature to `Option<String>` [#375](https://github.com/webrtc-rs/webrtc/pull/375).
+
 ## v0.6.0
 
 * Added more stats to `RemoteInboundRTPStats` and `RemoteOutboundRTPStats` [#282](https://github.com/webrtc-rs/webrtc/pull/282) by [@k0nserv](https://github.com/k0nserv).

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Change `RTCPeerConnection::on_track` callback signature to `|track: Arc<TrackRemote>, receiver: Arc<RTCRtpReceiver>, transceiver: Arc<RTCRtpTransceiver>|` [#355](https://github.com/webrtc-rs/webrtc/pull/355).
 
-* Change `RTCPeerConnection::mid` signature to `Option<String>` [#375](https://github.com/webrtc-rs/webrtc/pull/375).
+* Change `RTCPeerConnection::mid` return signature to `Option<String>` [#375](https://github.com/webrtc-rs/webrtc/pull/375).
 
 ## v0.6.0
 

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -549,15 +549,15 @@ impl RTCPeerConnection {
                 }
                 // Step 5.4
                 if t.stopped.load(Ordering::SeqCst) {
-                    let Some(search_mid) = t.mid() else {return false;};
+                    let search_mid = match t.mid() {
+                        Some(mid) => mid,
+                        None => return false,
+                    };
 
-                    let Some(remote_desc) =
-                        &*params.current_remote_description.lock().await else {
-                            return false;
-                        };
-
-                    return get_by_mid(&search_mid, local_desc).is_some()
-                        || get_by_mid(&search_mid, remote_desc).is_some();
+                    if let Some(remote_desc) = &*params.current_remote_description.lock().await {
+                        return get_by_mid(&search_mid, local_desc).is_some()
+                            || get_by_mid(&search_mid, remote_desc).is_some();
+                    }
                 }
             }
             // Step 6

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -549,17 +549,15 @@ impl RTCPeerConnection {
                 }
                 // Step 5.4
                 if t.stopped.load(Ordering::SeqCst) {
-                    if let Some(search_mid) = t.mid() {
-                        let current_remote_description =
-                            params.current_remote_description.lock().await;
-                        if let Some(remote_desc) = &*current_remote_description {
-                            if get_by_mid(&search_mid, local_desc).is_some()
-                                || get_by_mid(&search_mid, remote_desc).is_some()
-                            {
-                                return true;
-                            }
-                        }
-                    }
+                    let Some(search_mid) = t.mid() else {return false;};
+
+                    let Some(remote_desc) =
+                        &*params.current_remote_description.lock().await else {
+                            return false;
+                        };
+
+                    return get_by_mid(&search_mid, local_desc).is_some()
+                        || get_by_mid(&search_mid, remote_desc).is_some();
                 }
             }
             // Step 6

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1182,11 +1182,11 @@ impl PeerConnectionInternal {
     pub(super) async fn has_local_description_changed(&self, desc: &RTCSessionDescription) -> bool {
         let rtp_transceivers = self.rtp_transceivers.lock().await;
         for t in &*rtp_transceivers {
-            if let Some(m) = t.mid().and_then(|mid| get_by_mid(&mid, desc)) {
-                if get_peer_direction(m) != t.direction() {
-                    return true;
-                }
-            } else {
+            let Some(m) = t.mid().and_then(|mid| get_by_mid(&mid, desc)) else {
+                return true;
+            };
+
+            if get_peer_direction(m) != t.direction() {
                 return true;
             }
         }

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -346,7 +346,7 @@ impl PeerConnectionInternal {
         for incoming_track in filtered_tracks.iter() {
             let mut track_handled = false;
             for t in local_transceivers {
-                if t.mid().await.as_ref() != Some(&incoming_track.mid) {
+                if t.mid().as_ref() != Some(&incoming_track.mid) {
                     continue;
                 }
 
@@ -684,7 +684,7 @@ impl PeerConnectionInternal {
                 sender.set_negotiated();
             }
             media_sections.push(MediaSection {
-                id: t.mid().await.unwrap(),
+                id: t.mid().unwrap(),
                 transceivers: vec![Arc::clone(t)],
                 ..Default::default()
             });
@@ -802,7 +802,7 @@ impl PeerConnectionInternal {
                     sender.set_negotiated();
                 }
                 media_sections.push(MediaSection {
-                    id: t.mid().await.unwrap(),
+                    id: t.mid().unwrap(),
                     transceivers: vec![Arc::clone(t)],
                     ..Default::default()
                 });
@@ -1011,8 +1011,7 @@ impl PeerConnectionInternal {
 
                         let transceivers = self.rtp_transceivers.lock().await;
                         for t in &*transceivers {
-                            if t.mid().await.as_ref() != Some(&mid) || t.receiver().await.is_none()
-                            {
+                            if t.mid().as_ref() != Some(&mid) || t.receiver().await.is_none() {
                                 continue;
                             }
 
@@ -1183,7 +1182,7 @@ impl PeerConnectionInternal {
     pub(super) async fn has_local_description_changed(&self, desc: &RTCSessionDescription) -> bool {
         let rtp_transceivers = self.rtp_transceivers.lock().await;
         for t in &*rtp_transceivers {
-            if let Some(m) = t.mid().await.and_then(|mid| get_by_mid(&mid, desc)) {
+            if let Some(m) = t.mid().and_then(|mid| get_by_mid(&mid, desc)) {
                 if get_peer_direction(m) != t.direction() {
                     return true;
                 }
@@ -1230,7 +1229,7 @@ impl PeerConnectionInternal {
                 None => continue,
             };
 
-            if let Some(mid) = transeiver.mid().await {
+            if let Some(mid) = transeiver.mid() {
                 let tracks = receiver.tracks().await;
 
                 for track in tracks {
@@ -1357,7 +1356,7 @@ impl PeerConnectionInternal {
                 Some(r) => r,
                 None => continue,
             };
-            if let Some(mid) = transeiver.mid().await {
+            if let Some(mid) = transeiver.mid() {
                 let track = match sender.track().await {
                     Some(t) => t,
                     None => continue,

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1351,32 +1351,34 @@ impl PeerConnectionInternal {
             kind: &'static str,
         }
         let mut track_infos = vec![];
-        for transeiver in transceivers {
-            let sender = match transeiver.sender().await {
+        for transceiver in transceivers {
+            let sender = match transceiver.sender().await {
                 Some(r) => r,
                 None => continue,
             };
-            if let Some(mid) = transeiver.mid() {
-                let track = match sender.track().await {
-                    Some(t) => t,
-                    None => continue,
-                };
 
-                let track_id = track.id().to_string();
-                let kind = match track.kind() {
-                    RTPCodecType::Unspecified => continue,
-                    RTPCodecType::Audio => "audio",
-                    RTPCodecType::Video => "video",
-                };
+            let Some(mid) = transceiver.mid() else {
+                continue;
+            };
 
-                track_infos.push(TrackInfo {
-                    track_id,
-                    ssrc: sender.ssrc,
-                    mid: mid.clone(),
-                    rid: None,
-                    kind,
-                });
-            }
+            let Some(track) = sender.track().await else {
+                continue;
+            };
+
+            let track_id = track.id().to_string();
+            let kind = match track.kind() {
+                RTPCodecType::Unspecified => continue,
+                RTPCodecType::Audio => "audio",
+                RTPCodecType::Video => "video",
+            };
+
+            track_infos.push(TrackInfo {
+                track_id,
+                ssrc: sender.ssrc,
+                mid: mid.clone(),
+                rid: None,
+                kind,
+            });
         }
 
         let stream_stats = self

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1182,8 +1182,9 @@ impl PeerConnectionInternal {
     pub(super) async fn has_local_description_changed(&self, desc: &RTCSessionDescription) -> bool {
         let rtp_transceivers = self.rtp_transceivers.lock().await;
         for t in &*rtp_transceivers {
-            let Some(m) = t.mid().and_then(|mid| get_by_mid(&mid, desc)) else {
-                return true;
+            let m = match t.mid().and_then(|mid| get_by_mid(&mid, desc)) {
+                Some(m) => m,
+                None => return true,
             };
 
             if get_peer_direction(m) != t.direction() {
@@ -1357,12 +1358,14 @@ impl PeerConnectionInternal {
                 None => continue,
             };
 
-            let Some(mid) = transceiver.mid() else {
-                continue;
+            let mid = match transceiver.mid() {
+                Some(mid) => mid,
+                None => continue,
             };
 
-            let Some(track) = sender.track().await else {
-                continue;
+            let track = match sender.track().await {
+                Some(track) => track,
+                None => continue,
             };
 
             let track_id = track.id().to_string();

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -855,7 +855,7 @@ pub(crate) fn get_by_mid<'a, 'b>(
 ) -> Option<&'b MediaDescription> {
     if let Some(parsed) = &desc.parsed {
         for m in &parsed.media_descriptions {
-            if let Some(mid) = m.attribute(ATTR_KEY_MID).and_then(|o| o) {
+            if let Some(mid) = m.attribute(ATTR_KEY_MID).flatten() {
                 if mid == search_mid {
                     return Some(m);
                 }

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -322,7 +322,7 @@ async fn test_rtp_transceiver_stopping() -> Result<()> {
     offer_pc.set_remote_description(answer).await?;
 
     assert!(
-        !offer_transceiver.mid().await.is_empty(),
+        offer_transceiver.mid().await.is_some(),
         "A mid should have been associated with the transceiver when applying the answer"
     );
     // Stop the transceiver

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -322,7 +322,7 @@ async fn test_rtp_transceiver_stopping() -> Result<()> {
     offer_pc.set_remote_description(answer).await?;
 
     assert!(
-        offer_transceiver.mid().await.is_some(),
+        offer_transceiver.mid().is_some(),
         "A mid should have been associated with the transceiver when applying the answer"
     );
     // Stop the transceiver


### PR DESCRIPTION

The current implementation is:

```
pub struct RTCRtpTransceiver {
    mid: Mutex<String>,                           //atomic.Value
    sender: Mutex<Option<Arc<RTCRtpSender>>>,     //atomic.Value
    receiver: Mutex<Option<Arc<RTCRtpReceiver>>>, //atomic.Value
    ...
}
```

Essentially, the empty string is used instead of `None` (`Option<String>`).
This PR makes the behavior of `mid` explicitly optional, and also replaces `Mutex` with `OnceCell`.