### PR TITLE
Prevent loss of initial packet(s) in RTP streams

### DIFF
--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added support for insecure/deprecated signature verification algorithms, opt in via `SettingsEngine::allow_insecure_verification_algorithm` [#342](https://github.com/webrtc-rs/webrtc/pull/342).
 * Make RTCRtpCodecCapability::payloader_for_codec public API [#349](https://github.com/webrtc-rs/webrtc/pull/349).
 * Fixed a panic in `calculate_rtt_ms` [#350](https://github.com/webrtc-rs/webrtc/pull/350).
+* Fixed `TrackRemote` missing at least the first, sometimes more, RTP packet during probing. [#387](https://github.com/webrtc-rs/webrtc/pull/387)
+
 ### Breaking changes
 
 * Change `RTCPeerConnection::on_track` callback signature to `|track: Arc<TrackRemote>, receiver: Arc<RTCRtpReceiver>, transceiver: Arc<RTCRtpTransceiver>|` [#355](https://github.com/webrtc-rs/webrtc/pull/355).

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -582,10 +582,10 @@ impl RTCDtlsTransport {
         stream_info: &StreamInfo,
         interceptor: &Arc<dyn Interceptor + Send + Sync>,
     ) -> Result<(
-        Option<Arc<srtp::stream::Stream>>,
-        Option<Arc<dyn RTPReader + Send + Sync>>,
-        Option<Arc<srtp::stream::Stream>>,
-        Option<Arc<dyn RTCPReader + Send + Sync>>,
+        Arc<srtp::stream::Stream>,
+        Arc<dyn RTPReader + Send + Sync>,
+        Arc<srtp::stream::Stream>,
+        Arc<dyn RTCPReader + Send + Sync>,
     )> {
         let srtp_session = self
             .get_srtp_session()
@@ -608,10 +608,10 @@ impl RTCDtlsTransport {
         let rtcp_interceptor = interceptor.bind_rtcp_reader(rtcp_stream_reader).await;
 
         Ok((
-            Some(rtp_read_stream),
-            Some(rtp_interceptor),
-            Some(rtcp_read_stream),
-            Some(rtcp_interceptor),
+            rtp_read_stream,
+            rtp_interceptor,
+            rtcp_read_stream,
+            rtcp_interceptor,
         ))
     }
 }

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -137,21 +137,22 @@ pub(crate) fn create_stream_info(
     codec: RTCRtpCodecCapability,
     webrtc_header_extensions: &[RTCRtpHeaderExtensionParameters],
 ) -> StreamInfo {
-    let mut header_extensions = vec![];
-    for h in webrtc_header_extensions {
-        header_extensions.push(RTPHeaderExtension {
+    let header_extensions: Vec<RTPHeaderExtension> = webrtc_header_extensions
+        .iter()
+        .map(|h| RTPHeaderExtension {
             id: h.id,
             uri: h.uri.clone(),
-        });
-    }
+        })
+        .collect();
 
-    let mut feedbacks = vec![];
-    for f in &codec.rtcp_feedback {
-        feedbacks.push(interceptor::stream_info::RTCPFeedback {
+    let feedbacks: Vec<_> = codec
+        .rtcp_feedback
+        .iter()
+        .map(|f| interceptor::stream_info::RTCPFeedback {
             typ: f.typ.clone(),
             parameter: f.parameter.clone(),
-        });
-    }
+        })
+        .collect();
 
     StreamInfo {
         id,

--- a/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -540,10 +540,10 @@ impl RTCRtpReceiver {
 
                     (
                         Some(stream_info),
-                        rtp_read_stream,
-                        rtp_interceptor,
-                        rtcp_read_stream,
-                        rtcp_interceptor,
+                        Some(rtp_read_stream),
+                        Some(rtp_interceptor),
+                        Some(rtcp_read_stream),
+                        Some(rtcp_interceptor),
                     )
                 } else {
                     (None, None, None, None, None)
@@ -600,10 +600,10 @@ impl RTCRtpReceiver {
                     "".to_owned(),
                     TrackStream {
                         stream_info: Some(stream_info),
-                        rtp_read_stream,
-                        rtp_interceptor,
-                        rtcp_read_stream,
-                        rtcp_interceptor,
+                        rtp_read_stream: Some(rtp_read_stream),
+                        rtp_interceptor: Some(rtp_interceptor),
+                        rtcp_read_stream: Some(rtcp_read_stream),
+                        rtcp_interceptor: Some(rtcp_interceptor),
                     },
                 )
                 .await?;


### PR DESCRIPTION
The method by which we detected non-signaled SSRCs would silently drop a
few packets. This is particularly problematic for a video stream since
these initial packets usually contain the first part of a keyframe to
start the stream.

See: #386 


**Note:** The first packet read for each RTP stream is not processed by interceptors unfortunately.
