### PR TITLE
Fix `SettingEngine.set_interface_filter` not working on Windows

### DIFF
--- a/util/src/ifaces/ffi/windows/mod.rs
+++ b/util/src/ifaces/ffi/windows/mod.rs
@@ -321,8 +321,8 @@ unsafe fn local_ifaces_with_buffer(buffer: &mut Vec<u8>) -> io::Result<()> {
 }
 
 /// Convert wide-char(16bit) pointer to OsString.
-/// Note: When the string length exceeds buffer_size, it will return empty.
-fn windows_pwchar_to_string(ptr: *const wchar_t, buffer_size: usize) -> OsString {
+/// Note: When the string length exceeds buffer_size or the null wide char is not found, it will return empty.
+unsafe fn windows_pwchar_to_string(ptr: *const wchar_t, buffer_size: usize) -> OsString {
     if ptr.is_null() || buffer_size == 0 {
         return OsString::new();
     }
@@ -339,6 +339,7 @@ fn windows_pwchar_to_string(ptr: *const wchar_t, buffer_size: usize) -> OsString
 
     // # SAFETY
     // Caller has provided a pointer of valid C String, And confirm the maximum length of the buffer.
+    // If the provided c string pointer is invalid, its behavior is undefined!
     // When the wcsnlen's length is equal to the buffer_size, it is considered an error, and returns empty.
     // See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strnlen-strnlen-s?view=msvc-170#return-value
     //

--- a/util/src/ifaces/ffi/windows/mod.rs
+++ b/util/src/ifaces/ffi/windows/mod.rs
@@ -319,7 +319,7 @@ unsafe fn local_ifaces_with_buffer(buffer: &mut Vec<u8>) -> io::Result<()> {
     }
 }
 
-// In windows, wchar_t is 16bit, in GUN Libc it is 32bit,
+// In windows, wchar_t is 16bit, in GNU LibC it is 32bit,
 // So in Windows, the length of both wchar_t and WCHAR is equal.
 // See https://learn.microsoft.com/en-us/cpp/cpp/char-wchar-t-char16-t-char32-t
 fn windows_pwchar_to_string(ptr: *const wchar_t) -> OsString {


### PR DESCRIPTION
I'm using `SettingEngine.set_interface_filter` and found it doesn't work on Windows.

I read `util/ifaces/ffi/windows` source code and found that the value of `Interface.name` is `"".to_string()` when initialized.

I found that the object returned after calling `GetAdaptersAddresses` contains two members `FriendlyName` and `AdapterName`, so I read the source code of Pion. It calls the standard library `net.Interfaces()` of go, and in version 1.19.4 of go, it uses `FriendlyName`.

```go
// https://cs.opensource.google/go/go/+/master:src/net/interface_windows.go;l=61
ifi := Interface{
    Index: int(index),
    Name:  windows.UTF16PtrToString(aa.FriendlyName),
}
```

So to be consistent with Pion, I also used `FriendlyName` to fix this.

In Windows, `wchar_t` and `WCHAR` are both 16bit, so I used `wcslen` and `OsString` to deal with this problem.

Currently it works fine on Windows:

```
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface vEthernet (以太网 3)
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface vEthernet (以太网)
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface 以太网 3
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface vEthernet (WSL)
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface 本地连接
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface 以太网
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface Loopback Pseudo-Interface 1
[2023-01-14T22:39:30Z INFO  webrtc_actix::engine::rtc] interface vEthernet (Default Switch)
```

I think this is a small problem, so I didn't create Issues. Thanks a lot.