### PR TITLE
Custom `RTCRtpTransceiver` creating

### DIFF
--- a/webrtc/src/api/mod.rs
+++ b/webrtc/src/api/mod.rs
@@ -168,6 +168,14 @@ impl API {
         )
         .await
     }
+
+    pub fn setting_engine(&self) -> Arc<SettingEngine> {
+        Arc::clone(&self.setting_engine)
+    }
+
+    pub fn media_engine(&self) -> Arc<MediaEngine> {
+        Arc::clone(&self.media_engine)
+    }
 }
 
 #[derive(Default)]

--- a/webrtc/src/api/mod.rs
+++ b/webrtc/src/api/mod.rs
@@ -169,10 +169,12 @@ impl API {
         .await
     }
 
+    /// Returns the internal [`SettingEngine`].
     pub fn setting_engine(&self) -> Arc<SettingEngine> {
         Arc::clone(&self.setting_engine)
     }
 
+    /// Returns the internal [`MediaEngine`].
     pub fn media_engine(&self) -> Arc<MediaEngine> {
         Arc::clone(&self.media_engine)
     }

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -2073,4 +2073,12 @@ impl RTCPeerConnection {
 
         gathering_complete_rx
     }
+
+    pub fn dtls_transport(&self) -> Arc<RTCDtlsTransport> {
+        Arc::clone(&self.internal.dtls_transport)
+    }
+
+    pub async fn add_transceiver(&self, t: Arc<RTCRtpTransceiver>) {
+        self.internal.add_rtp_transceiver(t).await
+    }
 }

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -2074,10 +2074,12 @@ impl RTCPeerConnection {
         gathering_complete_rx
     }
 
+    /// Returns the internal [`RTCDtlsTransport`].
     pub fn dtls_transport(&self) -> Arc<RTCDtlsTransport> {
         Arc::clone(&self.internal.dtls_transport)
     }
 
+    /// Adds the specified [`RTCRtpTransceiver`] to this [`RTCPeerConnection`].
     pub async fn add_transceiver(&self, t: Arc<RTCRtpTransceiver>) {
         self.internal.add_rtp_transceiver(t).await
     }

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -191,7 +191,7 @@ pub struct RTCRtpTransceiver {
 }
 
 impl RTCRtpTransceiver {
-    pub(crate) async fn new(
+    pub async fn new(
         receiver: Arc<RTCRtpReceiver>,
         sender: Arc<RTCRtpSender>,
         direction: RTCRtpTransceiverDirection,


### PR DESCRIPTION
This PR provides API for creating custom `RTCRtpSender`, `RTCRtpReceiver` and `RTCRtpTransceiver` and adding `RTCRtpTransceiver` to `RTCPeerConnection`.