### PR TITLE
sctp: fix 'attempt to add with overflow' panic in dev profile

### DIFF
--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Limit the bytes in the PendingQueue to avoid packets accumulating there uncontrollably [367](https://github.com/webrtc-rs/webrtc/pull/367).
+* Fix 'attempt to add with overflow' panic in dev profile [#393](https://github.com/webrtc-rs/webrtc/pull/393)
+* Limit the bytes in the PendingQueue to avoid packets accumulating there uncontrollably [#367](https://github.com/webrtc-rs/webrtc/pull/367).
 * Improve algorithm used to push to pending queue from O(n*log(n)) to O(log(n)) [#365](https://github.com/webrtc-rs/webrtc/pull/365).
 * Reuse as many allocations as possible when marshaling [#364](https://github.com/webrtc-rs/webrtc/pull/364).
 * The lock for the internal association was contended badly because marshaling was done while still in a critical section and also tokio was scheduling tasks badly [#363](https://github.com/webrtc-rs/webrtc/pull/363).

--- a/sctp/src/queue/reassembly_queue.rs
+++ b/sctp/src/queue/reassembly_queue.rs
@@ -267,7 +267,8 @@ impl ReassemblyQueue {
                 return Err(Error::ErrTryAgain);
             }
             if cset.ssn == self.next_ssn {
-                self.next_ssn += 1;
+                // From RFC 4960 Sec 6.5:
+                self.next_ssn = self.next_ssn.wrapping_add(1);
             }
             self.ordered.remove(0)
         } else {
@@ -314,7 +315,7 @@ impl ReassemblyQueue {
 
         // Finally, forward next_ssn
         if sna16lte(self.next_ssn, last_ssn) {
-            self.next_ssn = last_ssn + 1;
+            self.next_ssn = last_ssn.wrapping_add(1);
         }
     }
 


### PR DESCRIPTION
Fixes an unwrapped add that only affects programs compiled in the dev profile ([release profile naturally wraps](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#integer-overflow)).

This issue should not affect applications built in release, but is surprising in dev nonetheless.  As this is my first contribution, I'm not too familiar with the codebase yet.  My primary fix is on line 270, while I only suspect line 318 also qualifies. I have not reproduced this issue for 318 and not certain how to test either issue directly -- any guidance here is appreciated.

Partial stacktrace of the panic:

```
thread 'async-compat/tokio-1' panicked at 'attempt to add with overflow', /home/cscorley/.cargo/registry/src/github.com-1ecc6299db9ec823/webrtc-sctp-0.7.0/src/queue/reassembly_queue.rs:270:17
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   2: core::panicking::panic
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:115:5
   3: webrtc_sctp::queue::reassembly_queue::ReassemblyQueue::read
   4: webrtc_sctp::stream::Stream::read_sctp::{{closure}}
```