### PR TITLE
Unify `assert_eq!(…)`/`assert_ne!(…)` to take args in order of `…!(actual, expected)`

### DIFF
--- a/data/src/data_channel/data_channel_test.rs
+++ b/data/src/data_channel/data_channel_test.rs
@@ -450,12 +450,12 @@ async fn test_data_channel_buffered_amount() -> Result<()> {
     }
 
     let n = dc0.write(&Bytes::new()).await?;
-    assert_eq!(0, n, "data length should match");
-    assert_eq!(1, dc0.buffered_amount(), "incorrect bufferedAmount");
+    assert_eq!(n, 0, "data length should match");
+    assert_eq!(dc0.buffered_amount(), 1, "incorrect bufferedAmount");
 
     let n = dc0.write(&Bytes::from_static(&[0])).await?;
-    assert_eq!(1, n, "data length should match");
-    assert_eq!(2, dc0.buffered_amount(), "incorrect bufferedAmount");
+    assert_eq!(n, 1, "data length should match");
+    assert_eq!(dc0.buffered_amount(), 2, "incorrect bufferedAmount");
 
     bridge_process_at_least_one(&br).await;
 
@@ -467,8 +467,8 @@ async fn test_data_channel_buffered_amount() -> Result<()> {
 
     dc0.set_buffered_amount_low_threshold(1500);
     assert_eq!(
-        1500,
         dc0.buffered_amount_low_threshold(),
+        1500,
         "incorrect bufferedAmountLowThreshold"
     );
     let n_cbs2 = Arc::clone(&n_cbs);
@@ -549,28 +549,28 @@ async fn test_stats() -> Result<()> {
     let mut bytes_sent = 0;
 
     let n = dc0.write(&Bytes::from(sbuf.clone())).await?;
-    assert_eq!(sbuf.len(), n, "data length should match");
+    assert_eq!(n, sbuf.len(), "data length should match");
     bytes_sent += n;
 
     assert_eq!(dc0.bytes_sent(), bytes_sent);
     assert_eq!(dc0.messages_sent(), 1);
 
     let n = dc0.write(&Bytes::from(sbuf.clone())).await?;
-    assert_eq!(sbuf.len(), n, "data length should match");
+    assert_eq!(n, sbuf.len(), "data length should match");
     bytes_sent += n;
 
     assert_eq!(dc0.bytes_sent(), bytes_sent);
     assert_eq!(dc0.messages_sent(), 2);
 
     let n = dc0.write(&Bytes::from_static(&[0])).await?;
-    assert_eq!(1, n, "data length should match");
+    assert_eq!(n, 1, "data length should match");
     bytes_sent += n;
 
     assert_eq!(dc0.bytes_sent(), bytes_sent);
     assert_eq!(dc0.messages_sent(), 3);
 
     let n = dc0.write(&Bytes::from_static(&[])).await?;
-    assert_eq!(0, n, "data length should match");
+    assert_eq!(n, 0, "data length should match");
     bytes_sent += n;
 
     assert_eq!(dc0.bytes_sent(), bytes_sent);
@@ -581,28 +581,28 @@ async fn test_stats() -> Result<()> {
     let mut bytes_read = 0;
 
     let n = dc1.read(&mut rbuf[..]).await?;
-    assert_eq!(sbuf.len(), n, "data length should match");
+    assert_eq!(n, sbuf.len(), "data length should match");
     bytes_read += n;
 
     assert_eq!(dc1.bytes_received(), bytes_read);
     assert_eq!(dc1.messages_received(), 1);
 
     let n = dc1.read(&mut rbuf[..]).await?;
-    assert_eq!(sbuf.len(), n, "data length should match");
+    assert_eq!(n, sbuf.len(), "data length should match");
     bytes_read += n;
 
     assert_eq!(dc1.bytes_received(), bytes_read);
     assert_eq!(dc1.messages_received(), 2);
 
     let n = dc1.read(&mut rbuf[..]).await?;
-    assert_eq!(1, n, "data length should match");
+    assert_eq!(n, 1, "data length should match");
     bytes_read += n;
 
     assert_eq!(dc1.bytes_received(), bytes_read);
     assert_eq!(dc1.messages_received(), 3);
 
     let n = dc1.read(&mut rbuf[..]).await?;
-    assert_eq!(0, n, "data length should match");
+    assert_eq!(n, 0, "data length should match");
     bytes_read += n;
 
     assert_eq!(dc1.bytes_received(), bytes_read);

--- a/data/src/error.rs
+++ b/data/src/error.rs
@@ -60,3 +60,12 @@ impl PartialEq<util::Error> for Error {
         false
     }
 }
+
+impl PartialEq<Error> for util::Error {
+    fn eq(&self, other: &Error) -> bool {
+        if let Some(down) = self.downcast_ref::<Error>() {
+            return other == down;
+        }
+        false
+    }
+}

--- a/data/src/message/message_test.rs
+++ b/data/src/message/message_test.rs
@@ -46,12 +46,9 @@ fn test_message_unmarshal_ack_success() -> Result<()> {
 fn test_message_unmarshal_invalid_message_type() {
     let mut bytes = Bytes::from_static(&[0x01]);
     let expected = Error::InvalidMessageType(0x01);
-    let actual = Message::unmarshal(&mut bytes);
-    if let Err(err) = actual {
-        assert_eq!(expected, err);
-    } else {
-        panic!("expected err, but got ok");
-    }
+    let result = Message::unmarshal(&mut bytes);
+    let actual = result.expect_err("expected err, but got ok");
+    assert_eq!(actual, expected);
 }
 
 #[test]

--- a/dtls/src/crypto/crypto_test.rs
+++ b/dtls/src/crypto/crypto_test.rs
@@ -97,7 +97,7 @@ fn test_generate_key_signature() -> Result<()> {
     )?;
 
     assert_eq!(
-        expected_signature, signature,
+        signature, expected_signature,
         "Signature generation failed \nexp {:?} \nactual {:?} ",
         expected_signature, signature
     );
@@ -134,8 +134,8 @@ fn test_ccm_encryption_and_decryption() -> Result<()> {
     let cipher_text = ccm.encrypt(&rlh, &raw)?;
 
     assert_eq!(
-        [0, 27],
         &cipher_text[RECORD_LAYER_HEADER_SIZE - 2..RECORD_LAYER_HEADER_SIZE],
+        [0, 27],
         "RecordLayer size updating failed \nexp: {:?} \nactual {:?} ",
         [0, 27],
         &cipher_text[RECORD_LAYER_HEADER_SIZE - 2..RECORD_LAYER_HEADER_SIZE]

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -1579,7 +1579,7 @@ async fn test_binding_request_timeout() -> Result<()> {
         a.internal.invalidate_pending_binding_requests(now).await;
         {
             let pending_binding_requests = a.internal.pending_binding_requests.lock().await;
-            assert_eq!(EXPECTED_REMOVAL_COUNT, pending_binding_requests.len(), "Binding invalidation due to timeout did not remove the correct number of binding requests")
+            assert_eq!(pending_binding_requests.len(), EXPECTED_REMOVAL_COUNT, "Binding invalidation due to timeout did not remove the correct number of binding requests")
         }
     }
 

--- a/ice/src/candidate/candidate_test.rs
+++ b/ice/src/candidate/candidate_test.rs
@@ -263,7 +263,7 @@ fn test_candidate_pair_state_to_string() {
     ];
 
     for (candidate_pair_state, expected_string) in tests {
-        assert_eq!(expected_string, candidate_pair_state.to_string());
+        assert_eq!(candidate_pair_state.to_string(), expected_string);
     }
 }
 
@@ -279,8 +279,8 @@ fn test_candidate_type_serialization() {
 
     for (candidate_type, expected_string) in tests {
         assert_eq!(
-            expected_string.to_string(),
-            serde_json::to_string(&candidate_type).unwrap()
+            serde_json::to_string(&candidate_type).unwrap(),
+            expected_string.to_string()
         );
     }
 }
@@ -296,7 +296,7 @@ fn test_candidate_type_to_string() {
     ];
 
     for (candidate_type, expected_string) in tests {
-        assert_eq!(expected_string, candidate_type.to_string());
+        assert_eq!(candidate_type.to_string(), expected_string);
     }
 }
 

--- a/ice/src/external_ip_mapper/external_ip_mapper_test.rs
+++ b/ice/src/external_ip_mapper/external_ip_mapper_test.rs
@@ -27,8 +27,8 @@ fn test_external_ip_mapper_new_external_ip_mapper() -> Result<()> {
     assert_eq!(m.candidate_type, CandidateType::Host, "should match");
     assert!(m.ipv4_mapping.ip_sole.is_some());
     assert!(m.ipv6_mapping.ip_sole.is_none());
-    assert_eq!(0, m.ipv4_mapping.ip_map.len(), "should match");
-    assert_eq!(0, m.ipv6_mapping.ip_map.len(), "should match");
+    assert_eq!(m.ipv4_mapping.ip_map.len(), 0, "should match");
+    assert_eq!(m.ipv6_mapping.ip_map.len(), 0, "should match");
 
     // IPv4 with no explicit local IP, using CandidateTypeServerReflexive
     let m =
@@ -40,17 +40,17 @@ fn test_external_ip_mapper_new_external_ip_mapper() -> Result<()> {
     );
     assert!(m.ipv4_mapping.ip_sole.is_some());
     assert!(m.ipv6_mapping.ip_sole.is_none());
-    assert_eq!(0, m.ipv4_mapping.ip_map.len(), "should match");
-    assert_eq!(0, m.ipv6_mapping.ip_map.len(), "should match");
+    assert_eq!(m.ipv4_mapping.ip_map.len(), 0, "should match");
+    assert_eq!(m.ipv6_mapping.ip_map.len(), 0, "should match");
 
     // IPv4 with no explicit local IP, defaults to CandidateTypeHost
     let m = ExternalIpMapper::new(CandidateType::Unspecified, &["2601:4567::5678".to_owned()])?
         .unwrap();
-    assert_eq!(CandidateType::Host, m.candidate_type, "should match");
+    assert_eq!(m.candidate_type, CandidateType::Host, "should match");
     assert!(m.ipv4_mapping.ip_sole.is_none());
     assert!(m.ipv6_mapping.ip_sole.is_some());
-    assert_eq!(0, m.ipv4_mapping.ip_map.len(), "should match");
-    assert_eq!(0, m.ipv6_mapping.ip_map.len(), "should match");
+    assert_eq!(m.ipv4_mapping.ip_map.len(), 0, "should match");
+    assert_eq!(m.ipv6_mapping.ip_map.len(), 0, "should match");
 
     // IPv4 and IPv6 in the mix
     let m = ExternalIpMapper::new(
@@ -58,11 +58,11 @@ fn test_external_ip_mapper_new_external_ip_mapper() -> Result<()> {
         &["1.2.3.4".to_owned(), "2601:4567::5678".to_owned()],
     )?
     .unwrap();
-    assert_eq!(CandidateType::Host, m.candidate_type, "should match");
+    assert_eq!(m.candidate_type, CandidateType::Host, "should match");
     assert!(m.ipv4_mapping.ip_sole.is_some());
     assert!(m.ipv6_mapping.ip_sole.is_some());
-    assert_eq!(0, m.ipv4_mapping.ip_map.len(), "should match");
-    assert_eq!(0, m.ipv6_mapping.ip_map.len(), "should match");
+    assert_eq!(m.ipv4_mapping.ip_map.len(), 0, "should match");
+    assert_eq!(m.ipv6_mapping.ip_map.len(), 0, "should match");
 
     // Unsupported candidate type - CandidateTypePeerReflexive
     let result = ExternalIpMapper::new(CandidateType::PeerReflexive, &["1.2.3.4".to_owned()]);
@@ -105,11 +105,11 @@ fn test_external_ip_mapper_new_external_ip_mapper_with_explicit_local_ip() -> Re
     // IPv4 with  explicit local IP, defaults to CandidateTypeHost
     let m = ExternalIpMapper::new(CandidateType::Unspecified, &["1.2.3.4/10.0.0.1".to_owned()])?
         .unwrap();
-    assert_eq!(CandidateType::Host, m.candidate_type, "should match");
+    assert_eq!(m.candidate_type, CandidateType::Host, "should match");
     assert!(m.ipv4_mapping.ip_sole.is_none());
     assert!(m.ipv6_mapping.ip_sole.is_none());
-    assert_eq!(1, m.ipv4_mapping.ip_map.len(), "should match");
-    assert_eq!(0, m.ipv6_mapping.ip_map.len(), "should match");
+    assert_eq!(m.ipv4_mapping.ip_map.len(), 1, "should match");
+    assert_eq!(m.ipv6_mapping.ip_map.len(), 0, "should match");
 
     // Cannot assign two ext IPs for one local IPv4
     let result = ExternalIpMapper::new(
@@ -179,11 +179,11 @@ fn test_external_ip_mapper_find_external_ip_without_explicit_local_ip() -> Resul
 
     // find external IPv4
     let ext_ip = m.find_external_ip("10.0.0.1")?;
-    assert_eq!("1.2.3.4", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "1.2.3.4", "should match");
 
     // find external IPv6
     let ext_ip = m.find_external_ip("fe80::0001")?; // use '0001' instead of '1' on purpse
-    assert_eq!("2200::1", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "2200::1", "should match");
 
     // Bad local IP string
     let result = m.find_external_ip("really.bad");
@@ -208,20 +208,20 @@ fn test_external_ip_mapper_find_external_ip_with_explicit_local_ip() -> Result<(
 
     // find external IPv4
     let ext_ip = m.find_external_ip("10.0.0.1")?;
-    assert_eq!("1.2.3.4", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "1.2.3.4", "should match");
 
     let ext_ip = m.find_external_ip("10.0.0.2")?;
-    assert_eq!("1.2.3.5", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "1.2.3.5", "should match");
 
     let result = m.find_external_ip("10.0.0.3");
     assert!(result.is_err(), "should fail");
 
     // find external IPv6
     let ext_ip = m.find_external_ip("fe80::0001")?; // use '0001' instead of '1' on purpse
-    assert_eq!("2200::1", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "2200::1", "should match");
 
     let ext_ip = m.find_external_ip("fe80::0002")?; // use '0002' instead of '2' on purpse
-    assert_eq!("2200::2", ext_ip.to_string(), "should match");
+    assert_eq!(ext_ip.to_string(), "2200::2", "should match");
 
     let result = m.find_external_ip("fe80::3");
     assert!(result.is_err(), "should fail");

--- a/ice/src/mdns/mdns_test.rs
+++ b/ice/src/mdns/mdns_test.rs
@@ -90,7 +90,7 @@ async fn test_multicast_dns_static_host_name() -> Result<()> {
         ..Default::default()
     };
     if let Err(err) = Agent::new(cfg0).await {
-        assert_eq!(Error::ErrInvalidMulticastDnshostName, err);
+        assert_eq!(err, Error::ErrInvalidMulticastDnshostName);
     } else {
         panic!("expected error, but got ok");
     }

--- a/ice/src/network_type/network_type_test.rs
+++ b/ice/src/network_type/network_type_test.rs
@@ -93,6 +93,6 @@ fn test_network_type_to_string() {
     ];
 
     for (network_type, expected_string) in tests {
-        assert_eq!(expected_string, network_type.to_string());
+        assert_eq!(network_type.to_string(), expected_string);
     }
 }

--- a/ice/src/priority/priority_test.rs
+++ b/ice/src/priority/priority_test.rs
@@ -7,7 +7,7 @@ fn test_priority_get_from() -> Result<()> {
     let mut p = PriorityAttr::default();
     let result = p.get_from(&m);
     if let Err(err) = result {
-        assert_eq!(stun::Error::ErrAttributeNotFound, err, "unexpected error");
+        assert_eq!(err, stun::Error::ErrAttributeNotFound, "unexpected error");
     } else {
         panic!("expected error, but got ok");
     }

--- a/ice/src/state/state_test.rs
+++ b/ice/src/state/state_test.rs
@@ -16,8 +16,8 @@ fn test_connected_state_string() -> Result<()> {
 
     for (connection_state, expected_string) in tests {
         assert_eq!(
-            expected_string,
             connection_state.to_string(),
+            expected_string,
             "testCase: {} vs {}",
             expected_string,
             connection_state,
@@ -38,8 +38,8 @@ fn test_gathering_state_string() -> Result<()> {
 
     for (gathering_state, expected_string) in tests {
         assert_eq!(
-            expected_string,
             gathering_state.to_string(),
+            expected_string,
             "testCase: {} vs {}",
             expected_string,
             gathering_state,

--- a/ice/src/tcp_type/tcp_type_test.rs
+++ b/ice/src/tcp_type/tcp_type_test.rs
@@ -3,16 +3,16 @@ use crate::error::Result;
 
 #[test]
 fn test_tcp_type() -> Result<()> {
-    //assert_eq!(TCPType::Unspecified, tcpType)
-    assert_eq!(TcpType::Active, TcpType::from("active"));
-    assert_eq!(TcpType::Passive, TcpType::from("passive"));
-    assert_eq!(TcpType::SimultaneousOpen, TcpType::from("so"));
-    assert_eq!(TcpType::Unspecified, TcpType::from("something else"));
+    //assert_eq!(tcpType, TCPType::Unspecified)
+    assert_eq!(TcpType::from("active"), TcpType::Active);
+    assert_eq!(TcpType::from("passive"), TcpType::Passive);
+    assert_eq!(TcpType::from("so"), TcpType::SimultaneousOpen);
+    assert_eq!(TcpType::from("something else"), TcpType::Unspecified);
 
-    assert_eq!("unspecified", TcpType::Unspecified.to_string());
-    assert_eq!("active", TcpType::Active.to_string());
-    assert_eq!("passive", TcpType::Passive.to_string());
-    assert_eq!("so", TcpType::SimultaneousOpen.to_string());
+    assert_eq!(TcpType::Unspecified.to_string(), "unspecified");
+    assert_eq!(TcpType::Active.to_string(), "active");
+    assert_eq!(TcpType::Passive.to_string(), "passive");
+    assert_eq!(TcpType::SimultaneousOpen.to_string(), "so");
 
     Ok(())
 }

--- a/ice/src/url/url_test.rs
+++ b/ice/src/url/url_test.rs
@@ -89,17 +89,17 @@ fn test_parse_url_success() -> Result<()> {
     {
         let url = Url::parse_url(raw_url)?;
 
-        assert_eq!(expected_scheme, url.scheme, "testCase: {:?}", raw_url);
+        assert_eq!(url.scheme, expected_scheme, "testCase: {:?}", raw_url);
         assert_eq!(
             expected_url_string,
             url.to_string(),
             "testCase: {:?}",
             raw_url
         );
-        assert_eq!(expected_secure, url.is_secure(), "testCase: {:?}", raw_url);
-        assert_eq!(expected_host, url.host, "testCase: {:?}", raw_url);
-        assert_eq!(expected_port, url.port, "testCase: {:?}", raw_url);
-        assert_eq!(expected_proto, url.proto, "testCase: {:?}", raw_url);
+        assert_eq!(url.is_secure(), expected_secure, "testCase: {:?}", raw_url);
+        assert_eq!(url.host, expected_host, "testCase: {:?}", raw_url);
+        assert_eq!(url.port, expected_port, "testCase: {:?}", raw_url);
+        assert_eq!(url.proto, expected_proto, "testCase: {:?}", raw_url);
     }
 
     Ok(())

--- a/interceptor/src/nack/generator/generator_test.rs
+++ b/interceptor/src/nack/generator/generator_test.rs
@@ -42,7 +42,7 @@ async fn test_generator_interceptor() -> Result<()> {
             .await
             .expect("A read packet")
             .expect("Not an error");
-        assert_eq!(seq_num, r.header.sequence_number);
+        assert_eq!(r.header.sequence_number, seq_num);
     }
 
     tokio::time::sleep(INTERVAL * 2).await; // wait for at least 2 nack packets
@@ -54,8 +54,8 @@ async fn test_generator_interceptor() -> Result<()> {
         .await
         .expect("Write rtcp");
     if let Some(p) = r[0].as_any().downcast_ref::<TransportLayerNack>() {
-        assert_eq!(13, p.nacks[0].packet_id);
-        assert_eq!(0b10, p.nacks[0].lost_packets); // we want packets: 13, 15 (not packet 17, because skipLastN is setReceived to 2)
+        assert_eq!(p.nacks[0].packet_id, 13);
+        assert_eq!(p.nacks[0].lost_packets, 0b10); // we want packets: 13, 15 (not packet 17, because skipLastN is setReceived to 2)
     } else {
         assert!(false, "single packet RTCP Compound Packet expected");
     }

--- a/interceptor/src/nack/responder/responder_test.rs
+++ b/interceptor/src/nack/responder/responder_test.rs
@@ -38,7 +38,7 @@ async fn test_responder_interceptor() -> Result<()> {
         let p = timeout_or_fail(Duration::from_millis(10), stream.written_rtp())
             .await
             .expect("A packet");
-        assert_eq!(seq_num, p.header.sequence_number);
+        assert_eq!(p.header.sequence_number, seq_num);
     }
 
     stream
@@ -58,7 +58,7 @@ async fn test_responder_interceptor() -> Result<()> {
     for seq_num in [11, 12, 15] {
         if let Ok(r) = tokio::time::timeout(Duration::from_millis(50), stream.written_rtp()).await {
             if let Some(p) = r {
-                assert_eq!(seq_num, p.header.sequence_number);
+                assert_eq!(p.header.sequence_number, seq_num);
             } else {
                 assert!(
                     false,

--- a/interceptor/src/report/receiver/receiver_test.rs
+++ b/interceptor/src/report/receiver/receiver_test.rs
@@ -35,8 +35,9 @@ async fn test_receiver_interceptor_before_any_packet() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0,
@@ -45,8 +46,7 @@ async fn test_receiver_interceptor_before_any_packet() -> Result<()> {
                 total_lost: 0,
                 delay: 0,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -98,8 +98,9 @@ async fn test_receiver_interceptor_after_rtp_packets() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 9,
@@ -108,8 +109,7 @@ async fn test_receiver_interceptor_after_rtp_packets() -> Result<()> {
                 total_lost: 0,
                 delay: 0,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -181,8 +181,9 @@ async fn test_receiver_interceptor_after_rtp_and_rtcp_packets() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 9,
@@ -191,8 +192,7 @@ async fn test_receiver_interceptor_after_rtp_and_rtcp_packets() -> Result<()> {
                 total_lost: 0,
                 delay: rr.reports[0].delay,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -253,8 +253,9 @@ async fn test_receiver_interceptor_overflow() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: (1 << 16) | 0x0000,
@@ -263,8 +264,7 @@ async fn test_receiver_interceptor_overflow() -> Result<()> {
                 total_lost: 0,
                 delay: rr.reports[0].delay,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -353,8 +353,9 @@ async fn test_receiver_interceptor_overflow_five_pkts() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: (1 << 16) | 0x0001,
@@ -363,8 +364,7 @@ async fn test_receiver_interceptor_overflow_five_pkts() -> Result<()> {
                 total_lost: 0,
                 delay: rr.reports[0].delay,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -425,8 +425,9 @@ async fn test_receiver_interceptor_packet_loss() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0x03,
@@ -435,8 +436,7 @@ async fn test_receiver_interceptor_packet_loss() -> Result<()> {
                 total_lost: 1,
                 delay: 0,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -466,8 +466,9 @@ async fn test_receiver_interceptor_packet_loss() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0x03,
@@ -476,8 +477,7 @@ async fn test_receiver_interceptor_packet_loss() -> Result<()> {
                 total_lost: 1,
                 delay: rr.reports[0].delay,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -536,8 +536,9 @@ async fn test_receiver_interceptor_overflow_and_packet_loss() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 1 << 16 | 0x01,
@@ -546,8 +547,7 @@ async fn test_receiver_interceptor_overflow_and_packet_loss() -> Result<()> {
                 total_lost: 1,
                 delay: 0,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -598,8 +598,9 @@ async fn test_receiver_interceptor_reordered_packets() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0x04,
@@ -608,8 +609,7 @@ async fn test_receiver_interceptor_reordered_packets() -> Result<()> {
                 total_lost: 0,
                 delay: 0,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -678,8 +678,9 @@ async fn test_receiver_interceptor_jitter() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0x02,
@@ -688,8 +689,7 @@ async fn test_receiver_interceptor_jitter() -> Result<()> {
                 total_lost: 0,
                 delay: 0,
                 jitter: 30000 / 16,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);
@@ -743,8 +743,9 @@ async fn test_receiver_interceptor_delay() -> Result<()> {
         .as_any()
         .downcast_ref::<rtcp::receiver_report::ReceiverReport>()
     {
-        assert_eq!(1, rr.reports.len());
+        assert_eq!(rr.reports.len(), 1);
         assert_eq!(
+            rr.reports[0],
             rtcp::reception_report::ReceptionReport {
                 ssrc: 123456,
                 last_sequence_number: 0,
@@ -753,8 +754,7 @@ async fn test_receiver_interceptor_delay() -> Result<()> {
                 total_lost: 0,
                 delay: 65536,
                 jitter: 0,
-            },
-            rr.reports[0]
+            }
         )
     } else {
         assert!(false);

--- a/interceptor/src/report/sender/sender_test.rs
+++ b/interceptor/src/report/sender/sender_test.rs
@@ -38,6 +38,7 @@ async fn test_sender_interceptor_before_any_packet() -> Result<()> {
         .downcast_ref::<rtcp::sender_report::SenderReport>()
     {
         assert_eq!(
+            sr,
             &rtcp::sender_report::SenderReport {
                 ssrc: 123456,
                 ntp_time: unix2ntp(mt.now()),
@@ -45,8 +46,7 @@ async fn test_sender_interceptor_before_any_packet() -> Result<()> {
                 packet_count: 0,
                 octet_count: 0,
                 ..Default::default()
-            },
-            sr
+            }
         )
     } else {
         assert!(false);
@@ -102,6 +102,7 @@ async fn test_sender_interceptor_after_rtp_packets() -> Result<()> {
         .downcast_ref::<rtcp::sender_report::SenderReport>()
     {
         assert_eq!(
+            sr,
             &rtcp::sender_report::SenderReport {
                 ssrc: 123456,
                 ntp_time: unix2ntp(mt.now()),
@@ -109,8 +110,7 @@ async fn test_sender_interceptor_after_rtp_packets() -> Result<()> {
                 packet_count: 10,
                 octet_count: 20,
                 ..Default::default()
-            },
-            sr
+            }
         )
     } else {
         assert!(false);
@@ -204,6 +204,7 @@ async fn test_sender_interceptor_after_rtp_packets_overflow() -> Result<()> {
         .downcast_ref::<rtcp::sender_report::SenderReport>()
     {
         assert_eq!(
+            sr,
             &rtcp::sender_report::SenderReport {
                 ssrc: 123456,
                 ntp_time: unix2ntp(mt.now()),
@@ -211,8 +212,7 @@ async fn test_sender_interceptor_after_rtp_packets_overflow() -> Result<()> {
                 packet_count: 5,
                 octet_count: 10,
                 ..Default::default()
-            },
-            sr
+            }
         )
     } else {
         assert!(false);
@@ -226,8 +226,8 @@ async fn test_sender_interceptor_after_rtp_packets_overflow() -> Result<()> {
 #[tokio::test]
 async fn test_stream_counters_initially_zero() -> Result<()> {
     let counters = sender_stream::Counters::default();
-    assert_eq!(0, counters.octet_count());
-    assert_eq!(0, counters.packet_count());
+    assert_eq!(counters.octet_count(), 0);
+    assert_eq!(counters.packet_count(), 0);
     Ok(())
 }
 
@@ -237,7 +237,7 @@ async fn test_stream_packet_counter_wraps_on_overflow() -> Result<()> {
     for _ in 0..3 {
         counters.increment_packets();
     }
-    assert_eq!(2, counters.packet_count());
+    assert_eq!(counters.packet_count(), 2);
     Ok(())
 }
 
@@ -246,7 +246,7 @@ async fn test_stream_octet_counter_wraps_on_overflow() -> Result<()> {
     let mut counters = sender_stream::Counters::default();
     counters.count_octets(u32::MAX as usize);
     counters.count_octets(3);
-    assert_eq!(2, counters.octet_count());
+    assert_eq!(counters.octet_count(), 2);
     Ok(())
 }
 
@@ -254,6 +254,6 @@ async fn test_stream_octet_counter_wraps_on_overflow() -> Result<()> {
 async fn test_stream_octet_counter_saturates_u32_from_usize() -> Result<()> {
     let mut counters = sender_stream::Counters::default();
     counters.count_octets(0xabcdef01234567_usize);
-    assert_eq!(0xffffffff_u32, counters.octet_count());
+    assert_eq!(counters.octet_count(), 0xffffffff_u32);
     Ok(())
 }

--- a/interceptor/src/twcc/receiver/receiver_test.rs
+++ b/interceptor/src/twcc/receiver/receiver_test.rs
@@ -77,15 +77,15 @@ async fn test_twcc_receiver_interceptor_after_rtp_packets() -> Result<()> {
     let pkts = stream.written_rtcp().await.unwrap();
     assert_eq!(pkts.len(), 1);
     if let Some(cc) = pkts[0].as_any().downcast_ref::<TransportLayerCc>() {
-        assert_eq!(1, cc.media_ssrc);
-        assert_eq!(0, cc.base_sequence_number);
+        assert_eq!(cc.media_ssrc, 1);
+        assert_eq!(cc.base_sequence_number, 0);
         assert_eq!(
+            cc.packet_chunks,
             vec![PacketStatusChunk::RunLengthChunk(RunLengthChunk {
                 type_tcc: StatusChunkTypeTcc::RunLengthChunk,
                 packet_status_symbol: SymbolTypeTcc::PacketReceivedSmallDelta,
                 run_length: 10,
-            })],
-            cc.packet_chunks
+            })]
         );
     } else {
         assert!(false);
@@ -145,8 +145,9 @@ async fn test_twcc_receiver_interceptor_different_delays_between_rtp_packets() -
 
     assert_eq!(pkts.len(), 1);
     if let Some(cc) = pkts[0].as_any().downcast_ref::<TransportLayerCc>() {
-        assert_eq!(0, cc.base_sequence_number);
+        assert_eq!(cc.base_sequence_number, 0);
         assert_eq!(
+            cc.packet_chunks,
             vec![PacketStatusChunk::StatusVectorChunk(StatusVectorChunk {
                 type_tcc: StatusChunkTypeTcc::StatusVectorChunk,
                 symbol_size: SymbolSizeTypeTcc::TwoBit,
@@ -156,8 +157,7 @@ async fn test_twcc_receiver_interceptor_different_delays_between_rtp_packets() -
                     SymbolTypeTcc::PacketReceivedLargeDelta,
                     SymbolTypeTcc::PacketReceivedLargeDelta,
                 ],
-            })],
-            cc.packet_chunks
+            })]
         );
     } else {
         assert!(false);
@@ -224,8 +224,9 @@ async fn test_twcc_receiver_interceptor_packet_loss() -> Result<()> {
 
     assert_eq!(pkts.len(), 1);
     if let Some(cc) = pkts[0].as_any().downcast_ref::<TransportLayerCc>() {
-        assert_eq!(0, cc.base_sequence_number);
+        assert_eq!(cc.base_sequence_number, 0);
         assert_eq!(
+            cc.packet_chunks,
             vec![
                 PacketStatusChunk::StatusVectorChunk(StatusVectorChunk {
                     type_tcc: StatusChunkTypeTcc::StatusVectorChunk,
@@ -263,8 +264,7 @@ async fn test_twcc_receiver_interceptor_packet_loss() -> Result<()> {
                     packet_status_symbol: SymbolTypeTcc::PacketReceivedLargeDelta,
                     run_length: 1,
                 }),
-            ],
-            cc.packet_chunks
+            ]
         );
     } else {
         assert!(false);
@@ -312,8 +312,9 @@ async fn test_twcc_receiver_interceptor_overflow() -> Result<()> {
     let pkts = stream.written_rtcp().await.unwrap();
     assert_eq!(pkts.len(), 1);
     if let Some(cc) = pkts[0].as_any().downcast_ref::<TransportLayerCc>() {
-        assert_eq!(65530, cc.base_sequence_number);
+        assert_eq!(cc.base_sequence_number, 65530);
         assert_eq!(
+            cc.packet_chunks,
             vec![
                 PacketStatusChunk::StatusVectorChunk(StatusVectorChunk {
                     type_tcc: StatusChunkTypeTcc::StatusVectorChunk,
@@ -344,8 +345,7 @@ async fn test_twcc_receiver_interceptor_overflow() -> Result<()> {
                         SymbolTypeTcc::PacketReceivedSmallDelta,
                     ],
                 }),
-            ],
-            cc.packet_chunks
+            ]
         );
     } else {
         assert!(false);

--- a/interceptor/src/twcc/sender/sender_test.rs
+++ b/interceptor/src/twcc/sender/sender_test.rs
@@ -54,7 +54,7 @@ async fn test_twcc_sender_interceptor() -> Result<()> {
                     tokio::select! {
                         p = stream.written_rtp() =>{
                             if let Some(p) = p {
-                                assert_eq!(seq_num, p.header.sequence_number);
+                                assert_eq!(p.header.sequence_number, seq_num);
                                 let _ = p_chan_tx2.send(p).await;
                             }else{
                                 assert!(false, "stream.written_rtp none");

--- a/interceptor/src/twcc/twcc_test.rs
+++ b/interceptor/src/twcc/twcc_test.rs
@@ -13,7 +13,7 @@ fn test_chunk_add() -> Result<()> {
             assert!(c.can_add(SymbolTypeTcc::PacketNotReceived as u16), "{}", i);
             c.add(SymbolTypeTcc::PacketNotReceived as u16);
         }
-        assert_eq!(vec![0u16; MAX_RUN_LENGTH_CAP], c.deltas);
+        assert_eq!(c.deltas, vec![0u16; MAX_RUN_LENGTH_CAP]);
         assert!(!c.has_different_types);
 
         assert!(!c.can_add(SymbolTypeTcc::PacketNotReceived as u16));
@@ -27,7 +27,7 @@ fn test_chunk_add() -> Result<()> {
         };
 
         let buf = status_chunk.marshal()?;
-        assert_eq!(&[0x1f, 0xff], &buf[..]);
+        assert_eq!(&buf[..], &[0x1f, 0xff]);
     }
 
     //"fill with small delta"
@@ -56,7 +56,7 @@ fn test_chunk_add() -> Result<()> {
         };
 
         let buf = status_chunk.marshal()?;
-        assert_eq!(&[0x20, 0xe], &buf[..]);
+        assert_eq!(&buf[..], &[0x20, 0xe]);
     }
 
     //"fill with large delta"
@@ -86,7 +86,7 @@ fn test_chunk_add() -> Result<()> {
         };
 
         let buf = status_chunk.marshal()?;
-        assert_eq!(&[0x40, 0x7], &buf[..]);
+        assert_eq!(&buf[..], &[0x40, 0x7]);
     }
 
     // "fill with different types"
@@ -118,7 +118,7 @@ fn test_chunk_add() -> Result<()> {
         };
 
         let buf = status_chunk.marshal()?;
-        assert_eq!(&[0xd5, 0x6a], &buf[..]);
+        assert_eq!(&buf[..], &[0xd5, 0x6a]);
     }
 
     //"overfill and encode"
@@ -149,7 +149,7 @@ fn test_chunk_add() -> Result<()> {
             PacketStatusChunk::StatusVectorChunk(_) => assert!(true),
             _ => assert!(false),
         };
-        assert_eq!(1, c.deltas.len());
+        assert_eq!(c.deltas.len(), 1);
 
         assert!(c.can_add(SymbolTypeTcc::PacketReceivedLargeDelta as u16));
         c.add(SymbolTypeTcc::PacketReceivedLargeDelta as u16);
@@ -159,7 +159,7 @@ fn test_chunk_add() -> Result<()> {
             PacketStatusChunk::StatusVectorChunk(_) => assert!(true),
             _ => assert!(false),
         };
-        assert_eq!(0, c.deltas.len());
+        assert_eq!(c.deltas.len(), 0);
 
         assert_eq!(
             PacketStatusChunk::StatusVectorChunk(StatusVectorChunk {
@@ -201,16 +201,16 @@ fn test_feedback() -> Result<()> {
         let got = f.add_received(1, 1023 * 1000);
 
         assert!(got);
-        assert_eq!(2, f.next_sequence_number);
-        assert_eq!(15, f.ref_timestamp64ms);
+        assert_eq!(f.next_sequence_number, 2);
+        assert_eq!(f.ref_timestamp64ms, 15);
 
         let got = f.add_received(4, 1086 * 1000);
         assert!(got);
-        assert_eq!(5, f.next_sequence_number);
-        assert_eq!(15, f.ref_timestamp64ms);
+        assert_eq!(f.next_sequence_number, 5);
+        assert_eq!(f.ref_timestamp64ms, 15);
 
         assert!(f.last_chunk.has_different_types);
-        assert_eq!(4, f.last_chunk.deltas.len());
+        assert_eq!(f.last_chunk.deltas.len(), 4);
         assert!(!f
             .last_chunk
             .deltas
@@ -234,12 +234,12 @@ fn test_feedback() -> Result<()> {
         let pkt = f.get_rtcp();
 
         assert!(pkt.header().padding);
-        assert_eq!(7, pkt.header().length);
-        assert_eq!(5, pkt.base_sequence_number);
-        assert_eq!(7, pkt.packet_status_count);
-        assert_eq!(5, pkt.reference_time);
-        assert_eq!(0, pkt.fb_pkt_count);
-        assert_eq!(1, pkt.packet_chunks.len());
+        assert_eq!(pkt.header().length, 7);
+        assert_eq!(pkt.base_sequence_number, 5);
+        assert_eq!(pkt.packet_status_count, 7);
+        assert_eq!(pkt.reference_time, 5);
+        assert_eq!(pkt.fb_pkt_count, 0);
+        assert_eq!(pkt.packet_chunks.len(), 1);
 
         assert_eq!(
             vec![PacketStatusChunk::StatusVectorChunk(StatusVectorChunk {
@@ -276,9 +276,9 @@ fn test_feedback() -> Result<()> {
                 delta: 0x0400 * TYPE_TCC_DELTA_SCALE_FACTOR,
             },
         ];
-        assert_eq!(expected_deltas.len(), pkt.recv_deltas.len());
-        for (i, d) in expected_deltas.iter().enumerate() {
-            assert_eq!(d, &pkt.recv_deltas[i]);
+        assert_eq!(pkt.recv_deltas.len(), expected_deltas.len());
+        for (i, expected) in expected_deltas.iter().enumerate() {
+            assert_eq!(&pkt.recv_deltas[i], expected);
         }
     }
 
@@ -299,12 +299,12 @@ fn test_feedback() -> Result<()> {
         let pkt = f.get_rtcp();
 
         assert!(pkt.header().padding);
-        assert_eq!(7, pkt.header().length);
-        assert_eq!(65535, pkt.base_sequence_number);
-        assert_eq!(13, pkt.packet_status_count);
-        assert_eq!(5, pkt.reference_time);
-        assert_eq!(0, pkt.fb_pkt_count);
-        assert_eq!(2, pkt.packet_chunks.len());
+        assert_eq!(pkt.header().length, 7);
+        assert_eq!(pkt.base_sequence_number, 65535);
+        assert_eq!(pkt.packet_status_count, 13);
+        assert_eq!(pkt.reference_time, 5);
+        assert_eq!(pkt.fb_pkt_count, 0);
+        assert_eq!(pkt.packet_chunks.len(), 2);
 
         assert_eq!(
             vec![
@@ -355,9 +355,9 @@ fn test_feedback() -> Result<()> {
                 delta: 0x0400 * TYPE_TCC_DELTA_SCALE_FACTOR,
             },
         ];
-        assert_eq!(expected_deltas.len(), pkt.recv_deltas.len());
-        for (i, d) in expected_deltas.iter().enumerate() {
-            assert_eq!(d, &pkt.recv_deltas[i]);
+        assert_eq!(pkt.recv_deltas.len(), expected_deltas.len());
+        for (i, expected) in expected_deltas.iter().enumerate() {
+            assert_eq!(&pkt.recv_deltas[i], expected);
         }
     }
 
@@ -369,8 +369,8 @@ fn test_feedback() -> Result<()> {
             f.set_base(sequence_number, arrival_ts * 1000);
 
             let got = f.get_rtcp();
-            assert_eq!(want_ref_time, got.reference_time);
-            assert_eq!(want_base_sequence_number, got.base_sequence_number);
+            assert_eq!(got.reference_time, want_ref_time);
+            assert_eq!(got.base_sequence_number, want_base_sequence_number);
         }
     }
 
@@ -510,7 +510,7 @@ fn test_build_feedback_packet_rolling() -> Result<()> {
     );
 
     let rtcp_packets = r.build_feedback_packet();
-    assert_eq!(1, rtcp_packets.len());
+    assert_eq!(rtcp_packets.len(), 1);
 
     let expected = TransportLayerCc {
         sender_ssrc: 5000,

--- a/mdns/src/conn/conn_test.rs
+++ b/mdns/src/conn/conn_test.rs
@@ -13,7 +13,7 @@ mod test {
         server_a.close().await?;
 
         if let Err(err) = server_a.close().await {
-            assert_eq!(Error::ErrConnectionClosed, err);
+            assert_eq!(err, Error::ErrConnectionClosed);
         } else {
             assert!(false, "expected error, but got ok");
         }

--- a/mdns/src/message/message_test.rs
+++ b/mdns/src/message/message_test.rs
@@ -319,7 +319,7 @@ fn test_name_pack_unpack() -> Result<()> {
         let result = input.pack(vec![], &mut Some(HashMap::new()), 0);
         if let Some(want_err) = want_err {
             if let Err(actual_err) = result {
-                assert_eq!(want_err, actual_err);
+                assert_eq!(actual_err, want_err);
             } else {
                 assert!(false);
             }
@@ -507,7 +507,7 @@ fn test_resource_not_started() -> Result<()> {
     for (name, test_fn) in tests {
         let mut p = Parser::default();
         if let Err(err) = test_fn(&mut p) {
-            assert_eq!(Error::ErrNotStarted, err, "{}", name);
+            assert_eq!(err, Error::ErrNotStarted, "{}", name);
         }
     }
 
@@ -623,28 +623,28 @@ fn test_skip_each() -> Result<()> {
 
     p.skip_question()?;
     if let Err(err) = p.skip_question() {
-        assert_eq!(Error::ErrSectionDone, err);
+        assert_eq!(err, Error::ErrSectionDone);
     } else {
         assert!(false, "expected error, but got ok");
     }
 
     p.skip_answer()?;
     if let Err(err) = p.skip_answer() {
-        assert_eq!(Error::ErrSectionDone, err);
+        assert_eq!(err, Error::ErrSectionDone);
     } else {
         assert!(false, "expected error, but got ok");
     }
 
     p.skip_authority()?;
     if let Err(err) = p.skip_authority() {
-        assert_eq!(Error::ErrSectionDone, err);
+        assert_eq!(err, Error::ErrSectionDone);
     } else {
         assert!(false, "expected error, but got ok");
     }
 
     p.skip_additional()?;
     if let Err(err) = p.skip_additional() {
-        assert_eq!(Error::ErrSectionDone, err);
+        assert_eq!(err, Error::ErrSectionDone);
     } else {
         assert!(false, "expected error, but got ok");
     }
@@ -713,7 +713,7 @@ fn test_skip_after_read() -> Result<()> {
         };
 
         if let Err(err) = result {
-            assert_eq!(Error::ErrSectionDone, err);
+            assert_eq!(err, Error::ErrSectionDone);
         } else {
             assert!(false, "expected error, but got ok");
         }
@@ -746,7 +746,7 @@ fn test_skip_not_started() -> Result<()> {
     let mut p = Parser::default();
     for (name, test_fn) in tests {
         if let Err(err) = test_fn(&mut p) {
-            assert_eq!(Error::ErrNotStarted, err);
+            assert_eq!(err, Error::ErrNotStarted);
         } else {
             assert!(false, "{} expected error, but got ok", name);
         }
@@ -814,7 +814,7 @@ fn test_too_many_records() -> Result<()> {
     for (name, mut msg, want) in tests {
         if let Err(got) = msg.pack() {
             assert_eq!(
-                want, got,
+                got, want,
                 "got Message.Pack() for {} = {}, want = {}",
                 name, got, want
             )
@@ -878,7 +878,7 @@ fn test_too_long_txt() -> Result<()> {
     }
     let rb = TxtResource { txt: vec![str256] };
     if let Err(err) = rb.pack(vec![], &mut Some(HashMap::new()), 0) {
-        assert_eq!(Error::ErrStringTooLong, err);
+        assert_eq!(err, Error::ErrStringTooLong);
     } else {
         assert!(false, "expected error, but got ok");
     }
@@ -935,7 +935,7 @@ fn test_start_error() -> Result<()> {
             let mut b = env_fn();
             if let Err(got_err) = test_fn(&mut b) {
                 assert_eq!(
-                    *env_err, got_err,
+                    got_err, *env_err,
                     "got Builder{}.{} = {}, want = {}",
                     env_name, test_name, got_err, env_err
                 );
@@ -1095,7 +1095,7 @@ fn test_builder_resource_error() -> Result<()> {
             let mut b = env_fn();
             if let Err(got_err) = test_fn(&mut b) {
                 assert_eq!(
-                    *env_err, got_err,
+                    got_err, *env_err,
                     "got Builder{}.{} = {}, want = {}",
                     env_name, test_name, got_err, env_err
                 );
@@ -1117,7 +1117,7 @@ fn test_finish_error() -> Result<()> {
     let mut b = Builder::default();
     let want = Error::ErrNotStarted;
     if let Err(got) = b.finish() {
-        assert_eq!(want, got, "got Builder.Finish() = {}, want = {}", got, want);
+        assert_eq!(got, want, "got Builder.Finish() = {}, want = {}", got, want);
     } else {
         assert!(false, "expected error, but got ok");
     }
@@ -1217,7 +1217,7 @@ fn test_resource_pack() -> Result<()> {
 
     for (mut m, want_err) in tests {
         if let Err(err) = m.pack() {
-            assert_eq!(want_err, err);
+            assert_eq!(err, want_err);
         } else {
             assert!(false, "expected error, but got ok");
         }

--- a/media/src/io/h264_reader/h264_reader_test.rs
+++ b/media/src/io/h264_reader/h264_reader_test.rs
@@ -6,7 +6,7 @@ fn test_data_does_not_start_with_h264header() -> Result<()> {
     let test_function = |input: &[u8]| {
         let mut reader = H264Reader::new(Cursor::new(input));
         if let Err(err) = reader.next_nal() {
-            assert_eq!(Error::ErrDataIsNotH264Stream, err);
+            assert_eq!(err, Error::ErrDataIsNotH264Stream);
         } else {
             assert!(false);
         }
@@ -28,10 +28,10 @@ fn test_parse_header() -> Result<()> {
 
     let nal = reader.next_nal()?;
 
-    assert_eq!(1, nal.data.len());
+    assert_eq!(nal.data.len(), 1);
     assert!(nal.forbidden_zero_bit);
-    assert_eq!(0, nal.picture_order_count);
-    assert_eq!(1, nal.ref_idc);
+    assert_eq!(nal.picture_order_count, 0);
+    assert_eq!(nal.ref_idc, 1);
     assert_eq!(NalUnitType::EndOfStream, nal.unit_type);
 
     Ok(())
@@ -65,10 +65,10 @@ fn test_skip_sei() -> Result<()> {
     let mut reader = H264Reader::new(Cursor::new(h264bytes));
 
     let nal = reader.next_nal()?;
-    assert_eq!(0xAA, nal.data[0]);
+    assert_eq!(nal.data[0], 0xAA);
 
     let nal = reader.next_nal()?;
-    assert_eq!(0xAB, nal.data[0]);
+    assert_eq!(nal.data[0], 0xAB);
 
     Ok(())
 }

--- a/media/src/io/h264_writer/h264_writer_test.rs
+++ b/media/src/io/h264_writer/h264_writer_test.rs
@@ -26,7 +26,7 @@ fn test_is_key_frame() -> Result<()> {
 
     for (name, payload, want) in tests {
         let got = is_key_frame(&payload);
-        assert_eq!(want, got, "{} failed", name);
+        assert_eq!(got, want, "{} failed", name);
     }
 
     Ok(())
@@ -86,7 +86,7 @@ fn test_write_rtp() -> Result<()> {
             h264writer.close()?;
         }
 
-        assert_eq!(want_bytes, writer);
+        assert_eq!(writer, want_bytes);
     }
 
     Ok(())
@@ -119,7 +119,7 @@ fn test_write_rtp_fu() -> Result<()> {
         }
         h264writer.close()?;
     }
-    assert_eq!(want_bytes, writer);
+    assert_eq!(writer, want_bytes);
 
     Ok(())
 }

--- a/media/src/io/ivf_reader/ivf_reader_test.rs
+++ b/media/src/io/ivf_reader/ivf_reader_test.rs
@@ -35,21 +35,21 @@ fn test_ivf_reader_parse_valid_file_header() -> Result<()> {
     let r = BufReader::new(&ivf[..]);
     let (_, header) = IVFReader::new(r)?;
 
-    assert_eq!(b"DKIF", &header.signature, "signature is 'DKIF'");
-    assert_eq!(0, header.version, "version should be 0");
-    assert_eq!(b"VP80", &header.four_cc, "FourCC should be 'VP80'");
-    assert_eq!(176, header.width, "width should be 176");
-    assert_eq!(144, header.height, "height should be 144");
+    assert_eq!(&header.signature, b"DKIF", "signature is 'DKIF'");
+    assert_eq!(header.version, 0, "version should be 0");
+    assert_eq!(&header.four_cc, b"VP80", "FourCC should be 'VP80'");
+    assert_eq!(header.width, 176, "width should be 176");
+    assert_eq!(header.height, 144, "height should be 144");
     assert_eq!(
-        30000, header.timebase_denominator,
+        header.timebase_denominator, 30000,
         "timebase denominator should be 30000"
     );
     assert_eq!(
-        1000, header.timebase_numerator,
+        header.timebase_numerator, 1000,
         "timebase numerator should be 1000"
     );
-    assert_eq!(29, header.num_frames, "number of frames should be 29");
-    assert_eq!(0, header.unused, "bytes should be unused");
+    assert_eq!(header.num_frames, 29, "number of frames should be 29");
+    assert_eq!(header.unused, 0, "bytes should be unused");
 
     Ok(())
 }
@@ -79,24 +79,24 @@ fn test_ivf_reader_parse_valid_frames() -> Result<()> {
     // Parse Frame #1
     let (payload, header) = reader.parse_next_frame()?;
 
-    assert_eq!(4, header.frame_size, "Frame header frameSize should be 4");
-    assert_eq!(4, payload.len(), "Payload should be length 4");
+    assert_eq!(header.frame_size, 4, "Frame header frameSize should be 4");
+    assert_eq!(payload.len(), 4, "Payload should be length 4");
     assert_eq!(
         payload,
         Bytes::from_static(&[0xDE, 0xAD, 0xBE, 0xEF,]),
         "Payload value should be 0xDEADBEEF"
     );
     assert_eq!(
-        IVF_FILE_HEADER_SIZE + IVF_FRAME_HEADER_SIZE + header.frame_size as usize,
-        reader.bytes_read
+        reader.bytes_read,
+        IVF_FILE_HEADER_SIZE + IVF_FRAME_HEADER_SIZE + header.frame_size as usize
     );
     let previous_bytes_read = reader.bytes_read;
 
     // Parse Frame #2
     let (payload, header) = reader.parse_next_frame()?;
 
-    assert_eq!(12, header.frame_size, "Frame header frameSize should be 4");
-    assert_eq!(12, payload.len(), "Payload should be length 12");
+    assert_eq!(header.frame_size, 12, "Frame header frameSize should be 4");
+    assert_eq!(payload.len(), 12, "Payload should be length 12");
     assert_eq!(
         payload,
         Bytes::from_static(&[
@@ -105,8 +105,8 @@ fn test_ivf_reader_parse_valid_frames() -> Result<()> {
         "Payload value should be 0xDEADBEEFDEADBEEF"
     );
     assert_eq!(
-        previous_bytes_read + IVF_FRAME_HEADER_SIZE + header.frame_size as usize,
         reader.bytes_read,
+        previous_bytes_read + IVF_FRAME_HEADER_SIZE + header.frame_size as usize,
     );
 
     Ok(())

--- a/media/src/io/ivf_writer/ivf_writer_test.rs
+++ b/media/src/io/ivf_writer/ivf_writer_test.rs
@@ -90,26 +90,26 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
     let payload = vp8packet.depacketize(&valid_packet.payload)?;
     assert_eq!(1, vp8packet.s, "Start packet S value should be 1");
     assert_eq!(
-        1,
         payload[0] & 0x01,
+        1,
         "Non Keyframe packet P value should be 1"
     );
 
     // Check mid partition packet parameters
     let mut vp8packet = rtp::codecs::vp8::Vp8Packet::default();
     let payload = vp8packet.depacketize(&mid_part_packet.payload)?;
-    assert_eq!(0, vp8packet.s, "Mid Partition packet S value should be 0");
+    assert_eq!(vp8packet.s, 0, "Mid Partition packet S value should be 0");
     assert_eq!(
-        1,
         payload[0] & 0x01,
+        1,
         "Non Keyframe packet P value should be 1"
     );
 
     // Check keyframe packet parameters
     let mut vp8packet = rtp::codecs::vp8::Vp8Packet::default();
     let payload = vp8packet.depacketize(&keyframe_packet.payload)?;
-    assert_eq!(1, vp8packet.s, "Start packet S value should be 1");
-    assert_eq!(0, payload[0] & 0x01, "Keyframe packet P value should be 0");
+    assert_eq!(vp8packet.s, 1, "Start packet S value should be 1");
+    assert_eq!(payload[0] & 0x01, 0, "Keyframe packet P value should be 0");
 
     let add_packet_test_case = vec![
         (
@@ -157,7 +157,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             !writer.seen_key_frame,
             "Writer's seenKeyFrame should initialize false"
         );
-        assert_eq!(0, writer.count, "Writer's packet count should initialize 0");
+        assert_eq!(writer.count, 0, "Writer's packet count should initialize 0");
         let result = writer.write_rtp(&packet);
         if err.is_some() {
             assert!(result.is_err(), "{}", msg1);
@@ -168,19 +168,19 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
 
         assert_eq!(seen_key_frame, writer.seen_key_frame, "{} failed", msg1);
         if count == 1 {
-            assert_eq!(0, writer.count);
+            assert_eq!(writer.count, 0);
         } else if count == 2 {
-            assert_eq!(1, writer.count);
+            assert_eq!(writer.count, 1);
         }
 
         writer.write_rtp(&mid_part_packet)?;
         if count == 1 {
-            assert_eq!(0, writer.count);
+            assert_eq!(writer.count, 0);
         } else if count == 2 {
-            assert_eq!(1, writer.count);
+            assert_eq!(writer.count, 1);
 
             writer.write_rtp(&valid_packet)?;
-            assert_eq!(2, writer.count);
+            assert_eq!(writer.count, 2);
         }
 
         writer.close()?;

--- a/media/src/io/ogg_reader/ogg_reader_test.rs
+++ b/media/src/io/ogg_reader/ogg_reader_test.rs
@@ -36,7 +36,7 @@ fn test_ogg_reader_parse_next_page() -> Result<()> {
     let (mut reader, _header) = OggReader::new(r, true)?;
 
     let (payload, _) = reader.parse_next_page()?;
-    assert_eq!(Bytes::from_static(&[0x98, 0x36, 0xbe, 0x88, 0x9e]), payload);
+    assert_eq!(payload, Bytes::from_static(&[0x98, 0x36, 0xbe, 0x88, 0x9e]));
 
     let result = reader.parse_next_page();
     assert!(result.is_err());
@@ -54,7 +54,7 @@ fn test_ogg_reader_parse_errors() -> Result<()> {
         let result = OggReader::new(Cursor::new(ogg), false);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(Error::ErrBadIDPageSignature, err);
+            assert_eq!(err, Error::ErrBadIDPageSignature);
         }
     }
 
@@ -66,7 +66,7 @@ fn test_ogg_reader_parse_errors() -> Result<()> {
         let result = OggReader::new(Cursor::new(ogg), false);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(Error::ErrBadIDPageType, err);
+            assert_eq!(err, Error::ErrBadIDPageType);
         }
     }
 
@@ -78,7 +78,7 @@ fn test_ogg_reader_parse_errors() -> Result<()> {
         let result = OggReader::new(Cursor::new(ogg), false);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(Error::ErrBadIDPageLength, err);
+            assert_eq!(err, Error::ErrBadIDPageLength);
         }
     }
 
@@ -90,7 +90,7 @@ fn test_ogg_reader_parse_errors() -> Result<()> {
         let result = OggReader::new(Cursor::new(ogg), false);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(Error::ErrBadIDPagePayloadSignature, err);
+            assert_eq!(err, Error::ErrBadIDPagePayloadSignature);
         }
     }
 
@@ -102,7 +102,7 @@ fn test_ogg_reader_parse_errors() -> Result<()> {
         let result = OggReader::new(Cursor::new(ogg), true);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(Error::ErrChecksumMismatch, err);
+            assert_eq!(err, Error::ErrChecksumMismatch);
         }
     }
 

--- a/media/src/io/sample_builder/sample_builder_test.rs
+++ b/media/src/io/sample_builder/sample_builder_test.rs
@@ -1254,13 +1254,13 @@ fn test_sample_builder_max_late() {
         payload: bytes!(0x01),
     });
     assert_eq!(
+        s.pop(),
         Some(Sample {
             data: bytes!(0x01),
             duration: Duration::from_secs(1),
             packet_timestamp: 1,
             ..Default::default()
         }),
-        s.pop(),
         "Failed to build samples before gap"
     );
 
@@ -1290,13 +1290,13 @@ fn test_sample_builder_max_late() {
     });
 
     assert_eq!(
+        s.pop(),
         Some(Sample {
             data: bytes!(0x01),
             duration: Duration::from_secs(1),
             packet_timestamp: 2,
             ..Default::default()
         }),
-        s.pop(),
         "Failed to build samples after large gap"
     );
     assert_eq!(None, s.pop(), "Failed to build samples after large gap");
@@ -1310,6 +1310,7 @@ fn test_sample_builder_max_late() {
         payload: bytes!(0x03),
     });
     assert_eq!(
+        s.pop(),
         Some(Sample {
             data: bytes!(0x02),
             duration: Duration::from_secs(1),
@@ -1317,17 +1318,16 @@ fn test_sample_builder_max_late() {
             prev_dropped_packets: 4998,
             ..Default::default()
         }),
-        s.pop(),
         "Failed to build samples after large gap"
     );
     assert_eq!(
+        s.pop(),
         Some(Sample {
             data: bytes!(0x02),
             duration: Duration::from_secs(1),
             packet_timestamp: 501,
             ..Default::default()
         }),
-        s.pop(),
         "Failed to build samples after large gap"
     );
 }
@@ -1434,15 +1434,15 @@ fn test_sample_builder_clean_reference() {
 
         for i in 0..3 {
             assert_eq!(
-                None,
                 s.buffer[seq_start.wrapping_add(i) as usize],
+                None,
                 "Old packet ({}) is not unreferenced (seq_start: {}, max_late: 10, pushed: 12)",
                 i,
                 seq_start
             );
         }
-        assert_eq!(Some(pkt4), s.buffer[seq_start.wrapping_add(14) as usize]);
-        assert_eq!(Some(pkt5), s.buffer[seq_start.wrapping_add(12) as usize]);
+        assert_eq!(s.buffer[seq_start.wrapping_add(14) as usize], Some(pkt4));
+        assert_eq!(s.buffer[seq_start.wrapping_add(12) as usize], Some(pkt5));
     }
 }
 
@@ -1469,7 +1469,7 @@ fn test_sample_builder_push_max_zero() {
 #[test]
 fn test_pop_with_timestamp() {
     let mut s = SampleBuilder::new(0, FakeDepacketizer::new(), 1);
-    assert_eq!(None, s.pop_with_timestamp());
+    assert_eq!(s.pop_with_timestamp(), None);
 }
 
 #[test]
@@ -1489,7 +1489,7 @@ fn test_sample_builder_data() {
         while let Some((sample, ts)) = s.pop_with_timestamp() {
             assert_eq!(ts, (j + 42) as u32, "timestamp");
             assert_eq!(sample.data.len(), 1, "data length");
-            assert_eq!(j as u8, sample.data[0], "timestamp");
+            assert_eq!(sample.data[0], j as u8, "timestamp");
             j += 1;
         }
     }

--- a/media/src/io/sample_builder/sample_sequence_location_test.rs
+++ b/media/src/io/sample_builder/sample_sequence_location_test.rs
@@ -3,24 +3,24 @@ use super::sample_sequence_location::*;
 #[test]
 fn test_sample_sequence_location_compare() {
     let s1 = SampleSequenceLocation { head: 32, tail: 42 };
-    assert_eq!(Comparison::Before, s1.compare(16));
-    assert_eq!(Comparison::Inside, s1.compare(32));
-    assert_eq!(Comparison::Inside, s1.compare(38));
-    assert_eq!(Comparison::Inside, s1.compare(41));
-    assert_eq!(Comparison::After, s1.compare(42));
-    assert_eq!(Comparison::After, s1.compare(0x57));
+    assert_eq!(s1.compare(16), Comparison::Before);
+    assert_eq!(s1.compare(32), Comparison::Inside);
+    assert_eq!(s1.compare(38), Comparison::Inside);
+    assert_eq!(s1.compare(41), Comparison::Inside);
+    assert_eq!(s1.compare(42), Comparison::After);
+    assert_eq!(s1.compare(0x57), Comparison::After);
 
     let s2 = SampleSequenceLocation {
         head: 0xffa0,
         tail: 32,
     };
-    assert_eq!(Comparison::Before, s2.compare(0xff00));
-    assert_eq!(Comparison::Inside, s2.compare(0xffa0));
-    assert_eq!(Comparison::Inside, s2.compare(0xffff));
-    assert_eq!(Comparison::Inside, s2.compare(0));
-    assert_eq!(Comparison::Inside, s2.compare(31));
-    assert_eq!(Comparison::After, s2.compare(32));
-    assert_eq!(Comparison::After, s2.compare(128));
+    assert_eq!(s2.compare(0xff00), Comparison::Before);
+    assert_eq!(s2.compare(0xffa0), Comparison::Inside);
+    assert_eq!(s2.compare(0xffff), Comparison::Inside);
+    assert_eq!(s2.compare(0), Comparison::Inside);
+    assert_eq!(s2.compare(31), Comparison::Inside);
+    assert_eq!(s2.compare(32), Comparison::After);
+    assert_eq!(s2.compare(128), Comparison::After);
 }
 
 #[test]

--- a/rtcp/src/header.rs
+++ b/rtcp/src/header.rs
@@ -241,12 +241,12 @@ mod test {
                 want_error
             );
 
-            if let Some(err) = want_error {
+            if let Some(want_error) = want_error {
                 let got_err = got.err().unwrap();
                 assert_eq!(
-                    err, got_err,
+                    want_error, got_err,
                     "Unmarshal {}: err = {:?}, want {:?}",
-                    name, got_err, err,
+                    name, got_err, want_error,
                 );
             } else {
                 let actual = got.unwrap();

--- a/rtcp/src/packet.rs
+++ b/rtcp/src/packet.rs
@@ -210,7 +210,7 @@ mod test {
         let result = unmarshal(&mut Bytes::new());
         if let Err(got) = result {
             let want = Error::InvalidHeader;
-            assert_eq!(want, got, "Unmarshal(nil) err = {}, want {}", got, want);
+            assert_eq!(got, want, "Unmarshal(nil) err = {}, want {}", got, want);
         } else {
             panic!("want error");
         }
@@ -230,7 +230,7 @@ mod test {
         if let Err(got) = result {
             let want = Error::PacketTooShort;
             assert_eq!(
-                want, got,
+                got, want,
                 "Unmarshal(invalid_header_length) err = {}, want {}",
                 got, want
             );

--- a/rtcp/src/payload_feedbacks/receiver_estimated_maximum_bitrate/receiver_estimated_maximum_bitrate_test.rs
+++ b/rtcp/src/payload_feedbacks/receiver_estimated_maximum_bitrate/receiver_estimated_maximum_bitrate_test.rs
@@ -14,7 +14,7 @@ fn test_receiver_estimated_maximum_bitrate_marshal() {
     ]);
 
     let output = input.marshal().unwrap();
-    assert_eq!(expected, output);
+    assert_eq!(output, expected);
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn test_receiver_estimated_maximum_bitrate_unmarshal() {
     };
 
     let packet = ReceiverEstimatedMaximumBitrate::unmarshal(&mut input).unwrap();
-    assert_eq!(expected, packet);
+    assert_eq!(packet, expected);
 }
 
 #[test]
@@ -52,11 +52,11 @@ fn test_receiver_estimated_maximum_bitrate_truncate() {
 
     let mut buf = input.clone();
     let mut packet = ReceiverEstimatedMaximumBitrate::unmarshal(&mut buf).unwrap();
-    assert_eq!(8927168.0, packet.bitrate);
+    assert_eq!(packet.bitrate, 8927168.0);
 
     // Just verify marshal produces the same input.
     let output = packet.marshal().unwrap();
-    assert_eq!(input, output);
+    assert_eq!(output, input);
 
     // If we subtract the bitrate by 1, we'll round down a lower mantissa
     packet.bitrate -= 1.0;
@@ -66,11 +66,11 @@ fn test_receiver_estimated_maximum_bitrate_truncate() {
     // exp = 6
 
     let mut output = packet.marshal().unwrap();
-    assert_ne!(input, output);
+    assert_ne!(output, input);
     let expected = Bytes::from_static(&[
         143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 222, 72, 116, 237, 22,
     ]);
-    assert_eq!(expected, output);
+    assert_eq!(output, expected);
 
     // Which if we actually unmarshal again, we'll find that it's actually decreased by 63 (which is exp)
     // mantissa = 139486
@@ -97,7 +97,7 @@ fn test_receiver_estimated_maximum_bitrate_overflow() {
     ]);
 
     let output = packet.marshal().unwrap();
-    assert_eq!(expected, output);
+    assert_eq!(output, expected);
 
     // mantissa = 262143
     // exp = 63
@@ -105,16 +105,16 @@ fn test_receiver_estimated_maximum_bitrate_overflow() {
 
     let mut buf = output;
     let packet = ReceiverEstimatedMaximumBitrate::unmarshal(&mut buf).unwrap();
-    assert_eq!(f32::from_bits(0x67FFFFC0), packet.bitrate);
+    assert_eq!(packet.bitrate, f32::from_bits(0x67FFFFC0));
 
     // Make sure we marshal to the same result again.
     let output = packet.marshal().unwrap();
-    assert_eq!(expected, output);
+    assert_eq!(output, expected);
 
     // Finally, try unmarshalling one number higher than we used to be able to handle.
     let mut input = Bytes::from_static(&[
         143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 188, 0, 0,
     ]);
     let packet = ReceiverEstimatedMaximumBitrate::unmarshal(&mut input).unwrap();
-    assert_eq!(f32::from_bits(0x62800000), packet.bitrate);
+    assert_eq!(packet.bitrate, f32::from_bits(0x62800000));
 }

--- a/rtp/src/codecs/h265/h265_test.rs
+++ b/rtp/src/codecs/h265/h265_test.rs
@@ -253,15 +253,15 @@ fn test_h265_single_nalunit_packet() -> Result<()> {
 
         if let Some(expected_packet) = cur.expected_packet {
             assert_eq!(
-                expected_packet.payload_header(),
                 parsed.payload_header(),
+                expected_packet.payload_header(),
                 "invalid payload header"
             );
-            assert_eq!(expected_packet.donl(), parsed.donl(), "invalid DONL");
+            assert_eq!(parsed.donl(), expected_packet.donl(), "invalid DONL");
 
             assert_eq!(
-                expected_packet.payload(),
                 parsed.payload(),
+                expected_packet.payload(),
                 "invalid payload"
             );
         }
@@ -411,20 +411,20 @@ fn test_h265_aggregation_packet() -> Result<()> {
                     "invalid first unit NALUSize"
                 );
                 assert_eq!(
-                    first_unit.donl(),
                     parsed_first_unit.donl(),
+                    first_unit.donl(),
                     "invalid first unit DONL"
                 );
                 assert_eq!(
-                    first_unit.nal_unit(),
                     parsed_first_unit.nal_unit(),
+                    first_unit.nal_unit(),
                     "invalid first unit NalUnit"
                 );
             }
 
             assert_eq!(
-                expected_packet.other_units().len(),
                 parsed.other_units().len(),
+                expected_packet.other_units().len(),
                 "number of other units mismatch"
             );
 
@@ -436,21 +436,21 @@ fn test_h265_aggregation_packet() -> Result<()> {
                 );
 
                 assert_eq!(
-                    expected_packet.other_units()[ndx].dond(),
                     parsed.other_units()[ndx].dond(),
+                    expected_packet.other_units()[ndx].dond(),
                     "invalid unit DOND"
                 );
 
                 assert_eq!(
-                    expected_packet.other_units()[ndx].nal_unit(),
                     parsed.other_units()[ndx].nal_unit(),
+                    expected_packet.other_units()[ndx].nal_unit(),
                     "invalid first unit NalUnit"
                 );
             }
 
             assert_eq!(
-                expected_packet.other_units(),
                 parsed.other_units(),
+                expected_packet.other_units(),
                 "invalid payload"
             );
         }
@@ -714,20 +714,20 @@ fn test_h265_paci_packet() -> Result<()> {
 
         if let Some(expected_fu) = &cur.expected_fu {
             assert_eq!(
-                expected_fu.payload_header(),
                 parsed.payload_header(),
+                expected_fu.payload_header(),
                 "invalid PayloadHeader"
             );
-            assert_eq!(expected_fu.a(), parsed.a(), "invalid A");
-            assert_eq!(expected_fu.ctype(), parsed.ctype(), "invalid CType");
-            assert_eq!(expected_fu.phs_size(), parsed.phs_size(), "invalid PHSsize");
-            assert_eq!(expected_fu.f0(), parsed.f0(), "invalid F0");
-            assert_eq!(expected_fu.f1(), parsed.f1(), "invalid F1");
-            assert_eq!(expected_fu.f2(), parsed.f2(), "invalid F2");
-            assert_eq!(expected_fu.y(), parsed.y(), "invalid Y");
-            assert_eq!(expected_fu.phes(), parsed.phes(), "invalid PHES");
-            assert_eq!(expected_fu.payload(), parsed.payload(), "invalid Payload");
-            assert_eq!(expected_fu.tsci(), parsed.tsci(), "invalid TSCI");
+            assert_eq!(parsed.a(), expected_fu.a(), "invalid A");
+            assert_eq!(parsed.ctype(), expected_fu.ctype(), "invalid CType");
+            assert_eq!(parsed.phs_size(), expected_fu.phs_size(), "invalid PHSsize");
+            assert_eq!(parsed.f0(), expected_fu.f0(), "invalid F0");
+            assert_eq!(parsed.f1(), expected_fu.f1(), "invalid F1");
+            assert_eq!(parsed.f2(), expected_fu.f2(), "invalid F2");
+            assert_eq!(parsed.y(), expected_fu.y(), "invalid Y");
+            assert_eq!(parsed.phes(), expected_fu.phes(), "invalid PHES");
+            assert_eq!(parsed.payload(), expected_fu.payload(), "invalid Payload");
+            assert_eq!(parsed.tsci(), expected_fu.tsci(), "invalid TSCI");
         }
     }
 

--- a/rtp/src/codecs/vp9/vp9_test.rs
+++ b/rtp/src/codecs/vp9/vp9_test.rs
@@ -304,7 +304,7 @@ fn test_vp9_payloader_payload() -> Result<()> {
         for b in &bs {
             actual.extend(pck.payload(mtu, b)?);
         }
-        assert_eq!(expected, actual, "{}: Payloaded packet", name);
+        assert_eq!(actual, expected, "{}: Payloaded packet", name);
     }
 
     //"PictureIDOverflow"

--- a/rtp/src/packetizer/packetizer_test.rs
+++ b/rtp/src/packetizer/packetizer_test.rs
@@ -89,7 +89,7 @@ async fn test_packetizer_abs_send_time() -> Result<()> {
         assert!(false, "Generated {} packets instead of 1", packets.len())
     }
 
-    assert_eq!(expected, packets[0]);
+    assert_eq!(packets[0], expected);
 
     Ok(())
 }

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -81,10 +81,10 @@ fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
 
     let fwdtsn = a.create_forward_tsn();
 
-    assert_eq!(10, fwdtsn.new_cumulative_tsn, "should be able to serialize");
-    assert_eq!(1, fwdtsn.streams.len(), "there should be one stream");
-    assert_eq!(1, fwdtsn.streams[0].identifier, "si should be 1");
-    assert_eq!(2, fwdtsn.streams[0].sequence, "ssn should be 2");
+    assert_eq!(fwdtsn.new_cumulative_tsn, 10, "should be able to serialize");
+    assert_eq!(fwdtsn.streams.len(), 1, "there should be one stream");
+    assert_eq!(fwdtsn.streams[0].identifier, 1, "si should be 1");
+    assert_eq!(fwdtsn.streams[0].sequence, 2, "ssn should be 2");
 
     Ok(())
 }
@@ -131,8 +131,8 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
 
     let fwdtsn = a.create_forward_tsn();
 
-    assert_eq!(12, fwdtsn.new_cumulative_tsn, "should be able to serialize");
-    assert_eq!(2, fwdtsn.streams.len(), "there should be two stream");
+    assert_eq!(fwdtsn.new_cumulative_tsn, 12, "should be able to serialize");
+    assert_eq!(fwdtsn.streams.len(), 2, "there should be two stream");
 
     let mut si1ok = false;
     let mut si2ok = false;
@@ -300,9 +300,8 @@ async fn test_handle_forward_tsn_dup_forward_tsn_chunk_should_generate_sack() ->
 
     let p = a.handle_forward_tsn(&fwdtsn).await?;
 
-    let ack_state = a.ack_state;
     assert_eq!(a.peer_last_tsn, prev_tsn, "peerLastTSN should not advance");
-    assert_eq!(AckState::Immediate, ack_state, "sack should be requested");
+    assert_eq!(a.ack_state, AckState::Immediate, "sack should be requested");
     assert!(p.is_empty(), "should return empty");
 
     Ok(())
@@ -378,20 +377,20 @@ async fn handle_init_test(name: &str, initial_state: AssociationState, expect_er
         assert!(result.is_ok(), "{} should be ok", name);
     }
     assert_eq!(
+        a.peer_last_tsn,
         if init.initial_tsn == 0 {
             u32::MAX
         } else {
             init.initial_tsn - 1
         },
-        a.peer_last_tsn,
         "{} should match",
         name
     );
-    assert_eq!(1001, a.my_max_num_outbound_streams, "{} should match", name);
-    assert_eq!(1002, a.my_max_num_inbound_streams, "{} should match", name);
-    assert_eq!(5678, a.peer_verification_tag, "{} should match", name);
-    assert_eq!(pkt.source_port, a.destination_port, "{} should match", name);
-    assert_eq!(pkt.destination_port, a.source_port, "{} should match", name);
+    assert_eq!(a.my_max_num_outbound_streams, 1001, "{} should match", name);
+    assert_eq!(a.my_max_num_inbound_streams, 1002, "{} should match", name);
+    assert_eq!(a.peer_verification_tag, 5678, "{} should match", name);
+    assert_eq!(a.destination_port, pkt.source_port, "{} should match", name);
+    assert_eq!(a.source_port, pkt.destination_port, "{} should match", name);
     assert!(a.use_forward_tsn, "{} should be set to true", name);
 }
 
@@ -446,8 +445,8 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
         name: "client".to_owned(),
     });
     assert_eq!(
-        65536,
         a.max_message_size.load(Ordering::SeqCst),
+        65536,
         "should match"
     );
 
@@ -460,8 +459,8 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
 
         if let Err(err) = s.write_sctp(&p.slice(..65536), ppi).await {
             assert_ne!(
-                Error::ErrOutboundPacketTooLarge,
                 err,
+                Error::ErrOutboundPacketTooLarge,
                 "should be not Error::ErrOutboundPacketTooLarge"
             );
         } else {
@@ -470,8 +469,8 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
 
         if let Err(err) = s.write_sctp(&p.slice(..65537), ppi).await {
             assert_eq!(
-                Error::ErrOutboundPacketTooLarge,
                 err,
+                Error::ErrOutboundPacketTooLarge,
                 "should be Error::ErrOutboundPacketTooLarge"
             );
         } else {
@@ -492,8 +491,8 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
     });
 
     assert_eq!(
-        30000,
         a.max_message_size.load(Ordering::SeqCst),
+        30000,
         "should match"
     );
 
@@ -506,8 +505,8 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
 
         if let Err(err) = s.write_sctp(&p.slice(..30000), ppi).await {
             assert_ne!(
-                Error::ErrOutboundPacketTooLarge,
                 err,
+                Error::ErrOutboundPacketTooLarge,
                 "should be not Error::ErrOutboundPacketTooLarge"
             );
         } else {
@@ -516,8 +515,8 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
 
         if let Err(err) = s.write_sctp(&p.slice(..30001), ppi).await {
             assert_eq!(
-                Error::ErrOutboundPacketTooLarge,
                 err,
+                Error::ErrOutboundPacketTooLarge,
                 "should be Error::ErrOutboundPacketTooLarge"
             );
         } else {

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -250,16 +250,16 @@ async fn test_assoc_reliable_simple() -> Result<()> {
 
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), 0, "incorrect bufferedAmount");
     }
 
     let n = s0
         .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG.len(), "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(MSG.len(), a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), MSG.len(), "incorrect bufferedAmount");
     }
 
     flush_buffers(&br, &a0, &a1).await;
@@ -276,7 +276,7 @@ async fn test_assoc_reliable_simple() -> Result<()> {
 
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), 0, "incorrect bufferedAmount");
     }
 
     close_association_pair(&br, a0, a1).await;
@@ -325,7 +325,7 @@ async fn test_assoc_reliable_ordered_reordered() -> Result<()> {
 
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), 0, "incorrect bufferedAmount");
     }
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
@@ -335,7 +335,7 @@ async fn test_assoc_reliable_ordered_reordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -344,7 +344,7 @@ async fn test_assoc_reliable_ordered_reordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     tokio::time::sleep(Duration::from_millis(10)).await;
     br.reorder(0).await;
@@ -427,7 +427,7 @@ async fn test_assoc_reliable_ordered_fragmented_then_defragmented() -> Result<()
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbufl.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbufl.len(), "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
 
@@ -494,7 +494,7 @@ async fn test_assoc_reliable_unordered_fragmented_then_defragmented() -> Result<
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbufl.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbufl.len(), "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
 
@@ -564,7 +564,7 @@ async fn test_assoc_reliable_unordered_ordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -573,7 +573,7 @@ async fn test_assoc_reliable_unordered_ordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     flush_buffers(&br, &a0, &a1).await;
 
@@ -649,12 +649,12 @@ async fn test_assoc_reliable_retransmission() -> Result<()> {
     let n = s0
         .write_sctp(&MSG1, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG1.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG1.len(), "unexpected length of received data");
 
     let n = s0
         .write_sctp(&MSG2, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG2.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG2.len(), "unexpected length of received data");
 
     tokio::time::sleep(Duration::from_millis(10)).await;
     log::debug!("dropping packet");
@@ -721,16 +721,16 @@ async fn test_assoc_reliable_short_buffer() -> Result<()> {
 
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), 0, "incorrect bufferedAmount");
     }
 
     let n = s0
         .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG.len(), "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(MSG.len(), a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), MSG.len(), "incorrect bufferedAmount");
     }
 
     flush_buffers(&br, &a0, &a1).await;
@@ -740,8 +740,8 @@ async fn test_assoc_reliable_short_buffer() -> Result<()> {
     assert!(result.is_err(), "expected error to be io.ErrShortBuffer");
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrShortBuffer,
             err,
+            Error::ErrShortBuffer,
             "expected error to be io.ErrShortBuffer"
         );
     }
@@ -753,7 +753,7 @@ async fn test_assoc_reliable_short_buffer() -> Result<()> {
 
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), 0, "incorrect bufferedAmount");
     }
 
     close_association_pair(&br, a0, a1).await;
@@ -807,7 +807,7 @@ async fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -816,7 +816,7 @@ async fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     log::debug!("flush_buffers");
     flush_buffers(&br, &a0, &a1).await;
@@ -897,7 +897,7 @@ async fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -906,7 +906,7 @@ async fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     //log::debug!("flush_buffers");
     flush_buffers(&br, &a0, &a1).await;
@@ -982,7 +982,7 @@ async fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -991,7 +991,7 @@ async fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     //log::debug!("flush_buffers");
     flush_buffers(&br, &a0, &a1).await;
@@ -1068,7 +1068,7 @@ async fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -1077,7 +1077,7 @@ async fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     //log::debug!("flush_buffers");
     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1103,13 +1103,13 @@ async fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
         let q = s0.reassembly_queue.lock().await;
         assert!(!q.is_readable(), "should no longer be readable");
         assert_eq!(
-            0,
             q.unordered.len(),
+            0,
             "should be nothing in the unordered queue"
         );
         assert_eq!(
-            0,
             q.unordered_chunks.len(),
+            0,
             "should be nothing in the unorderedChunks list"
         );
     }
@@ -1165,7 +1165,7 @@ async fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -1174,7 +1174,7 @@ async fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     //log::debug!("flush_buffers");
     flush_buffers(&br, &a0, &a1).await;
@@ -1250,7 +1250,7 @@ async fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
     let n = s0
@@ -1259,7 +1259,7 @@ async fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
             PayloadProtocolIdentifier::Binary,
         )
         .await?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     //log::debug!("flush_buffers");
     flush_buffers(&br, &a0, &a1).await;
@@ -1283,13 +1283,13 @@ async fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
         let q = s0.reassembly_queue.lock().await;
         assert!(!q.is_readable(), "should no longer be readable");
         assert_eq!(
-            0,
             q.unordered.len(),
+            0,
             "should be nothing in the unordered queue"
         );
         assert_eq!(
-            0,
             q.unordered_chunks.len(),
+            0,
             "should be nothing in the unorderedChunks list"
         );
     }
@@ -1349,7 +1349,7 @@ async fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
                 PayloadProtocolIdentifier::Binary,
             )
             .await?;
-        assert_eq!(sbuf.len(), n, "unexpected length of received data");
+        assert_eq!(n, sbuf.len(), "unexpected length of received data");
     }
 
     // process packets for 500 msec, assuming that the fast retrans/recover
@@ -1390,7 +1390,7 @@ async fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
         log::debug!("nAckTimeouts: {}", b.stats.get_num_ack_timeouts());
         log::debug!("nFastRetrans: {}", a.stats.get_num_fast_retrans());
 
-        assert_eq!(1, a.stats.get_num_fast_retrans(), "should be 1");
+        assert_eq!(a.stats.get_num_fast_retrans(), 1, "should be 1");
     }
 
     close_association_pair(&br, a0, a1).await;
@@ -1454,7 +1454,7 @@ async fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
                 PayloadProtocolIdentifier::Binary,
             )
             .await?;
-        assert_eq!(sbuf.len(), n, "unexpected length of received data");
+        assert_eq!(n, sbuf.len(), "unexpected length of received data");
     }
 
     let mut rbuf = vec![0u8; 3000];
@@ -1478,7 +1478,7 @@ async fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
                 break;
             }
             let (n, ppi) = s1.read_sctp(&mut rbuf).await?;
-            assert_eq!(sbuf.len(), n, "unexpected length of received data");
+            assert_eq!(n, sbuf.len(), "unexpected length of received data");
             assert_eq!(
                 n_packets_received,
                 u32::from_be_bytes([rbuf[0], rbuf[1], rbuf[2], rbuf[3]]),
@@ -1524,15 +1524,15 @@ async fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
         log::debug!("nT3Timeouts: {}", a.stats.get_num_t3timeouts());
 
         assert_eq!(
-            N_PACKETS_TO_SEND as u64,
             b.stats.get_num_datas(),
+            N_PACKETS_TO_SEND as u64,
             "packet count mismatch"
         );
         assert!(
             a.stats.get_num_sacks() <= N_PACKETS_TO_SEND as u64 / 2,
             "too many sacks"
         );
-        assert_eq!(0, a.stats.get_num_t3timeouts(), "should be no retransmit");
+        assert_eq!(a.stats.get_num_t3timeouts(), 0, "should be no retransmit");
     }
 
     close_association_pair(&br, a0, a1).await;
@@ -1589,7 +1589,7 @@ async fn test_assoc_congestion_control_slow_reader() -> Result<()> {
                 PayloadProtocolIdentifier::Binary,
             )
             .await?;
-        assert_eq!(sbuf.len(), n, "unexpected length of received data");
+        assert_eq!(n, sbuf.len(), "unexpected length of received data");
     }
 
     let mut rbuf = vec![0u8; 3000];
@@ -1630,7 +1630,7 @@ async fn test_assoc_congestion_control_slow_reader() -> Result<()> {
                 break;
             }
             let (n, ppi) = s1.read_sctp(&mut rbuf).await?;
-            assert_eq!(sbuf.len(), n, "unexpected length of received data");
+            assert_eq!(n, sbuf.len(), "unexpected length of received data");
             assert_eq!(
                 n_packets_received,
                 u32::from_be_bytes([rbuf[0], rbuf[1], rbuf[2], rbuf[3]]),
@@ -1651,8 +1651,8 @@ async fn test_assoc_congestion_control_slow_reader() -> Result<()> {
         "unexpected num of packets received"
     );
     assert_eq!(
-        0,
         s1.get_num_bytes_in_reassembly_queue().await,
+        0,
         "reassembly queue should be empty"
     );
 
@@ -1717,7 +1717,7 @@ async fn test_assoc_delayed_ack() -> Result<()> {
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
         )?;
-    assert_eq!(sbuf.len(), n, "unexpected length of received data");
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
 
     // Repeat calling br.Tick() until the buffered amount becomes 0
     let since = SystemTime::now();
@@ -1739,7 +1739,7 @@ async fn test_assoc_delayed_ack() -> Result<()> {
                 break;
             }
             let (n, ppi) = s1.read_sctp(&mut rbuf).await?;
-            assert_eq!(sbuf.len(), n, "unexpected length of received data");
+            assert_eq!(n, sbuf.len(), "unexpected length of received data");
             assert_eq!(ppi, PayloadProtocolIdentifier::Binary, "unexpected ppi");
 
             n_packets_received += 1;
@@ -1753,8 +1753,8 @@ async fn test_assoc_delayed_ack() -> Result<()> {
 
     assert_eq!(n_packets_received, 1, "unexpected num of packets received");
     assert_eq!(
-        0,
         s1.get_num_bytes_in_reassembly_queue().await,
+        0,
         "reassembly queue should be empty"
     );
 
@@ -1766,18 +1766,18 @@ async fn test_assoc_delayed_ack() -> Result<()> {
         log::debug!("nSACKs      : {}", a.stats.get_num_sacks());
         log::debug!("nAckTimeouts: {}", b.stats.get_num_ack_timeouts());
 
-        assert_eq!(1, b.stats.get_num_datas(), "DATA chunk count mismatch");
+        assert_eq!(b.stats.get_num_datas(), 1, "DATA chunk count mismatch");
         assert_eq!(
             a.stats.get_num_sacks(),
             b.stats.get_num_datas(),
             "sack count should be equal to the number of data chunks"
         );
         assert_eq!(
-            1,
             b.stats.get_num_ack_timeouts(),
+            1,
             "ackTimeout count mismatch"
         );
-        assert_eq!(0, a.stats.get_num_t3timeouts(), "should be no retransmit");
+        assert_eq!(a.stats.get_num_t3timeouts(), 0, "should be no retransmit");
     }
 
     close_association_pair(&br, a0, a1).await;
@@ -1823,10 +1823,10 @@ async fn test_assoc_reset_close_one_way() -> Result<()> {
     let n = s0
         .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG.len(), "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(MSG.len(), a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), MSG.len(), "incorrect bufferedAmount");
     }
 
     log::debug!("s0.shutdown");
@@ -1923,10 +1923,10 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
     let n = s0
         .write_sctp(&MSG, PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(MSG.len(), n, "unexpected length of received data");
+    assert_eq!(n, MSG.len(), "unexpected length of received data");
     {
         let a = a0.association_internal.lock().await;
-        assert_eq!(MSG.len(), a.buffered_amount(), "incorrect bufferedAmount");
+        assert_eq!(a.buffered_amount(), MSG.len(), "incorrect bufferedAmount");
     }
 
     log::debug!("s0.shutdown");
@@ -2079,8 +2079,8 @@ async fn test_assoc_abort() -> Result<()> {
     let (_s0, _s1) = establish_session_pair(&br, &a0, &mut a1, SI).await?;
 
     // Both associations are established
-    assert_eq!(AssociationState::Established, a0.get_state());
-    assert_eq!(AssociationState::Established, a1.get_state());
+    assert_eq!(a0.get_state(), AssociationState::Established);
+    assert_eq!(a1.get_state(), AssociationState::Established);
 
     let result = a0.net_conn.send(&packet).await;
     assert!(result.is_ok(), "must be ok");
@@ -2091,8 +2091,8 @@ async fn test_assoc_abort() -> Result<()> {
     tokio::time::sleep(Duration::from_millis(10)).await;
 
     // The receiving association should be closed because it got an ABORT
-    assert_eq!(AssociationState::Established, a0.get_state());
-    assert_eq!(AssociationState::Closed, a1.get_state());
+    assert_eq!(a0.get_state(), AssociationState::Established);
+    assert_eq!(a1.get_state(), AssociationState::Closed);
 
     close_association_pair(&br, a0, a1).await;
 
@@ -2318,12 +2318,12 @@ async fn test_association_shutdown() -> Result<()> {
     let test_data = Bytes::from_static(b"test");
 
     let n = s11.write(&test_data).await?;
-    assert_eq!(test_data.len(), n);
+    assert_eq!(n, test_data.len());
 
     let mut buf = vec![0u8; test_data.len()];
     let n = s21.read(&mut buf).await?;
-    assert_eq!(test_data.len(), n);
-    assert_eq!(&test_data, &buf[0..n]);
+    assert_eq!(n, test_data.len());
+    assert_eq!(&buf[0..n], &test_data);
 
     if let Ok(result) = tokio::time::timeout(Duration::from_secs(1), a1.shutdown()).await {
         assert!(result.is_ok(), "shutdown should be ok");
@@ -2396,12 +2396,12 @@ async fn test_association_shutdown_during_write() -> Result<()> {
     let test_data = Bytes::from_static(b"test");
 
     let n = s11.write(&test_data).await?;
-    assert_eq!(test_data.len(), n);
+    assert_eq!(n, test_data.len());
 
     let mut buf = vec![0u8; test_data.len()];
     let n = s21.read(&mut buf).await?;
-    assert_eq!(test_data.len(), n);
-    assert_eq!(&test_data, &buf[0..n]);
+    assert_eq!(n, test_data.len());
+    assert_eq!(&buf[0..n], &test_data);
 
     {
         let mut close_loop_ch_rx = a1.close_loop_ch_rx.lock().await;

--- a/sctp/src/chunk/chunk_test.rs
+++ b/sctp/src/chunk/chunk_test.rs
@@ -59,10 +59,10 @@ fn test_abort_chunk_one_error_cause() -> Result<()> {
     let b = abort1.marshal()?;
     let abort2 = ChunkAbort::unmarshal(&b)?;
 
-    assert_eq!(1, abort2.error_causes.len(), "should have only one cause");
+    assert_eq!(abort2.error_causes.len(), 1, "should have only one cause");
     assert_eq!(
-        abort1.error_causes[0].error_cause_code(),
         abort2.error_causes[0].error_cause_code(),
+        abort1.error_causes[0].error_cause_code(),
         "errorCause code should match"
     );
 
@@ -90,11 +90,11 @@ fn test_abort_chunk_many_error_causes() -> Result<()> {
 
     let b = abort1.marshal()?;
     let abort2 = ChunkAbort::unmarshal(&b)?;
-    assert_eq!(3, abort2.error_causes.len(), "should have only one cause");
+    assert_eq!(abort2.error_causes.len(), 3, "should have only one cause");
     for (i, error_cause) in abort1.error_causes.iter().enumerate() {
         assert_eq!(
-            error_cause.error_cause_code(),
             abort2.error_causes[i].error_cause_code(),
+            error_cause.error_cause_code(),
             "errorCause code should match"
         );
     }
@@ -127,13 +127,13 @@ lazy_static! {
 #[test]
 fn test_chunk_error_unrecognized_chunk_type_unmarshal() -> Result<()> {
     let c = ChunkError::unmarshal(&RAW_IN)?;
-    assert_eq!(CT_ERROR, c.header().typ, "chunk type should be ERROR");
-    assert_eq!(1, c.error_causes.len(), "there should be on errorCause");
+    assert_eq!(c.header().typ, CT_ERROR, "chunk type should be ERROR");
+    assert_eq!(c.error_causes.len(), 1, "there should be on errorCause");
 
     let ec = &c.error_causes[0];
     assert_eq!(
-        UNRECOGNIZED_CHUNK_TYPE,
         ec.error_cause_code(),
+        UNRECOGNIZED_CHUNK_TYPE,
         "cause code should be unrecognizedChunkType"
     );
     assert_eq!(
@@ -201,7 +201,7 @@ fn test_chunk_forward_tsn_success() -> Result<()> {
     for binary in tests {
         let actual = ChunkForwardTsn::unmarshal(&binary)?;
         let b = actual.marshal()?;
-        assert_eq!(binary, b, "test not equal");
+        assert_eq!(b, binary, "test not equal");
     }
 
     Ok(())
@@ -341,7 +341,7 @@ fn test_chunk_shutdown_success() -> Result<()> {
     for binary in tests {
         let actual = ChunkShutdown::unmarshal(&binary)?;
         let b = actual.marshal()?;
-        assert_eq!(binary, b, "test not equal");
+        assert_eq!(b, binary, "test not equal");
     }
 
     Ok(())
@@ -432,7 +432,7 @@ fn test_chunk_shutdown_complete_success() -> Result<()> {
     for binary in tests {
         let actual = ChunkShutdownComplete::unmarshal(&binary)?;
         let b = actual.marshal()?;
-        assert_eq!(binary, b, "test not equal");
+        assert_eq!(b, binary, "test not equal");
     }
 
     Ok(())
@@ -537,7 +537,7 @@ fn test_chrome_chunk1_init() -> Result<()> {
     ]);
     let pkt = Packet::unmarshal(&raw_pkt)?;
     let raw_pkt2 = pkt.marshal()?;
-    assert_eq!(raw_pkt, raw_pkt2);
+    assert_eq!(raw_pkt2, raw_pkt);
 
     Ok(())
 }
@@ -576,7 +576,7 @@ fn test_chrome_chunk2_init_ack() -> Result<()> {
     ]);
     let pkt = Packet::unmarshal(&raw_pkt)?;
     let raw_pkt2 = pkt.marshal()?;
-    assert_eq!(raw_pkt, raw_pkt2);
+    assert_eq!(raw_pkt2, raw_pkt);
 
     Ok(())
 }

--- a/sctp/src/param/param_test.rs
+++ b/sctp/src/param/param_test.rs
@@ -14,7 +14,7 @@ fn test_parse_param_type_success() -> Result<()> {
 
     for (mut binary, expected) in tests {
         let pt: ParamType = binary.get_u16().into();
-        assert_eq!(expected, pt);
+        assert_eq!(pt, expected);
     }
 
     Ok(())
@@ -39,9 +39,9 @@ fn test_param_header_success() -> Result<()> {
 
     for (binary, parsed) in tests {
         let actual = ParamHeader::unmarshal(&binary)?;
-        assert_eq!(parsed, actual);
+        assert_eq!(actual, parsed);
         let b = actual.marshal()?;
-        assert_eq!(binary, b);
+        assert_eq!(b, binary);
     }
 
     Ok(())
@@ -83,9 +83,9 @@ fn test_param_forward_tsn_supported_success() -> Result<()> {
 
     for (binary, parsed) in tests {
         let actual = ParamForwardTsnSupported::unmarshal(&binary)?;
-        assert_eq!(parsed, actual);
+        assert_eq!(actual, parsed);
         let b = actual.marshal()?;
-        assert_eq!(binary, b);
+        assert_eq!(b, binary);
     }
 
     Ok(())
@@ -141,9 +141,9 @@ fn test_param_outgoing_reset_request_success() -> Result<()> {
 
     for (binary, parsed) in tests {
         let actual = ParamOutgoingResetRequest::unmarshal(&binary)?;
-        assert_eq!(parsed, actual);
+        assert_eq!(actual, parsed);
         let b = actual.marshal()?;
-        assert_eq!(binary, b);
+        assert_eq!(b, binary);
     }
 
     Ok(())
@@ -185,9 +185,9 @@ fn test_param_reconfig_response_success() -> Result<()> {
 
     for (binary, parsed) in tests {
         let actual = ParamReconfigResponse::unmarshal(&binary)?;
-        assert_eq!(parsed, actual);
+        assert_eq!(actual, parsed);
         let b = actual.marshal()?;
-        assert_eq!(binary, b);
+        assert_eq!(b, binary);
     }
 
     Ok(())
@@ -231,7 +231,7 @@ fn test_reconfig_result_stringer() -> Result<()> {
 
     for (result, expected) in tests {
         let actual = result.to_string();
-        assert_eq!(expected, actual, "Test case {}", expected);
+        assert_eq!(actual, expected, "Test case {}", expected);
     }
 
     Ok(())
@@ -248,7 +248,7 @@ fn test_build_param_success() -> Result<()> {
     for binary in tests {
         let p = build_param(&binary)?;
         let b = p.marshal()?;
-        assert_eq!(binary, b);
+        assert_eq!(b, binary);
     }
 
     Ok(())

--- a/sctp/src/queue/queue_test.rs
+++ b/sctp/src/queue/queue_test.rs
@@ -26,44 +26,44 @@ fn test_payload_queue_push_no_check() -> Result<()> {
     let mut pq = PayloadQueue::new(Arc::new(AtomicUsize::new(0)));
 
     pq.push_no_check(make_payload(0, 10));
-    assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(1, pq.len(), "item count mismatch");
+    assert_eq!(pq.get_num_bytes(), 10, "total bytes mismatch");
+    assert_eq!(pq.len(), 1, "item count mismatch");
     pq.push_no_check(make_payload(1, 11));
-    assert_eq!(21, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(2, pq.len(), "item count mismatch");
+    assert_eq!(pq.get_num_bytes(), 21, "total bytes mismatch");
+    assert_eq!(pq.len(), 2, "item count mismatch");
     pq.push_no_check(make_payload(2, 12));
-    assert_eq!(33, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(3, pq.len(), "item count mismatch");
+    assert_eq!(pq.get_num_bytes(), 33, "total bytes mismatch");
+    assert_eq!(pq.len(), 3, "item count mismatch");
 
     for i in 0..3 {
         assert!(!pq.sorted.is_empty(), "should not be empty");
         let c = pq.pop(i);
         assert!(c.is_some(), "pop should succeed");
         if let Some(c) = c {
-            assert_eq!(i, c.tsn, "TSN should match");
+            assert_eq!(c.tsn, i, "TSN should match");
         }
     }
 
-    assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(0, pq.len(), "item count mismatch");
+    assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
+    assert_eq!(pq.len(), 0, "item count mismatch");
 
     assert!(pq.sorted.is_empty(), "should be empty");
     pq.push_no_check(make_payload(3, 13));
-    assert_eq!(13, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 13, "total bytes mismatch");
     pq.push_no_check(make_payload(4, 14));
-    assert_eq!(27, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 27, "total bytes mismatch");
 
     for i in 3..5 {
         assert!(!pq.sorted.is_empty(), "should not be empty");
         let c = pq.pop(i);
         assert!(c.is_some(), "pop should succeed");
         if let Some(c) = c {
-            assert_eq!(i, c.tsn, "TSN should match");
+            assert_eq!(c.tsn, i, "TSN should match");
         }
     }
 
-    assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(0, pq.len(), "item count mismatch");
+    assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
+    assert_eq!(pq.len(), 0, "item count mismatch");
 
     Ok(())
 }
@@ -84,8 +84,8 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
     assert!(!gab2.is_empty());
     assert_eq!(gab2.len(), 1);
 
-    assert_eq!(gab1[0].start, gab2[0].start);
-    assert_eq!(gab1[0].end, gab2[0].end);
+    assert_eq!(gab2[0].start, gab1[0].start);
+    assert_eq!(gab2[0].end, gab1[0].end);
 
     pq.push(make_payload(8, 0), 0);
     pq.push(make_payload(9, 0), 0);
@@ -98,10 +98,10 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
     assert!(!gab2.is_empty());
     assert_eq!(gab2.len(), 2);
 
-    assert_eq!(gab1[0].start, gab2[0].start);
-    assert_eq!(gab1[0].end, gab2[0].end);
-    assert_eq!(gab1[1].start, gab2[1].start);
-    assert_eq!(gab1[1].end, gab2[1].end);
+    assert_eq!(gab2[0].start, gab1[0].start);
+    assert_eq!(gab2[0].end, gab1[0].end);
+    assert_eq!(gab2[1].start, gab1[1].start);
+    assert_eq!(gab2[1].end, gab1[1].end);
 
     Ok(())
 }
@@ -118,21 +118,21 @@ fn test_payload_queue_get_last_tsn_received() -> Result<()> {
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
-    assert_eq!(Some(&20), tsn, "should match");
+    assert_eq!(tsn, Some(&20), "should match");
 
     // append should work
     let ok = pq.push(make_payload(21, 0), 0);
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
-    assert_eq!(Some(&21), tsn, "should match");
+    assert_eq!(tsn, Some(&21), "should match");
 
     // check if sorting applied
     let ok = pq.push(make_payload(19, 0), 0);
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
-    assert_eq!(Some(&21), tsn, "should match");
+    assert_eq!(tsn, Some(&21), "should match");
 
     Ok(())
 }
@@ -238,13 +238,13 @@ fn test_pending_base_queue_push_and_pop() -> Result<()> {
     for i in 0..3 {
         let c = pq.get(i);
         assert!(c.is_some(), "should not be none");
-        assert_eq!(i as u32, c.unwrap().tsn, "TSN should match");
+        assert_eq!(c.unwrap().tsn, i as u32, "TSN should match");
     }
 
     for i in 0..3 {
         let c = pq.pop_front();
         assert!(c.is_some(), "should not be none");
-        assert_eq!(i, c.unwrap().tsn, "TSN should match");
+        assert_eq!(c.unwrap().tsn, i, "TSN should match");
     }
 
     pq.push_back(make_data_chunk(3, false, NO_FRAGMENT));
@@ -253,7 +253,7 @@ fn test_pending_base_queue_push_and_pop() -> Result<()> {
     for i in 3..5 {
         let c = pq.pop_front();
         assert!(c.is_some(), "should not be none");
-        assert_eq!(i, c.unwrap().tsn, "TSN should match");
+        assert_eq!(c.unwrap().tsn, i, "TSN should match");
     }
     Ok(())
 }
@@ -276,42 +276,42 @@ fn test_pending_base_queue_out_of_bounce() -> Result<()> {
 async fn test_pending_queue_push_and_pop() -> Result<()> {
     let pq = PendingQueue::new();
     pq.push(make_data_chunk(0, false, NO_FRAGMENT)).await;
-    assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 10, "total bytes mismatch");
     pq.push(make_data_chunk(1, false, NO_FRAGMENT)).await;
-    assert_eq!(20, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 20, "total bytes mismatch");
     pq.push(make_data_chunk(2, false, NO_FRAGMENT)).await;
-    assert_eq!(30, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 30, "total bytes mismatch");
 
     for i in 0..3 {
         let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
-        assert_eq!(i, c.tsn, "TSN should match");
+        assert_eq!(c.tsn, i, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
         let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", i);
     }
 
-    assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
 
     pq.push(make_data_chunk(3, false, NO_FRAGMENT)).await;
-    assert_eq!(10, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 10, "total bytes mismatch");
     pq.push(make_data_chunk(4, false, NO_FRAGMENT)).await;
-    assert_eq!(20, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 20, "total bytes mismatch");
 
     for i in 3..5 {
         let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
-        assert_eq!(i, c.tsn, "TSN should match");
+        assert_eq!(c.tsn, i, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
         let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", i);
     }
 
-    assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
 
     Ok(())
 }
@@ -332,7 +332,7 @@ async fn test_pending_queue_unordered_wins() -> Result<()> {
     let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
-    assert_eq!(1, c.tsn, "TSN should match");
+    assert_eq!(c.tsn, 1, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
     let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
@@ -340,7 +340,7 @@ async fn test_pending_queue_unordered_wins() -> Result<()> {
     let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
-    assert_eq!(3, c.tsn, "TSN should match");
+    assert_eq!(c.tsn, 3, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
     let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
@@ -348,7 +348,7 @@ async fn test_pending_queue_unordered_wins() -> Result<()> {
     let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
-    assert_eq!(0, c.tsn, "TSN should match");
+    assert_eq!(c.tsn, 0, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
     let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
@@ -356,12 +356,12 @@ async fn test_pending_queue_unordered_wins() -> Result<()> {
     let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
-    assert_eq!(2, c.tsn, "TSN should match");
+    assert_eq!(c.tsn, 2, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
     let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error");
 
-    assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
+    assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
 
     Ok(())
 }
@@ -382,7 +382,7 @@ async fn test_pending_queue_fragments() -> Result<()> {
         let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
-        assert_eq!(exp, c.tsn, "TSN should match");
+        assert_eq!(c.tsn, exp, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
         let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", exp);
@@ -401,7 +401,7 @@ async fn test_pending_queue_selection_persistence() -> Result<()> {
     let c = pq.peek();
     assert!(c.is_some(), "peek error");
     let c = c.unwrap();
-    assert_eq!(0, c.tsn, "TSN should match");
+    assert_eq!(c.tsn, 0, "TSN should match");
     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
     let result = pq.pop(beginning_fragment, unordered);
     assert!(result.is_some(), "should not error: {}", 0);
@@ -416,7 +416,7 @@ async fn test_pending_queue_selection_persistence() -> Result<()> {
         let c = pq.peek();
         assert!(c.is_some(), "peek error");
         let c = c.unwrap();
-        assert_eq!(exp, c.tsn, "TSN should match");
+        assert_eq!(c.tsn, exp, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
         let result = pq.pop(beginning_fragment, unordered);
         assert!(result.is_some(), "should not error: {}", exp);
@@ -434,8 +434,8 @@ async fn test_pending_queue_append() -> Result<()> {
         make_data_chunk(3, false, NO_FRAGMENT),
     ])
     .await;
-    assert_eq!(30, pq.get_num_bytes(), "total bytes mismatch");
-    assert_eq!(3, pq.len(), "len mismatch");
+    assert_eq!(pq.get_num_bytes(), 30, "total bytes mismatch");
+    assert_eq!(pq.len(), 3, "len mismatch");
 
     Ok(())
 }
@@ -464,7 +464,7 @@ fn test_reassembly_queue_ordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -482,8 +482,8 @@ fn test_reassembly_queue_ordered_fragments() -> Result<()> {
     let mut buf = vec![0u8; 16];
 
     let (n, ppi) = rq.read(&mut buf)?;
-    assert_eq!(7, n, "should received 7 bytes");
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(n, 7, "should received 7 bytes");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"ABCDEFG", "data should match");
 
@@ -508,7 +508,7 @@ fn test_reassembly_queue_unordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -521,7 +521,7 @@ fn test_reassembly_queue_unordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(7, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 7, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -535,13 +535,13 @@ fn test_reassembly_queue_unordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "chunk set should be complete");
-    assert_eq!(8, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 8, "num bytes mismatch");
 
     let mut buf = vec![0u8; 16];
 
     let (n, ppi) = rq.read(&mut buf)?;
-    assert_eq!(8, n, "should received 8 bytes");
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(n, 8, "should received 8 bytes");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"ABCDEFGH", "data should match");
 
@@ -564,7 +564,7 @@ fn test_reassembly_queue_ordered_and_unordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "chunk set should be complete");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -579,7 +579,7 @@ fn test_reassembly_queue_ordered_and_unordered_fragments() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "chunk set should be complete");
-    assert_eq!(6, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 6, "num bytes mismatch");
 
     //
     // Now we have two complete chunks ready to read in the reassemblyQueue.
@@ -589,15 +589,15 @@ fn test_reassembly_queue_ordered_and_unordered_fragments() -> Result<()> {
 
     // Should read unordered chunks first
     let (n, ppi) = rq.read(&mut buf)?;
-    assert_eq!(3, n, "should received 3 bytes");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(n, 3, "should received 3 bytes");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"DEF", "data should match");
 
     // Next should read ordered chunks
     let (n, ppi) = rq.read(&mut buf)?;
-    assert_eq!(3, n, "should received 3 bytes");
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(n, 3, "should received 3 bytes");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"ABC", "data should match");
 
@@ -636,7 +636,7 @@ fn test_reassembly_queue_unordered_complete_skips_incomplete() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(10, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 10, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -651,7 +651,7 @@ fn test_reassembly_queue_unordered_complete_skips_incomplete() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "chunk set should be complete");
-    assert_eq!(14, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 14, "num bytes mismatch");
 
     //
     // Now we have two complete chunks ready to read in the reassemblyQueue.
@@ -661,8 +661,8 @@ fn test_reassembly_queue_unordered_complete_skips_incomplete() -> Result<()> {
 
     // Should pick the one that has "GOOD"
     let (n, ppi) = rq.read(&mut buf)?;
-    assert_eq!(4, n, "should receive 4 bytes");
-    assert_eq!(10, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(n, 4, "should receive 4 bytes");
+    assert_eq!(rq.get_num_bytes(), 10, "num bytes mismatch");
     assert_eq!(ppi, org_ppi, "should have valid ppi");
     assert_eq!(&buf[..n], b"GOOD", "data should match");
 
@@ -688,7 +688,7 @@ fn test_reassembly_queue_ignores_chunk_with_wrong_si() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk should be ignored");
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
     Ok(())
 }
 
@@ -711,7 +711,7 @@ fn test_reassembly_queue_ignores_chunk_with_stale_ssn() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk should not be ignored");
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
 
     Ok(())
 }
@@ -733,12 +733,12 @@ fn test_reassembly_queue_should_fail_to_read_incomplete_chunk() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "the set should not be complete");
-    assert_eq!(2, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 2, "num bytes mismatch");
 
     let mut buf = vec![0u8; 16];
     let result = rq.read(&mut buf);
     assert!(result.is_err(), "read() should not succeed");
-    assert_eq!(2, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 2, "num bytes mismatch");
 
     Ok(())
 }
@@ -761,12 +761,12 @@ fn test_reassembly_queue_should_fail_to_read_if_the_nex_ssn_is_not_ready() -> Re
 
     let complete = rq.push(chunk);
     assert!(complete, "the set should be complete");
-    assert_eq!(2, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 2, "num bytes mismatch");
 
     let mut buf = vec![0u8; 16];
     let result = rq.read(&mut buf);
     assert!(result.is_err(), "read() should not succeed");
-    assert_eq!(2, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 2, "num bytes mismatch");
 
     Ok(())
 }
@@ -789,15 +789,15 @@ fn test_reassembly_queue_detect_buffer_too_short() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "the set should be complete");
-    assert_eq!(10, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 10, "num bytes mismatch");
 
     let mut buf = vec![0u8; 8]; // <- passing buffer too short
     let result = rq.read(&mut buf);
     assert!(result.is_err(), "read() should not succeed");
     if let Err(err) = result {
-        assert_eq!(Error::ErrShortBuffer, err, "read() should not succeed");
+        assert_eq!(err, Error::ErrShortBuffer, "read() should not succeed");
     }
-    assert_eq!(0, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 0, "num bytes mismatch");
 
     Ok(())
 }
@@ -823,7 +823,7 @@ fn test_reassembly_queue_forward_tsn_for_ordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(complete, "chunk set should be complete");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -836,7 +836,7 @@ fn test_reassembly_queue_forward_tsn_for_ordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(6, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 6, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -848,12 +848,12 @@ fn test_reassembly_queue_forward_tsn_for_ordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(9, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 9, "num bytes mismatch");
 
     rq.forward_tsn_for_ordered(ssn_dropped);
 
-    assert_eq!(1, rq.ordered.len(), "there should be one chunk left");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.ordered.len(), 1, "there should be one chunk left");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     Ok(())
 }
@@ -879,7 +879,7 @@ fn test_reassembly_queue_forward_tsn_for_unordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -892,7 +892,7 @@ fn test_reassembly_queue_forward_tsn_for_unordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(6, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 6, "num bytes mismatch");
 
     let chunk = ChunkPayloadData {
         payload_type: org_ppi,
@@ -906,7 +906,7 @@ fn test_reassembly_queue_forward_tsn_for_unordered_framents() -> Result<()> {
 
     let complete = rq.push(chunk);
     assert!(!complete, "chunk set should not be complete yet");
-    assert_eq!(9, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 9, "num bytes mismatch");
 
     // At this point, there are 3 chunks in the rq.unorderedChunks.
     // This call should remove chunks with tsn equals to 13 or older.
@@ -914,11 +914,11 @@ fn test_reassembly_queue_forward_tsn_for_unordered_framents() -> Result<()> {
 
     // As a result, there should be one chunk (tsn=14)
     assert_eq!(
-        1,
         rq.unordered_chunks.len(),
+        1,
         "there should be one chunk kept"
     );
-    assert_eq!(3, rq.get_num_bytes(), "num bytes mismatch");
+    assert_eq!(rq.get_num_bytes(), 3, "num bytes mismatch");
 
     Ok(())
 }
@@ -944,7 +944,7 @@ fn test_chunk_set_push_dup_chunks_to_chunk_set() -> Result<()> {
         ..Default::default()
     });
     assert!(!complete, "chunk with dup TSN is not complete");
-    assert_eq!(1, cset.chunks.len(), "chunk with dup TSN should be ignored");
+    assert_eq!(cset.chunks.len(), 1, "chunk with dup TSN should be ignored");
     Ok(())
 }
 

--- a/sctp/src/stream/stream_test.rs
+++ b/sctp/src/stream/stream_test.rs
@@ -8,15 +8,15 @@ use tokio::io::AsyncWriteExt;
 fn test_stream_buffered_amount() -> Result<()> {
     let s = Stream::default();
 
-    assert_eq!(0, s.buffered_amount());
-    assert_eq!(0, s.buffered_amount_low_threshold());
+    assert_eq!(s.buffered_amount(), 0);
+    assert_eq!(s.buffered_amount_low_threshold(), 0);
 
     s.buffered_amount.store(8192, Ordering::SeqCst);
     s.set_buffered_amount_low_threshold(2048);
-    assert_eq!(8192, s.buffered_amount(), "unexpected bufferedAmount");
+    assert_eq!(s.buffered_amount(), 8192, "unexpected bufferedAmount");
     assert_eq!(
-        2048,
         s.buffered_amount_low_threshold(),
+        2048,
         "unexpected threshold"
     );
 
@@ -40,33 +40,33 @@ async fn test_stream_amount_on_buffered_amount_low() -> Result<()> {
 
     // Negative value should be ignored (by design)
     s.on_buffer_released(-32).await; // bufferedAmount = 3072
-    assert_eq!(4096, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(0, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 4096, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 0, "callback count mismatch");
 
     // Above to above, no callback
     s.on_buffer_released(1024).await; // bufferedAmount = 3072
-    assert_eq!(3072, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(0, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 3072, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 0, "callback count mismatch");
 
     // Above to equal, callback should be made
     s.on_buffer_released(1024).await; // bufferedAmount = 2048
-    assert_eq!(2048, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(1, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 2048, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 1, "callback count mismatch");
 
     // Eaual to below, no callback
     s.on_buffer_released(1024).await; // bufferedAmount = 1024
-    assert_eq!(1024, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(1, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 1024, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 1, "callback count mismatch");
 
     // Blow to below, no callback
     s.on_buffer_released(1024).await; // bufferedAmount = 0
-    assert_eq!(0, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(1, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 0, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 1, "callback count mismatch");
 
     // Capped at 0, no callback
     s.on_buffer_released(1024).await; // bufferedAmount = 0
-    assert_eq!(0, s.buffered_amount(), "unexpected bufferedAmount");
-    assert_eq!(1, n_cbs.load(Ordering::SeqCst), "callback count mismatch");
+    assert_eq!(s.buffered_amount(), 0, "unexpected bufferedAmount");
+    assert_eq!(n_cbs.load(Ordering::SeqCst), 1, "callback count mismatch");
 
     Ok(())
 }
@@ -84,10 +84,10 @@ async fn test_stream() -> std::result::Result<(), io::Error> {
     );
 
     // getters
-    assert_eq!(0, s.stream_identifier());
-    assert_eq!(0, s.buffered_amount());
-    assert_eq!(0, s.buffered_amount_low_threshold());
-    assert_eq!(0, s.get_num_bytes_in_reassembly_queue().await);
+    assert_eq!(s.stream_identifier(), 0);
+    assert_eq!(s.buffered_amount(), 0);
+    assert_eq!(s.buffered_amount_low_threshold(), 0);
+    assert_eq!(s.get_num_bytes_in_reassembly_queue().await, 0);
 
     // setters
     s.set_default_payload_type(PayloadProtocolIdentifier::Binary);
@@ -95,13 +95,13 @@ async fn test_stream() -> std::result::Result<(), io::Error> {
 
     // write
     let n = s.write(&Bytes::from("Hello ")).await?;
-    assert_eq!(6, n);
-    assert_eq!(6, s.buffered_amount());
+    assert_eq!(n, 6);
+    assert_eq!(s.buffered_amount(), 6);
     let n = s
         .write_sctp(&Bytes::from("world"), PayloadProtocolIdentifier::Binary)
         .await?;
-    assert_eq!(5, n);
-    assert_eq!(11, s.buffered_amount());
+    assert_eq!(n, 5);
+    assert_eq!(s.buffered_amount(), 11);
 
     // async read
     //  1. pretend that we've received a chunk
@@ -140,7 +140,7 @@ async fn test_stream() -> std::result::Result<(), io::Error> {
     // shutdown read
     s.shutdown(Shutdown::Read).await?;
     // read must return 0
-    assert_eq!(Ok(0), s.read(&mut buf).await);
+    assert_eq!(s.read(&mut buf).await, Ok(0));
 
     Ok(())
 }
@@ -159,16 +159,16 @@ async fn test_poll_stream() -> std::result::Result<(), io::Error> {
     let mut poll_stream = PollStream::new(s.clone());
 
     // getters
-    assert_eq!(0, poll_stream.stream_identifier());
-    assert_eq!(0, poll_stream.buffered_amount());
-    assert_eq!(0, poll_stream.buffered_amount_low_threshold());
-    assert_eq!(0, poll_stream.get_num_bytes_in_reassembly_queue().await);
+    assert_eq!(poll_stream.stream_identifier(), 0);
+    assert_eq!(poll_stream.buffered_amount(), 0);
+    assert_eq!(poll_stream.buffered_amount_low_threshold(), 0);
+    assert_eq!(poll_stream.get_num_bytes_in_reassembly_queue().await, 0);
 
     // async write
     let n = poll_stream.write(&[1, 2, 3]).await?;
-    assert_eq!(3, n);
+    assert_eq!(n, 3);
     poll_stream.flush().await?;
-    assert_eq!(3, poll_stream.buffered_amount());
+    assert_eq!(poll_stream.buffered_amount(), 3);
 
     // async read
     //  1. pretend that we've received a chunk

--- a/sctp/src/timer/timer_test.rs
+++ b/sctp/src/timer/timer_test.rs
@@ -47,8 +47,8 @@ mod test_ack_timer {
         sleep(ACK_INTERVAL + Duration::from_millis(50)).await;
 
         assert_eq!(
-            0,
             ncbs.load(Ordering::SeqCst),
+            0,
             "should not be timed out (actual: {})",
             ncbs.load(Ordering::SeqCst)
         );
@@ -79,10 +79,10 @@ mod test_rto_manager {
     #[tokio::test]
     async fn test_rto_manager_initial_values() -> Result<()> {
         let m = RtoManager::new();
-        assert_eq!(RTO_INITIAL, m.rto, "should be rtoInitial");
-        assert_eq!(RTO_INITIAL, m.get_rto(), "should be rtoInitial");
-        assert_eq!(0, m.srtt, "should be 0");
-        assert_eq!(0.0, m.rttvar, "should be 0.0");
+        assert_eq!(m.rto, RTO_INITIAL, "should be rtoInitial");
+        assert_eq!(m.get_rto(), RTO_INITIAL, "should be rtoInitial");
+        assert_eq!(m.srtt, 0, "should be 0");
+        assert_eq!(m.rttvar, 0.0, "should be 0.0");
 
         Ok(())
     }
@@ -97,7 +97,7 @@ mod test_rto_manager {
         for i in 0..5 {
             m.set_new_rtt(600);
             let rto = m.get_rto();
-            assert_eq!(exp[i], rto, "should be equal: {}", i);
+            assert_eq!(rto, exp[i], "should be equal: {}", i);
         }
 
         Ok(())
@@ -116,7 +116,7 @@ mod test_rto_manager {
         for i in 0..5 {
             m.set_new_rtt(30000);
             let rto = m.get_rto();
-            assert_eq!(exp[i], rto, "should be equal: {}", i);
+            assert_eq!(rto, exp[i], "should be equal: {}", i);
         }
 
         Ok(())
@@ -125,17 +125,17 @@ mod test_rto_manager {
     #[tokio::test]
     async fn test_rto_manager_calculate_next_timeout() -> Result<()> {
         let rto = calculate_next_timeout(1, 0);
-        assert_eq!(1, rto, "should match");
+        assert_eq!(rto, 1, "should match");
         let rto = calculate_next_timeout(1, 1);
-        assert_eq!(2, rto, "should match");
+        assert_eq!(rto, 2, "should match");
         let rto = calculate_next_timeout(1, 2);
-        assert_eq!(4, rto, "should match");
+        assert_eq!(rto, 4, "should match");
         let rto = calculate_next_timeout(1, 30);
-        assert_eq!(60000, rto, "should match");
+        assert_eq!(rto, 60000, "should match");
         let rto = calculate_next_timeout(1, 63);
-        assert_eq!(60000, rto, "should match");
+        assert_eq!(rto, 60000, "should match");
         let rto = calculate_next_timeout(1, 64);
-        assert_eq!(60000, rto, "should match");
+        assert_eq!(rto, 60000, "should match");
 
         Ok(())
     }
@@ -148,9 +148,9 @@ mod test_rto_manager {
         }
 
         m.reset();
-        assert_eq!(RTO_INITIAL, m.get_rto(), "should be rtoInitial");
-        assert_eq!(0, m.srtt, "should be 0");
-        assert_eq!(0.0, m.rttvar, "should be 0");
+        assert_eq!(m.get_rto(), RTO_INITIAL, "should be rtoInitial");
+        assert_eq!(m.srtt, 0, "should be 0");
+        assert_eq!(m.rttvar, 0.0, "should be 0");
 
         Ok(())
     }
@@ -237,7 +237,7 @@ mod test_rtx_timer {
         rt.stop().await;
         assert!(!rt.is_running().await, "should not be running");
 
-        assert_eq!(4, ncbs.load(Ordering::SeqCst), "should be called 4 times");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 4, "should be called 4 times");
 
         Ok(())
     }
@@ -265,7 +265,7 @@ mod test_rtx_timer {
         rt.stop().await;
 
         assert!(!rt.is_running().await, "should not be running");
-        assert_eq!(1, ncbs.load(Ordering::SeqCst), "must be called once");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 1, "must be called once");
 
         Ok(())
     }
@@ -290,7 +290,7 @@ mod test_rtx_timer {
         rt.stop().await;
 
         assert!(!rt.is_running().await, "should not be running");
-        assert_eq!(0, ncbs.load(Ordering::SeqCst), "no callback should be made");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 0, "no callback should be made");
 
         Ok(())
     }
@@ -319,7 +319,7 @@ mod test_rtx_timer {
         rt.stop().await;
 
         assert!(!rt.is_running().await, "should NOT be running");
-        assert_eq!(1, ncbs.load(Ordering::SeqCst), "must be called once");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 1, "must be called once");
 
         Ok(())
     }
@@ -343,7 +343,7 @@ mod test_rtx_timer {
             assert!(!rt.is_running().await, "should NOT be running");
         }
 
-        assert_eq!(0, ncbs.load(Ordering::SeqCst), "no callback should be made");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 0, "no callback should be made");
 
         Ok(())
     }
@@ -380,7 +380,7 @@ mod test_rtx_timer {
         let elapsed = done_rx.recv().await;
 
         assert!(!rt.is_running().await, "should not be running");
-        assert_eq!(5, ncbs.load(Ordering::SeqCst), "should be called 5 times");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 5, "should be called 5 times");
 
         if let Some(elapsed) = elapsed {
             let diff = elapsed.duration_since(since).unwrap();
@@ -431,7 +431,7 @@ mod test_rtx_timer {
         let elapsed = done_rx.recv().await;
 
         assert!(rt.is_running().await, "should still be running");
-        assert_eq!(6, ncbs.load(Ordering::SeqCst), "should be called 6 times");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 6, "should be called 6 times");
 
         if let Some(elapsed) = elapsed {
             let diff = elapsed.duration_since(since).unwrap();
@@ -501,7 +501,7 @@ mod test_rtx_timer {
         assert!(!rt.is_running().await, "must not be running");
 
         sleep(Duration::from_millis(100)).await;
-        assert_eq!(0, ncbs.load(Ordering::SeqCst), "RTO should not occur");
+        assert_eq!(ncbs.load(Ordering::SeqCst), 0, "RTO should not occur");
 
         Ok(())
     }

--- a/sdp/src/extmap/extmap_test.rs
+++ b/sdp/src/extmap/extmap_test.rs
@@ -33,8 +33,8 @@ fn test_extmap() -> Result<()> {
         let mut reader = BufReader::new(u.1.as_bytes());
         let actual = ExtMap::unmarshal(&mut reader)?;
         assert_eq!(
-            u.1,
             actual.marshal(),
+            u.1,
             "{}: {} vs {}",
             i,
             u.1,

--- a/srtp/src/session/session_rtp_test.rs
+++ b/srtp/src/session/session_rtp_test.rs
@@ -307,7 +307,7 @@ async fn test_session_srtp_replay_protection() -> Result<()> {
 
     {
         let received_sequence_number = received_sequence_number.lock().await;
-        assert_eq!(&expected_sequence_number[..], &received_sequence_number[..]);
+        assert_eq!(&received_sequence_number[..], &expected_sequence_number[..]);
     }
 
     Ok(())

--- a/stun/src/agent/agent_test.rs
+++ b/stun/src/agent/agent_test.rs
@@ -55,8 +55,8 @@ async fn test_agent_process() -> Result<()> {
     let result = a.process(m);
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrAgentClosed,
             err,
+            Error::ErrAgentClosed,
             "closed agent should return <{}>, but got <{}>",
             Error::ErrAgentClosed,
             err,
@@ -78,8 +78,8 @@ fn test_agent_start() -> Result<()> {
     let result = a.start(id, deadline);
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrTransactionExists,
             err,
+            Error::ErrTransactionExists,
             "duplicate start should return <{}>, got <{}>",
             Error::ErrTransactionExists,
             err,
@@ -93,8 +93,8 @@ fn test_agent_start() -> Result<()> {
     let result = a.start(id, deadline);
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrAgentClosed,
             err,
+            Error::ErrAgentClosed,
             "start on closed agent should return <{}>, got <{}>",
             Error::ErrAgentClosed,
             err,
@@ -106,8 +106,8 @@ fn test_agent_start() -> Result<()> {
     let result = a.set_handler(noop_handler());
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrAgentClosed,
             err,
+            Error::ErrAgentClosed,
             "SetHandler on closed agent should return <{}>, got <{}>",
             Error::ErrAgentClosed,
             err,
@@ -127,8 +127,8 @@ async fn test_agent_stop() -> Result<()> {
     let result = a.stop(TransactionId::default());
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrTransactionNotExists,
             err,
+            Error::ErrTransactionNotExists,
             "unexpected error: {}, should be {}",
             Error::ErrTransactionNotExists,
             err,
@@ -148,9 +148,13 @@ async fn test_agent_stop() -> Result<()> {
     tokio::select! {
         evt = handler_rx.recv() => {
             if let Err(err) = evt.unwrap().event_body{
-                assert_eq!(Error::ErrTransactionStopped,err,
+                assert_eq!(
+                    err,
+                    Error::ErrTransactionStopped,
                     "unexpected error: {}, should be {}",
-                    err, Error::ErrTransactionStopped);
+                    err,
+                    Error::ErrTransactionStopped
+                );
             }else{
                 assert!(false, "expected error, got ok");
             }
@@ -163,8 +167,8 @@ async fn test_agent_stop() -> Result<()> {
     let result = a.close();
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrAgentClosed,
             err,
+            Error::ErrAgentClosed,
             "a.Close returned {} instead of {}",
             Error::ErrAgentClosed,
             err,
@@ -176,8 +180,8 @@ async fn test_agent_stop() -> Result<()> {
     let result = a.stop(TransactionId::default());
     if let Err(err) = result {
         assert_eq!(
-            Error::ErrAgentClosed,
             err,
+            Error::ErrAgentClosed,
             "unexpected error: {}, should be {}",
             Error::ErrAgentClosed,
             err,

--- a/stun/src/integrity/integrity_test.rs
+++ b/stun/src/integrity/integrity_test.rs
@@ -15,7 +15,7 @@ fn test_message_integrity_add_to_simple() -> Result<()> {
         0x84, 0x93, 0xfb, 0xc5, 0x3b, 0xa5, 0x82, 0xfb, 0x4c, 0x04, 0x4c, 0x45, 0x6b, 0xdc, 0x40,
         0xeb,
     ];
-    assert_eq!(expected, i.0, "{}", Error::ErrIntegrityMismatch);
+    assert_eq!(i.0, expected, "{}", Error::ErrIntegrityMismatch);
 
     //"Check"
     {

--- a/turn/benches/bench.rs
+++ b/turn/benches/bench.rs
@@ -70,7 +70,7 @@ fn benchmark_chan(c: &mut Criterion) {
         c.bench_function("BenchmarkChannelNumber/GetFrom", |b| {
             b.iter(|| {
                 n.get_from(&m).unwrap();
-                assert_eq!(expected, n);
+                assert_eq!(n, expected);
             })
         });
     }

--- a/util/src/vnet/chunk/chunk_test.rs
+++ b/util/src/vnet/chunk/chunk_test.rs
@@ -5,17 +5,17 @@ use super::*;
 #[test]
 fn test_tcp_frag_string() {
     let f = TCP_FLAG_FIN;
-    assert_eq!("FIN", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "FIN", "should match");
     let f = TCP_FLAG_SYN;
-    assert_eq!("SYN", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "SYN", "should match");
     let f = TCP_FLAG_RST;
-    assert_eq!("RST", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "RST", "should match");
     let f = TCP_FLAG_PSH;
-    assert_eq!("PSH", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "PSH", "should match");
     let f = TCP_FLAG_ACK;
-    assert_eq!("ACK", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "ACK", "should match");
     let f = TCP_FLAG_SYN | TCP_FLAG_ACK;
-    assert_eq!("SYN-ACK", f.to_string(), "should match");
+    assert_eq!(f.to_string(), "SYN-ACK", "should match");
 }
 
 const DEMO_IP: &str = "1.2.3.4";
@@ -28,7 +28,7 @@ fn test_chunk_udp() -> Result<()> {
     let mut c = ChunkUdp::new(src, dst);
     let s = c.to_string();
     log::debug!("chunk: {}", s);
-    assert_eq!(UDP_STR, c.network(), "should match");
+    assert_eq!(c.network(), UDP_STR, "should match");
     assert!(s.contains(&src.to_string()), "should include address");
     assert!(s.contains(&dst.to_string()), "should include address");
     assert_eq!(c.get_source_ip(), src.ip(), "ip should match");
@@ -44,15 +44,15 @@ fn test_chunk_udp() -> Result<()> {
 
     // Test setSourceAddr
     c.set_source_addr("2.3.4.5:4000")?;
-    assert_eq!("2.3.4.5:4000", c.source_addr().to_string());
+    assert_eq!(c.source_addr().to_string(), "2.3.4.5:4000");
 
     // Test Tag()
     assert!(!c.tag().is_empty(), "should not be empty");
 
     // Verify cloned chunk was not affected by the changes to original chunk
     c.user_data[0] = b'!'; // oroginal: "Hello" -> "Hell!"
-    assert_eq!("Hello".as_bytes(), cloned.user_data(), "should match");
-    assert_eq!("192.168.0.2:1234", cloned.source_addr().to_string());
+    assert_eq!(cloned.user_data(), "Hello".as_bytes(), "should match");
+    assert_eq!(cloned.source_addr().to_string(), "192.168.0.2:1234");
     assert_eq!(cloned.get_source_ip(), src.ip(), "ip should match");
     assert_eq!(cloned.get_destination_ip(), dst.ip(), "ip should match");
 

--- a/util/src/vnet/conn_map/conn_map_test.rs
+++ b/util/src/vnet/conn_map/conn_map_test.rs
@@ -46,13 +46,13 @@ async fn test_udp_conn_map_insert_remove() -> Result<()> {
             "should match"
         );
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(1, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 1, "should match");
     }
 
     conn_map.delete(&conn_in.local_addr()?).await?;
     {
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(0, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 0, "should match");
     }
 
     let result = conn_map.delete(&conn_in.local_addr()?).await;
@@ -85,13 +85,13 @@ async fn test_udp_conn_map_insert_0_remove() -> Result<()> {
             "should match"
         );
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(1, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 1, "should match");
     }
 
     conn_map.delete(&conn_in.local_addr()?).await?;
     {
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(0, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 0, "should match");
     }
 
     let result = conn_map.delete(&conn_in.local_addr()?).await;
@@ -123,7 +123,7 @@ async fn test_udp_conn_map_find_0() -> Result<()> {
         let addr_out = conn_out.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(1, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 1, "should match");
     }
 
     Ok(())
@@ -159,7 +159,7 @@ async fn test_udp_conn_map_insert_many_ips_with_same_port() -> Result<()> {
         let addr_out = conn_out1.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(1, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 1, "should match");
     }
 
     let addr2 = SocketAddr::from_str("10.1.2.2:5678")?;
@@ -170,7 +170,7 @@ async fn test_udp_conn_map_insert_many_ips_with_same_port() -> Result<()> {
         let addr_out = conn_out2.local_addr()?;
         assert_eq!(addr_in, addr_out, "should match");
         let port_map = conn_map.port_map.lock().await;
-        assert_eq!(1, port_map.len(), "should match");
+        assert_eq!(port_map.len(), 1, "should match");
     }
 
     Ok(())

--- a/util/src/vnet/nat/nat_test.rs
+++ b/util/src/vnet/nat/nat_test.rs
@@ -18,19 +18,19 @@ fn test_nat_type_default() -> Result<()> {
     })?;
 
     assert_eq!(
-        EndpointDependencyType::EndpointIndependent,
         nat.nat_type.mapping_behavior,
+        EndpointDependencyType::EndpointIndependent,
         "should match"
     );
     assert_eq!(
-        EndpointDependencyType::EndpointIndependent,
         nat.nat_type.filtering_behavior,
+        EndpointDependencyType::EndpointIndependent,
         "should match"
     );
     assert!(!nat.nat_type.hair_pining, "should be false");
     assert!(!nat.nat_type.port_preservation, "should be false");
     assert_eq!(
-        DEFAULT_NAT_MAPPING_LIFE_TIME, nat.nat_type.mapping_life_time,
+        nat.nat_type.mapping_life_time, DEFAULT_NAT_MAPPING_LIFE_TIME,
         "should be false"
     );
 
@@ -57,8 +57,8 @@ async fn test_nat_mapping_behavior_full_cone_nat() -> Result<()> {
     let oic = ChunkUdp::new(src, dst);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
@@ -119,8 +119,8 @@ async fn test_nat_mapping_behavior_addr_restricted_cone_nat() -> Result<()> {
     log::debug!("o-original  : {}", oic);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
     log::debug!("o-translated: {}", oec);
 
     // sending different (IP: 5.6.7.9) won't create a new mapping
@@ -129,8 +129,8 @@ async fn test_nat_mapping_behavior_addr_restricted_cone_nat() -> Result<()> {
         SocketAddr::from_str("5.6.7.9:9000")?,
     );
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
     log::debug!("o-translated: {}", oec2);
 
     let iec = ChunkUdp::new(
@@ -198,8 +198,8 @@ async fn test_nat_mapping_behavior_port_restricted_cone_nat() -> Result<()> {
     log::debug!("o-original  : {}", oic);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
     log::debug!("o-translated: {}", oec);
 
     // sending different (IP: 5.6.7.9) won't create a new mapping
@@ -208,8 +208,8 @@ async fn test_nat_mapping_behavior_port_restricted_cone_nat() -> Result<()> {
         SocketAddr::from_str("5.6.7.9:9000")?,
     );
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
     log::debug!("o-translated: {}", oec2);
 
     let iec = ChunkUdp::new(
@@ -287,8 +287,8 @@ async fn test_nat_mapping_behavior_symmetric_nat_addr_dependent_mapping() -> Res
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
     let oec3 = nat.translate_outbound(&oic3).await?.unwrap();
 
-    assert_eq!(2, nat.outbound_map_len().await, "should match");
-    assert_eq!(2, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 2, "should match");
+    assert_eq!(nat.inbound_map_len().await, 2, "should match");
 
     log::debug!("o-translated: {}", oec1);
     log::debug!("o-translated: {}", oec2);
@@ -339,8 +339,8 @@ async fn test_nat_mapping_behavior_symmetric_nat_port_dependent_mapping() -> Res
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
     let oec3 = nat.translate_outbound(&oic3).await?.unwrap();
 
-    assert_eq!(3, nat.outbound_map_len().await, "should match");
-    assert_eq!(3, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 3, "should match");
+    assert_eq!(nat.inbound_map_len().await, 3, "should match");
 
     log::debug!("o-translated: {}", oec1);
     log::debug!("o-translated: {}", oec2);
@@ -380,8 +380,8 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
     let oic = ChunkUdp::new(src, dst);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
@@ -393,8 +393,8 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
 
     // refresh
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
@@ -410,15 +410,15 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
 
     // refresh after expiration
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
 
     assert_ne!(
-        mapped,
         oec.source_addr().to_string(),
+        mapped,
         "mapped addr should not match"
     );
 
@@ -445,8 +445,8 @@ async fn test_nat_mapping_timeout_outbound_detects_timeout() -> Result<()> {
     let oic = ChunkUdp::new(src, dst);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(1, nat.outbound_map_len().await, "should match");
-    assert_eq!(1, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 1, "should match");
+    assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
@@ -463,8 +463,8 @@ async fn test_nat_mapping_timeout_outbound_detects_timeout() -> Result<()> {
 
     let result = nat.translate_inbound(&iec).await;
     assert!(result.is_err(), "should drop");
-    assert_eq!(0, nat.outbound_map_len().await, "should match");
-    assert_eq!(0, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 0, "should match");
+    assert_eq!(nat.inbound_map_len().await, 0, "should match");
 
     Ok(())
 }
@@ -487,8 +487,8 @@ async fn test_nat1to1_bahavior_one_mapping() -> Result<()> {
     let oic = ChunkUdp::new(src, dst);
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
-    assert_eq!(0, nat.outbound_map_len().await, "should match");
-    assert_eq!(0, nat.inbound_map_len().await, "should match");
+    assert_eq!(nat.outbound_map_len().await, 0, "should match");
+    assert_eq!(nat.inbound_map_len().await, 0, "should match");
 
     log::debug!("o-original  : {}", oic);
     log::debug!("o-translated: {}", oec);
@@ -536,8 +536,8 @@ async fn test_nat1to1_bahavior_more_mapping() -> Result<()> {
 
     let after = nat.translate_outbound(&before).await?.unwrap();
     assert_eq!(
-        "1.2.3.4:1234",
         after.source_addr().to_string(),
+        "1.2.3.4:1234",
         "should match"
     );
 
@@ -548,8 +548,8 @@ async fn test_nat1to1_bahavior_more_mapping() -> Result<()> {
 
     let after = nat.translate_outbound(&before).await?.unwrap();
     assert_eq!(
-        "1.2.3.5:1234",
         after.source_addr().to_string(),
+        "1.2.3.5:1234",
         "should match"
     );
 
@@ -562,8 +562,8 @@ async fn test_nat1to1_bahavior_more_mapping() -> Result<()> {
 
     let after = nat.translate_inbound(&before).await?.unwrap();
     assert_eq!(
-        "10.0.0.1:2525",
         after.destination_addr().to_string(),
+        "10.0.0.1:2525",
         "should match"
     );
 
@@ -574,8 +574,8 @@ async fn test_nat1to1_bahavior_more_mapping() -> Result<()> {
 
     let after = nat.translate_inbound(&before).await?.unwrap();
     assert_eq!(
-        "10.0.0.2:9847",
         after.destination_addr().to_string(),
+        "10.0.0.2:9847",
         "should match"
     );
 

--- a/util/src/vnet/net/net_test.rs
+++ b/util/src/vnet/net/net_test.rs
@@ -44,8 +44,8 @@ async fn test_net_native_resolve_addr() -> Result<()> {
     assert!(!nw.is_virtual(), "should be false");
 
     let udp_addr = nw.resolve_addr(true, "localhost:1234").await?;
-    assert_eq!("127.0.0.1", udp_addr.ip().to_string(), "should match");
-    assert_eq!(1234, udp_addr.port(), "should match");
+    assert_eq!(udp_addr.ip().to_string(), "127.0.0.1", "should match");
+    assert_eq!(udp_addr.port(), 1234, "should match");
 
     let result = nw.resolve_addr(false, "127.0.0.1:1234").await;
     assert!(result.is_err(), "should not match");
@@ -104,8 +104,8 @@ async fn test_net_native_loopback() -> Result<()> {
     let (n, raddr) = conn.recv_from(&mut buf).await?;
     assert_eq!(n, msg.len(), "should match msg size {}", msg.len());
     assert_eq!(
-        msg.as_bytes(),
         &buf[..n],
+        msg.as_bytes(),
         "should match msg content {}",
         msg
     );
@@ -132,7 +132,7 @@ async fn test_net_native_unexpected_operations() -> Result<()> {
 
     if !lo_name.is_empty() {
         if let Some(ifc) = nw.get_interface(&lo_name).await {
-            assert_eq!(lo_name, ifc.name, "should match ifc name");
+            assert_eq!(ifc.name, lo_name, "should match ifc name");
         } else {
             assert!(false, "should succeed");
         }
@@ -159,7 +159,7 @@ async fn test_net_virtual_interfaces() -> Result<()> {
         match ifc.name.as_str() {
             LO0_STR => {
                 let addrs = ifc.addrs();
-                assert_eq!(1, addrs.len(), "should be one address");
+                assert_eq!(addrs.len(), 1, "should be one address");
             }
             "eth0" => {
                 let addrs = ifc.addrs();
@@ -185,15 +185,15 @@ async fn test_net_virtual_interface_by_name() -> Result<()> {
     let nic = nw.get_nic()?;
     let nic = nic.lock().await;
     if let Some(ifc) = nic.get_interface(LO0_STR).await {
-        assert_eq!(LO0_STR, ifc.name.as_str(), "should match");
+        assert_eq!(ifc.name.as_str(), LO0_STR, "should match");
         let addrs = ifc.addrs();
-        assert_eq!(1, addrs.len(), "should be one address");
+        assert_eq!(addrs.len(), 1, "should be one address");
     } else {
         assert!(false, "should got ifc");
     }
 
     if let Some(ifc) = nic.get_interface("eth0").await {
-        assert_eq!("eth0", ifc.name.as_str(), "should match");
+        assert_eq!(ifc.name.as_str(), "eth0", "should match");
         let addrs = ifc.addrs();
         assert!(addrs.is_empty(), "should empty");
     } else {
@@ -212,7 +212,7 @@ async fn test_net_virtual_has_ipaddr() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let interfaces = nw.get_interfaces().await;
-    assert_eq!(2, interfaces.len(), "should be one interface");
+    assert_eq!(interfaces.len(), 2, "should be one interface");
 
     {
         let nic = nw.get_nic()?;
@@ -246,7 +246,7 @@ async fn test_net_virtual_get_all_ipaddrs() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let interfaces = nw.get_interfaces().await;
-    assert_eq!(2, interfaces.len(), "should be one interface");
+    assert_eq!(interfaces.len(), 2, "should be one interface");
 
     {
         let nic = nw.get_nic()?;
@@ -263,7 +263,7 @@ async fn test_net_virtual_get_all_ipaddrs() -> Result<()> {
     if let Net::VNet(vnet) = &nw {
         let net = vnet.lock().await;
         let ips = net.get_all_ipaddrs(false);
-        assert_eq!(2, ips.len(), "ips should match size {} == 2", ips.len())
+        assert_eq!(ips.len(), 2, "ips should match size {} == 2", ips.len())
     }
 
     Ok(())
@@ -280,7 +280,7 @@ async fn test_net_virtual_assign_port() -> Result<()> {
     let space = end + 1 - start;
 
     let interfaces = nw.get_interfaces().await;
-    assert_eq!(2, interfaces.len(), "should be one interface");
+    assert_eq!(interfaces.len(), 2, "should be one interface");
 
     {
         let nic = nw.get_nic()?;
@@ -312,8 +312,8 @@ async fn test_net_virtual_assign_port() -> Result<()> {
         {
             let vi = vnet.vi.lock().await;
             assert_eq!(
-                space as usize,
                 vi.udp_conns.len().await,
+                space as usize,
                 "udp_conns should match"
             );
         }
@@ -332,7 +332,7 @@ async fn test_net_virtual_determine_source_ip() -> Result<()> {
     assert!(nw.is_virtual(), "should be true");
 
     let interfaces = nw.get_interfaces().await;
-    assert_eq!(2, interfaces.len(), "should be one interface");
+    assert_eq!(interfaces.len(), 2, "should be one interface");
 
     {
         let nic = nw.get_nic()?;
@@ -393,14 +393,14 @@ async fn test_net_virtual_resolve_addr() -> Result<()> {
 
     let udp_addr = nw.resolve_addr(true, "localhost:1234").await?;
     assert_eq!(
-        "127.0.0.1",
         udp_addr.ip().to_string().as_str(),
+        "127.0.0.1",
         "udp addr {} should match 127.0.0.1",
         udp_addr.ip(),
     );
     assert_eq!(
-        1234,
         udp_addr.port(),
+        1234,
         "udp addr {} should match 1234",
         udp_addr.port()
     );
@@ -424,8 +424,8 @@ async fn test_net_virtual_loopback1() -> Result<()> {
     let (n, raddr) = conn.recv_from(&mut buf).await?;
     assert_eq!(n, msg.len(), "should match msg size {}", msg.len());
     assert_eq!(
-        msg.as_bytes(),
         &buf[..n],
+        msg.as_bytes(),
         "should match msg content {}",
         msg
     );
@@ -598,9 +598,9 @@ async fn test_net_virtual_loopback2() -> Result<()> {
                         }
                     };
 
-                    assert_eq!(6, n, "{} should match 6", n);
-                    assert_eq!("127.0.0.1:4000", addr.to_string(), "addr should match");
-                    assert_eq!(b"Hello!", &buf[..n], "buf should match");
+                    assert_eq!(n, 6, "{} should match 6", n);
+                    assert_eq!(addr.to_string(), "127.0.0.1:4000", "addr should match");
+                    assert_eq!(&buf[..n], b"Hello!", "buf should match");
 
                     let _ = recv_ch_tx.send(true).await;
                 }
@@ -771,7 +771,7 @@ async fn test_net_virtual_end2end() -> Result<()> {
 
     log::debug!("conn1: sending");
     let n = conn1.send_to(b"Hello!", conn2.local_addr()?).await?;
-    assert_eq!(6, n, "should match");
+    assert_eq!(n, 6, "should match");
 
     let _ = conn1_recv_ch_rx.recv().await;
     log::debug!("main recv conn1_recv_ch_rx");
@@ -887,7 +887,7 @@ async fn test_net_virtual_two_ips_on_a_nic() -> Result<()> {
 
                     // echo back to conn1
                     let n = conn2_tr.send_to(b"Good-bye!", addr).await?;
-                    assert_eq!( 9, n, "should match");
+                    assert_eq!(n, 9, "should match");
                 }
                 _ = close_ch_rx2.recv() => {
                     log::debug!("conn1 received close_ch_rx2");
@@ -903,7 +903,7 @@ async fn test_net_virtual_two_ips_on_a_nic() -> Result<()> {
 
     log::debug!("conn1: sending");
     let n = conn1.send_to(b"Hello!", conn2.local_addr()?).await?;
-    assert_eq!(6, n, "should match");
+    assert_eq!(n, 6, "should match");
 
     let _ = conn1_recv_ch_rx.recv().await;
     log::debug!("main recv conn1_recv_ch_rx");

--- a/util/src/vnet/router/router_test.rs
+++ b/util/src/vnet/router/router_test.rs
@@ -120,10 +120,10 @@ fn test_router_standalone_cidr_parsing() -> Result<()> {
         ..Default::default()
     })?;
 
-    assert_eq!("1.2.3.0", r.ipv4net.addr().to_string(), "ip should match");
+    assert_eq!(r.ipv4net.addr().to_string(), "1.2.3.0", "ip should match");
     assert_eq!(
-        "255.255.255.0",
         r.ipv4net.netmask().to_string(),
+        "255.255.255.0",
         "mask should match"
     );
 
@@ -143,10 +143,10 @@ async fn test_router_standalone_assign_ip_address() -> Result<()> {
             IpAddr::V4(ip) => ip.octets().to_vec(),
             IpAddr::V6(ip) => ip.octets().to_vec(),
         };
-        assert_eq!(1_u8, ip[0], "should match");
-        assert_eq!(2_u8, ip[1], "should match");
-        assert_eq!(3_u8, ip[2], "should match");
-        assert_eq!(i as u8, ip[3], "should match");
+        assert_eq!(ip[0], 1_u8, "should match");
+        assert_eq!(ip[1], 2_u8, "should match");
+        assert_eq!(ip[2], 3_u8, "should match");
+        assert_eq!(ip[3], i as u8, "should match");
     }
 
     let result = ri.assign_ip_address();
@@ -178,9 +178,9 @@ async fn test_router_standalone_add_net() -> Result<()> {
     assert!(eth0.is_some(), "should succeed");
     if let Some(eth0) = eth0 {
         let addrs = eth0.addrs();
-        assert_eq!(1, addrs.len(), "should match");
-        assert_eq!("1.2.3.1/24", addrs[0].to_string(), "should match");
-        assert_eq!("1.2.3.1", addrs[0].addr().to_string(), "should match");
+        assert_eq!(addrs.len(), 1, "should match");
+        assert_eq!(addrs[0].to_string(), "1.2.3.1/24", "should match");
+        assert_eq!(addrs[0].addr().to_string(), "1.2.3.1", "should match");
     }
 
     Ok(())
@@ -225,7 +225,7 @@ async fn test_router_standalone_routing() -> Result<()> {
             let n = nic.lock().await;
             if let Some(eth0) = n.get_interface("eth0").await {
                 let addrs = eth0.addrs();
-                assert_eq!(1, addrs.len(), "should match");
+                assert_eq!(addrs.len(), 1, "should match");
                 ips.push(SocketAddr::new(addrs[0].addr(), 1111 * (i + 1)));
             }
         }
@@ -250,7 +250,7 @@ async fn test_router_standalone_routing() -> Result<()> {
 
     {
         let n = nics[0].lock().await;
-        assert_eq!(0, n.cbs0.load(Ordering::SeqCst), "should be zero");
+        assert_eq!(n.cbs0.load(Ordering::SeqCst), 0, "should be zero");
     }
 
     Ok(())
@@ -305,7 +305,7 @@ async fn test_router_standalone_add_chunk_filter() -> Result<()> {
             let n = nic.lock().await;
             if let Some(eth0) = n.get_interface("eth0").await {
                 let addrs = eth0.addrs();
-                assert_eq!(1, addrs.len(), "should match");
+                assert_eq!(addrs.len(), 1, "should match");
                 ips.push(SocketAddr::new(addrs[0].addr(), 1111 * (i + 1)));
             }
         }
@@ -353,12 +353,12 @@ async fn test_router_standalone_add_chunk_filter() -> Result<()> {
 
     {
         let n = nics[0].lock().await;
-        assert_eq!(0, n.cbs0.load(Ordering::SeqCst), "should be zero");
+        assert_eq!(n.cbs0.load(Ordering::SeqCst), 0, "should be zero");
     }
 
     {
         let n = nics[1].lock().await;
-        assert_eq!(1, n.cbs0.load(Ordering::SeqCst), "should be one");
+        assert_eq!(n.cbs0.load(Ordering::SeqCst), 1, "should be one");
     }
 
     Ok(())
@@ -408,7 +408,7 @@ async fn delay_sub_test(title: String, min_delay: Duration, max_jitter: Duration
             let n = nic.lock().await;
             if let Some(eth0) = n.get_interface("eth0").await {
                 let addrs = eth0.addrs();
-                assert_eq!(1, addrs.len(), "should match");
+                assert_eq!(addrs.len(), 1, "should match");
                 ips.push(SocketAddr::new(addrs[0].addr(), 1111 * (i + 1)));
             }
         }
@@ -616,10 +616,10 @@ fn test_router_static_ips_more_than_one() -> Result<()> {
         ..Default::default()
     })?;
 
-    assert_eq!(3, lan.static_ips.len(), "should be 3");
-    assert_eq!("1.2.3.1", lan.static_ips[0].to_string(), "should match");
-    assert_eq!("1.2.3.2", lan.static_ips[1].to_string(), "should match");
-    assert_eq!("1.2.3.3", lan.static_ips[2].to_string(), "should match");
+    assert_eq!(lan.static_ips.len(), 3, "should be 3");
+    assert_eq!(lan.static_ips[0].to_string(), "1.2.3.1", "should match");
+    assert_eq!(lan.static_ips[1].to_string(), "1.2.3.2", "should match");
+    assert_eq!(lan.static_ips[2].to_string(), "1.2.3.3", "should match");
 
     Ok(())
 }
@@ -636,10 +636,10 @@ fn test_router_static_ips_static_ip_local_ip_mapping() -> Result<()> {
         ..Default::default()
     })?;
 
-    assert_eq!(3, lan.static_ips.len(), "should be 3");
-    assert_eq!("1.2.3.1", lan.static_ips[0].to_string(), "should match");
-    assert_eq!("1.2.3.2", lan.static_ips[1].to_string(), "should match");
-    assert_eq!("1.2.3.3", lan.static_ips[2].to_string(), "should match");
+    assert_eq!(lan.static_ips.len(), 3, "should be 3");
+    assert_eq!(lan.static_ips[0].to_string(), "1.2.3.1", "should match");
+    assert_eq!(lan.static_ips[1].to_string(), "1.2.3.2", "should match");
+    assert_eq!(lan.static_ips[2].to_string(), "1.2.3.3", "should match");
 
     assert_eq!(3, lan.static_local_ips.len(), "should be 3");
     let local_ips = vec!["192.168.0.1", "192.168.0.2", "192.168.0.3"];
@@ -723,25 +723,25 @@ async fn test_router_static_ips_1to1_nat() -> Result<()> {
         let l = lan.lock().await;
         let ri = l.router_internal.lock().await;
 
-        assert_eq!(3, ri.nat.mapped_ips.len(), "should be 3");
-        assert_eq!("1.2.3.1", ri.nat.mapped_ips[0].to_string(), "should match");
-        assert_eq!("1.2.3.2", ri.nat.mapped_ips[1].to_string(), "should match");
-        assert_eq!("1.2.3.3", ri.nat.mapped_ips[2].to_string(), "should match");
+        assert_eq!(ri.nat.mapped_ips.len(), 3, "should be 3");
+        assert_eq!(ri.nat.mapped_ips[0].to_string(), "1.2.3.1", "should match");
+        assert_eq!(ri.nat.mapped_ips[1].to_string(), "1.2.3.2", "should match");
+        assert_eq!(ri.nat.mapped_ips[2].to_string(), "1.2.3.3", "should match");
 
         assert_eq!(3, ri.nat.local_ips.len(), "should be 3");
         assert_eq!(
-            "192.168.0.1",
             ri.nat.local_ips[0].to_string(),
+            "192.168.0.1",
             "should match"
         );
         assert_eq!(
-            "192.168.0.2",
             ri.nat.local_ips[1].to_string(),
+            "192.168.0.2",
             "should match"
         );
         assert_eq!(
-            "192.168.0.3",
             ri.nat.local_ips[2].to_string(),
+            "192.168.0.3",
             "should match"
         );
     }

--- a/webrtc/src/api/media_engine/media_engine_test.rs
+++ b/webrtc/src/api/media_engine/media_engine_test.rs
@@ -492,7 +492,7 @@ a=fmtp:97 apt=96
         assert!(m.negotiated_video.load(Ordering::SeqCst));
 
         if let Err(err) = m.get_codec_by_payload(97).await {
-            assert_eq!(Error::ErrCodecNotFound, err);
+            assert_eq!(err, Error::ErrCodecNotFound);
         } else {
             assert!(false);
         }
@@ -536,7 +536,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             .get_rtp_parameters_by_kind(RTPCodecType::Audio, RTCRtpTransceiverDirection::Recvonly)
             .await;
 
-        assert_eq!(1, params.header_extensions.len());
+        assert_eq!(params.header_extensions.len(), 1);
     }
 
     //"Same Direction"
@@ -555,7 +555,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             .get_rtp_parameters_by_kind(RTPCodecType::Audio, RTCRtpTransceiverDirection::Recvonly)
             .await;
 
-        assert_eq!(1, params.header_extensions.len());
+        assert_eq!(params.header_extensions.len(), 1);
     }
 
     //"Different Direction"
@@ -574,7 +574,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             .get_rtp_parameters_by_kind(RTPCodecType::Audio, RTCRtpTransceiverDirection::Recvonly)
             .await;
 
-        assert_eq!(0, params.header_extensions.len());
+        assert_eq!(params.header_extensions.len(), 0);
     }
 
     //"No direction and inactive"
@@ -593,7 +593,7 @@ async fn test_media_engine_header_extension_direction() -> Result<()> {
             .get_rtp_parameters_by_kind(RTPCodecType::Audio, RTCRtpTransceiverDirection::Inactive)
             .await;
 
-        assert_eq!(1, params.header_extensions.len());
+        assert_eq!(params.header_extensions.len(), 1);
     }
 
     Ok(())
@@ -647,7 +647,7 @@ async fn validate(m: &MediaEngine) -> Result<()> {
             uri: "test-extension".to_owned(),
         })
         .await;
-    assert_eq!(2, id);
+    assert_eq!(id, 2);
     assert!(audio_negotiated);
     assert!(!video_negotiated);
 

--- a/webrtc/src/data_channel/data_channel_state.rs
+++ b/webrtc/src/data_channel/data_channel_state.rs
@@ -93,8 +93,8 @@ mod test {
 
         for (state_string, expected_state) in tests {
             assert_eq!(
-                expected_state,
                 RTCDataChannelState::from(state_string),
+                expected_state,
                 "testCase: {}",
                 expected_state,
             );
@@ -112,7 +112,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string(),)
+            assert_eq!(state.to_string(), expected_string)
         }
     }
 }

--- a/webrtc/src/data_channel/data_channel_test.rs
+++ b/webrtc/src/data_channel/data_channel_test.rs
@@ -727,7 +727,7 @@ async fn test_data_channel_messages_are_ordered() -> Result<()> {
     for i in 1..=m as usize {
         expected[i - 1] = i as u64;
     }
-    assert_eq!(expected, values);
+    assert_eq!(values, expected);
 
     Ok(())
 }

--- a/webrtc/src/dtls_transport/dtls_role.rs
+++ b/webrtc/src/dtls_transport/dtls_role.rs
@@ -109,7 +109,7 @@ mod test {
         ];
 
         for (role, expected_string) in tests {
-            assert_eq!(expected_string, role.to_string(),)
+            assert_eq!(role.to_string(), expected_string)
         }
     }
 
@@ -165,8 +165,8 @@ a=setup:";
             let mut reader = Cursor::new(session_description_str.as_bytes());
             let session_description = SessionDescription::unmarshal(&mut reader)?;
             assert_eq!(
-                expected_role,
                 DTLSRole::from(&session_description),
+                expected_role,
                 "{} failed",
                 name
             );

--- a/webrtc/src/dtls_transport/dtls_transport_state.rs
+++ b/webrtc/src/dtls_transport/dtls_transport_state.rs
@@ -97,8 +97,8 @@ mod test {
 
         for (state_string, expected_state) in tests {
             assert_eq!(
-                expected_state,
                 RTCDtlsTransportState::from(state_string),
+                expected_state,
                 "testCase: {}",
                 expected_state,
             );
@@ -117,7 +117,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string(),)
+            assert_eq!(state.to_string(), expected_string)
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_candidate.rs
+++ b/webrtc/src/ice_transport/ice_candidate.rs
@@ -212,7 +212,7 @@ mod test {
             let result = serde_json::from_str::<RTCIceCandidateInit>(&candidate_data);
             assert!(result.is_ok(), "testCase: unmarshal err: {:?}", result);
             if let Ok(actual_candidate_init) = result {
-                assert_eq!(candidate_init, actual_candidate_init);
+                assert_eq!(actual_candidate_init, candidate_init);
             }
         }
     }

--- a/webrtc/src/ice_transport/ice_candidate_type.rs
+++ b/webrtc/src/ice_transport/ice_candidate_type.rs
@@ -102,7 +102,7 @@ mod test {
 
         for (type_string, expected_type) in tests {
             let actual = RTCIceCandidateType::from(type_string);
-            assert_eq!(expected_type, actual);
+            assert_eq!(actual, expected_type);
         }
     }
 
@@ -117,7 +117,7 @@ mod test {
         ];
 
         for (ctype, expected_string) in tests {
-            assert_eq!(expected_string, ctype.to_string());
+            assert_eq!(ctype.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_connection_state.rs
+++ b/webrtc/src/ice_transport/ice_connection_state.rs
@@ -120,8 +120,8 @@ mod test {
 
         for (state_string, expected_state) in tests {
             assert_eq!(
-                expected_state,
                 RTCIceConnectionState::from(state_string),
+                expected_state,
                 "testCase: {}",
                 expected_state,
             );
@@ -142,7 +142,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string(),)
+            assert_eq!(state.to_string(), expected_string)
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_credential_type.rs
+++ b/webrtc/src/ice_transport/ice_credential_type.rs
@@ -58,7 +58,7 @@ mod test {
         ];
 
         for (ct_str, expected_ct) in tests {
-            assert_eq!(expected_ct, RTCIceCredentialType::from(ct_str));
+            assert_eq!(RTCIceCredentialType::from(ct_str), expected_ct);
         }
     }
 
@@ -71,7 +71,7 @@ mod test {
         ];
 
         for (ct, expected_string) in tests {
-            assert_eq!(expected_string, ct.to_string());
+            assert_eq!(ct.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_gatherer_state.rs
+++ b/webrtc/src/ice_transport/ice_gatherer_state.rs
@@ -87,7 +87,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string());
+            assert_eq!(state.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_gathering_state.rs
+++ b/webrtc/src/ice_transport/ice_gathering_state.rs
@@ -68,7 +68,7 @@ mod test {
         ];
 
         for (state_string, expected_state) in tests {
-            assert_eq!(expected_state, RTCIceGatheringState::from(state_string));
+            assert_eq!(RTCIceGatheringState::from(state_string), expected_state);
         }
     }
 
@@ -82,7 +82,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string());
+            assert_eq!(state.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_protocol.rs
+++ b/webrtc/src/ice_transport/ice_protocol.rs
@@ -64,7 +64,7 @@ mod test {
 
         for (proto_string, expected_proto) in tests {
             let actual = RTCIceProtocol::from(proto_string);
-            assert_eq!(expected_proto, actual);
+            assert_eq!(actual, expected_proto);
         }
     }
 
@@ -77,7 +77,7 @@ mod test {
         ];
 
         for (proto, expected_string) in tests {
-            assert_eq!(expected_string, proto.to_string());
+            assert_eq!(proto.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_role.rs
+++ b/webrtc/src/ice_transport/ice_role.rs
@@ -59,7 +59,7 @@ mod test {
         ];
 
         for (role_string, expected_role) in tests {
-            assert_eq!(expected_role, RTCIceRole::from(role_string));
+            assert_eq!(RTCIceRole::from(role_string), expected_role);
         }
     }
 
@@ -72,7 +72,7 @@ mod test {
         ];
 
         for (proto, expected_string) in tests {
-            assert_eq!(expected_string, proto.to_string());
+            assert_eq!(proto.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/ice_transport/ice_server.rs
+++ b/webrtc/src/ice_transport/ice_server.rs
@@ -141,7 +141,7 @@ mod test {
 
         for (ice_server, expected_err) in tests {
             if let Err(err) = ice_server.urls() {
-                assert_eq!(expected_err, err, "{:?} with err {:?}", ice_server, err);
+                assert_eq!(err, expected_err, "{:?} with err {:?}", ice_server, err);
             } else {
                 assert!(false, "expected error, but got ok");
             }

--- a/webrtc/src/ice_transport/ice_transport_state.rs
+++ b/webrtc/src/ice_transport/ice_transport_state.rs
@@ -158,7 +158,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string());
+            assert_eq!(state.to_string(), expected_string);
         }
     }
 

--- a/webrtc/src/peer_connection/configuration.rs
+++ b/webrtc/src/peer_connection/configuration.rs
@@ -87,7 +87,7 @@ mod test {
             };
 
             let parsed_urls = cfg.get_ice_servers();
-            assert_eq!(expected_server_str, parsed_urls[0].urls[0]);
+            assert_eq!(parsed_urls[0].urls[0], expected_server_str);
         }
 
         {
@@ -103,7 +103,7 @@ mod test {
             };
 
             let parsed_urls = cfg.get_ice_servers();
-            assert_eq!(expected_server_str, parsed_urls[0].urls[0]);
+            assert_eq!(parsed_urls[0].urls[0], expected_server_str);
         }
     }
 

--- a/webrtc/src/peer_connection/operation/operation_test.rs
+++ b/webrtc/src/peer_connection/operation/operation_test.rs
@@ -30,8 +30,8 @@ async fn test_operations_enqueue() -> Result<()> {
         ];
         {
             let r = results.lock().await;
-            assert_eq!(expected.len(), r.len());
-            assert_eq!(&expected, &*r);
+            assert_eq!(r.len(), expected.len());
+            assert_eq!(&*r, &expected);
         }
     }
 

--- a/webrtc/src/peer_connection/peer_connection_state.rs
+++ b/webrtc/src/peer_connection/peer_connection_state.rs
@@ -135,8 +135,8 @@ mod test {
 
         for (state_string, expected_state) in tests {
             assert_eq!(
-                expected_state,
                 RTCPeerConnectionState::from(state_string),
+                expected_state,
                 "testCase: {}",
                 expected_state,
             );
@@ -156,7 +156,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string(),)
+            assert_eq!(state.to_string(), expected_string)
         }
     }
 }

--- a/webrtc/src/peer_connection/policy/bundle_policy.rs
+++ b/webrtc/src/peer_connection/policy/bundle_policy.rs
@@ -78,7 +78,7 @@ mod test {
         ];
 
         for (policy_string, expected_policy) in tests {
-            assert_eq!(expected_policy, RTCBundlePolicy::from(policy_string));
+            assert_eq!(RTCBundlePolicy::from(policy_string), expected_policy);
         }
     }
 
@@ -92,7 +92,7 @@ mod test {
         ];
 
         for (policy, expected_string) in tests {
-            assert_eq!(expected_string, policy.to_string());
+            assert_eq!(policy.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/peer_connection/policy/ice_transport_policy.rs
+++ b/webrtc/src/peer_connection/policy/ice_transport_policy.rs
@@ -63,7 +63,7 @@ mod test {
         ];
 
         for (policy_string, expected_policy) in tests {
-            assert_eq!(expected_policy, RTCIceTransportPolicy::from(policy_string));
+            assert_eq!(RTCIceTransportPolicy::from(policy_string), expected_policy);
         }
     }
 
@@ -75,7 +75,7 @@ mod test {
         ];
 
         for (policy, expected_string) in tests {
-            assert_eq!(expected_string, policy.to_string());
+            assert_eq!(policy.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
+++ b/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
@@ -64,7 +64,7 @@ mod test {
         ];
 
         for (policy_string, expected_policy) in tests {
-            assert_eq!(expected_policy, RTCRtcpMuxPolicy::from(policy_string));
+            assert_eq!(RTCRtcpMuxPolicy::from(policy_string), expected_policy);
         }
     }
 
@@ -77,7 +77,7 @@ mod test {
         ];
 
         for (policy, expected_string) in tests {
-            assert_eq!(expected_string, policy.to_string());
+            assert_eq!(policy.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/peer_connection/policy/sdp_semantics.rs
+++ b/webrtc/src/peer_connection/policy/sdp_semantics.rs
@@ -82,7 +82,7 @@ mod test {
         ];
 
         for (value, expected_string) in tests {
-            assert_eq!(expected_string, value.to_string());
+            assert_eq!(value.to_string(), expected_string);
         }
     }
 

--- a/webrtc/src/peer_connection/sdp/sdp_test.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_test.rs
@@ -51,7 +51,7 @@ fn test_extract_fingerprint() -> Result<()> {
         let s = SessionDescription::default();
 
         if let Err(err) = extract_fingerprint(&s) {
-            assert_eq!(Error::ErrSessionDescriptionNoFingerprint, err);
+            assert_eq!(err, Error::ErrSessionDescriptionNoFingerprint);
         } else {
             assert!(false);
         }
@@ -68,7 +68,7 @@ fn test_extract_fingerprint() -> Result<()> {
         };
 
         if let Err(err) = extract_fingerprint(&s) {
-            assert_eq!(Error::ErrSessionDescriptionInvalidFingerprint, err);
+            assert_eq!(err, Error::ErrSessionDescriptionInvalidFingerprint);
         } else {
             assert!(false);
         }
@@ -92,7 +92,7 @@ fn test_extract_fingerprint() -> Result<()> {
         };
 
         if let Err(err) = extract_fingerprint(&s) {
-            assert_eq!(Error::ErrSessionDescriptionConflictingFingerprints, err);
+            assert_eq!(err, Error::ErrSessionDescriptionConflictingFingerprints);
         } else {
             assert!(false);
         }
@@ -120,7 +120,7 @@ async fn test_extract_ice_details() -> Result<()> {
         };
 
         if let Err(err) = extract_ice_details(&s).await {
-            assert_eq!(Error::ErrSessionDescriptionMissingIcePwd, err);
+            assert_eq!(err, Error::ErrSessionDescriptionMissingIcePwd);
         } else {
             assert!(false);
         }
@@ -140,7 +140,7 @@ async fn test_extract_ice_details() -> Result<()> {
         };
 
         if let Err(err) = extract_ice_details(&s).await {
-            assert_eq!(Error::ErrSessionDescriptionMissingIceUfrag, err);
+            assert_eq!(err, Error::ErrSessionDescriptionMissingIceUfrag);
         } else {
             assert!(false);
         }
@@ -216,7 +216,7 @@ async fn test_extract_ice_details() -> Result<()> {
         };
 
         if let Err(err) = extract_ice_details(&s).await {
-            assert_eq!(Error::ErrSessionDescriptionConflictingIceUfrag, err);
+            assert_eq!(err, Error::ErrSessionDescriptionConflictingIceUfrag);
         } else {
             assert!(false);
         }
@@ -246,7 +246,7 @@ async fn test_extract_ice_details() -> Result<()> {
         };
 
         if let Err(err) = extract_ice_details(&s).await {
-            assert_eq!(Error::ErrSessionDescriptionConflictingIcePwd, err);
+            assert_eq!(err, Error::ErrSessionDescriptionConflictingIcePwd);
         } else {
             assert!(false);
         }
@@ -379,7 +379,7 @@ fn test_track_details_from_sdp() -> Result<()> {
         };
 
         let tracks = track_details_from_sdp(&s, true);
-        assert_eq!(3, tracks.len());
+        assert_eq!(tracks.len(), 3);
         if track_details_for_ssrc(&tracks, 1000).is_some() {
             assert!(
                 false,
@@ -387,16 +387,16 @@ fn test_track_details_from_sdp() -> Result<()> {
             );
         }
         if let Some(track) = track_details_for_ssrc(&tracks, 2000) {
-            assert_eq!(RTPCodecType::Audio, track.kind);
-            assert_eq!(2000, track.ssrcs[0]);
-            assert_eq!("audio_trk_label", track.stream_id);
+            assert_eq!(track.kind, RTPCodecType::Audio);
+            assert_eq!(track.ssrcs[0], 2000);
+            assert_eq!(track.stream_id, "audio_trk_label");
         } else {
             assert!(false, "missing audio track with ssrc:2000");
         }
         if let Some(track) = track_details_for_ssrc(&tracks, 3000) {
-            assert_eq!(RTPCodecType::Video, track.kind);
-            assert_eq!(3000, track.ssrcs[0]);
-            assert_eq!("video_trk_label", track.stream_id);
+            assert_eq!(track.kind, RTPCodecType::Video);
+            assert_eq!(track.ssrcs[0], 3000);
+            assert_eq!(track.stream_id, "video_trk_label");
         } else {
             assert!(false, "missing video track with ssrc:3000");
         }
@@ -407,10 +407,10 @@ fn test_track_details_from_sdp() -> Result<()> {
             );
         }
         if let Some(track) = track_details_for_ssrc(&tracks, 5000) {
-            assert_eq!(RTPCodecType::Video, track.kind);
-            assert_eq!(5000, track.ssrcs[0]);
-            assert_eq!("video_trk_id", track.id);
-            assert_eq!("video_stream_id", track.stream_id);
+            assert_eq!(track.kind, RTPCodecType::Video);
+            assert_eq!(track.ssrcs[0], 5000);
+            assert_eq!(track.id, "video_trk_id");
+            assert_eq!(track.stream_id, "video_stream_id");
         } else {
             assert!(false, "missing video track with ssrc:5000");
         }
@@ -465,13 +465,13 @@ fn test_track_details_from_sdp() -> Result<()> {
             ..Default::default()
         };
         assert_eq!(
-            0,
             track_details_from_sdp(&s, true).len(),
+            0,
             "inactive and recvonly tracks should be ignored when passing exclude_inactive: true"
         );
         assert_eq!(
-            1,
             track_details_from_sdp(&s, false).len(),
+            1,
             "Inactive tracks should not be ignored when passing exclude_inactive: false"
         );
     }

--- a/webrtc/src/peer_connection/sdp/sdp_type.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_type.rs
@@ -84,7 +84,7 @@ mod test {
         ];
 
         for (sdp_type_string, expected_sdp_type) in tests {
-            assert_eq!(expected_sdp_type, RTCSdpType::from(sdp_type_string));
+            assert_eq!(RTCSdpType::from(sdp_type_string), expected_sdp_type);
         }
     }
 
@@ -99,7 +99,7 @@ mod test {
         ];
 
         for (sdp_type, expected_string) in tests {
-            assert_eq!(expected_string, sdp_type.to_string());
+            assert_eq!(sdp_type.to_string(), expected_string);
         }
     }
 }

--- a/webrtc/src/peer_connection/signaling_state.rs
+++ b/webrtc/src/peer_connection/signaling_state.rs
@@ -239,7 +239,7 @@ mod test {
         ];
 
         for (state_string, expected_state) in tests {
-            assert_eq!(expected_state, RTCSignalingState::from(state_string));
+            assert_eq!(RTCSignalingState::from(state_string), expected_state);
         }
     }
 
@@ -259,7 +259,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string());
+            assert_eq!(state.to_string(), expected_string);
         }
     }
 
@@ -359,7 +359,7 @@ mod test {
                     assert_eq!(*got, next, "{} state mismatch", desc);
                 }
                 (Err(got), Some(err)) => {
-                    assert_eq!(err.to_string(), got.to_string(), "{} error mismatch", desc);
+                    assert_eq!(got.to_string(), err.to_string(), "{} error mismatch", desc);
                 }
                 _ => {
                     assert!(

--- a/webrtc/src/rtp_transceiver/fmtp/generic/generic_test.rs
+++ b/webrtc/src/rtp_transceiver/fmtp/generic/generic_test.rs
@@ -57,7 +57,7 @@ fn test_generic_fmtp_parse() {
 
     for (name, input, expected) in tests {
         let f = parse("generic", input);
-        assert_eq!(&expected, &f, "{} failed", name);
+        assert_eq!(&f, &expected, "{} failed", name);
 
         assert_eq!(f.mime_type(), "generic");
     }

--- a/webrtc/src/rtp_transceiver/fmtp/h264/h264_test.rs
+++ b/webrtc/src/rtp_transceiver/fmtp/h264/h264_test.rs
@@ -53,7 +53,7 @@ fn test_h264_fmtp_parse() {
 
     for (name, input, expected) in tests {
         let f = parse("video/h264", input);
-        assert_eq!(&expected, &f, "{} failed", name);
+        assert_eq!(&f, &expected, "{} failed", name);
 
         assert_eq!(f.mime_type(), "video/h264");
     }

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -59,7 +59,7 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
     let seen_packet_b_tx = Arc::new(seen_packet_b_tx);
     let on_track_count = Arc::new(AtomicU64::new(0));
     receiver.on_track(Box::new(move |track, _, _| {
-        assert_eq!(0, on_track_count.fetch_add(1, Ordering::SeqCst));
+        assert_eq!(on_track_count.fetch_add(1, Ordering::SeqCst), 0);
         let seen_packet_a_tx2 = Arc::clone(&seen_packet_a_tx);
         let seen_packet_b_tx2 = Arc::clone(&seen_packet_b_tx);
         Box::pin(async move {
@@ -135,9 +135,9 @@ async fn test_rtp_sender_get_parameters() -> Result<()> {
 
     if let Some(sender) = rtp_transceiver.sender().await {
         let parameters = sender.get_parameters().await;
-        assert_ne!(0, parameters.rtp_parameters.codecs.len());
-        assert_eq!(1, parameters.encodings.len());
-        assert_eq!(sender.ssrc, parameters.encodings[0].ssrc);
+        assert_ne!(parameters.rtp_parameters.codecs.len(), 0);
+        assert_eq!(parameters.encodings.len(), 1);
+        assert_eq!(parameters.encodings[0].ssrc, sender.ssrc);
     } else {
         assert!(false);
     }
@@ -245,7 +245,7 @@ async fn test_rtp_sender_replace_track_invalid_track_kind_change() -> Result<()>
     });
 
     if let Err(err) = rtp_sender.replace_track(Some(track_b)).await {
-        assert_eq!(Error::ErrRTPSenderNewTrackHasIncorrectKind, err);
+        assert_eq!(err, Error::ErrRTPSenderNewTrackHasIncorrectKind);
     } else {
         assert!(false);
     }
@@ -327,7 +327,7 @@ async fn test_rtp_sender_replace_track_invalid_codec_change() -> Result<()> {
     });
 
     if let Err(err) = rtp_sender.replace_track(Some(track_b)).await {
-        assert_eq!(Error::ErrUnsupportedCodec, err);
+        assert_eq!(err, Error::ErrUnsupportedCodec);
     } else {
         assert!(false);
     }

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
@@ -121,7 +121,7 @@ mod test {
         ];
 
         for (ct_str, expected_type) in tests {
-            assert_eq!(expected_type, RTCRtpTransceiverDirection::from(ct_str));
+            assert_eq!(RTCRtpTransceiverDirection::from(ct_str), expected_type);
         }
     }
 
@@ -136,7 +136,7 @@ mod test {
         ];
 
         for (d, expected_string) in tests {
-            assert_eq!(expected_string, d.to_string());
+            assert_eq!(d.to_string(), expected_string);
         }
     }
 
@@ -151,7 +151,7 @@ mod test {
         ];
 
         for (d, expected_value) in tests {
-            assert_eq!(expected_value, d.has_send());
+            assert_eq!(d.has_send(), expected_value);
         }
     }
 
@@ -166,7 +166,7 @@ mod test {
         ];
 
         for (d, expected_value) in tests {
-            assert_eq!(expected_value, d.has_recv());
+            assert_eq!(d.has_recv(), expected_value);
         }
     }
 
@@ -181,8 +181,8 @@ mod test {
 
         for (expected_value, (send, recv)) in tests {
             assert_eq!(
-                expected_value,
-                RTCRtpTransceiverDirection::from_send_recv(send, recv)
+                RTCRtpTransceiverDirection::from_send_recv(send, recv),
+                expected_value
             );
         }
     }
@@ -204,7 +204,7 @@ mod test {
         ];
 
         for ((a, b), expected_direction) in tests {
-            assert_eq!(expected_direction, a.intersect(b));
+            assert_eq!(a.intersect(b), expected_direction);
         }
     }
 }

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -30,7 +30,7 @@ async fn test_rtp_transceiver_set_codec_preferences() -> Result<()> {
     )
     .await;
 
-    assert_eq!(&media_video_codecs, &tr.get_codecs().await);
+    assert_eq!(&tr.get_codecs().await, &media_video_codecs);
 
     let fail_test_cases = vec![
         vec![RTCRtpCodecParameters {
@@ -72,7 +72,7 @@ async fn test_rtp_transceiver_set_codec_preferences() -> Result<()> {
 
     for test_case in fail_test_cases {
         if let Err(err) = tr.set_codec_preferences(test_case).await {
-            assert_eq!(Error::ErrRTPTransceiverCodecUnsupported, err);
+            assert_eq!(err, Error::ErrRTPTransceiverCodecUnsupported);
         } else {
             assert!(false);
         }

--- a/webrtc/src/sctp_transport/sctp_transport_state.rs
+++ b/webrtc/src/sctp_transport/sctp_transport_state.rs
@@ -81,8 +81,8 @@ mod test {
 
         for (state_string, expected_state) in tests {
             assert_eq!(
-                expected_state,
                 RTCSctpTransportState::from(state_string),
+                expected_state,
                 "testCase: {}",
                 expected_state,
             );
@@ -99,7 +99,7 @@ mod test {
         ];
 
         for (state, expected_string) in tests {
-            assert_eq!(expected_string, state.to_string(),)
+            assert_eq!(state.to_string(), expected_string)
         }
     }
 }

--- a/webrtc/src/track/track_local/track_local_static_test.rs
+++ b/webrtc/src/track/track_local/track_local_static_test.rs
@@ -37,7 +37,7 @@ async fn test_track_local_static_no_codec_intersection() -> Result<()> {
         pc.add_track(Arc::clone(&track)).await?;
 
         if let Err(err) = signal_pair(&mut pc, &mut no_codec_pc).await {
-            assert_eq!(Error::ErrUnsupportedCodec, err);
+            assert_eq!(err, Error::ErrUnsupportedCodec);
         } else {
             assert!(false);
         }
@@ -78,8 +78,8 @@ async fn test_track_local_static_no_codec_intersection() -> Result<()> {
 
         if let Err(err) = signal_pair(&mut vp9only_pc, &mut pc).await {
             assert_eq!(
-                Error::ErrUnsupportedCodec,
                 err,
+                Error::ErrUnsupportedCodec,
                 "expected {}, but got {}",
                 Error::ErrUnsupportedCodec,
                 err
@@ -107,7 +107,7 @@ async fn test_track_local_static_no_codec_intersection() -> Result<()> {
         offerer.add_track(Arc::new(invalid_codec_track)).await?;
 
         if let Err(err) = signal_pair(&mut offerer, &mut answerer).await {
-            assert_eq!(Error::ErrUnsupportedCodec, err);
+            assert_eq!(err, Error::ErrUnsupportedCodec);
         } else {
             assert!(false);
         }


### PR DESCRIPTION
While there isn't an explicit convention for this in Rust the stdlib docs all use `assert_eq!(actual, expected)`/`assert_ne!(actual, expected)` —as do the [Rust by Example](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) and [The Rust Programming Language](https://doc.rust-lang.org/book/ch11-01-writing-tests.html) <sup>([*](https://github.com/rust-lang/book/pull/3497))</sup> books— making it a sort of implicit convention.

The project contains over 2000 occurrences of the pattern `/assert_(ne|eq|ok|err)!/`, so this PR is clearly a best-effort attempt to unify the arg order. There are no doubt instances that I missed either due to inattentiveness after having gone through thousands of lines of code, or ambiguous argument names.