### PR TITLE
ice: Remove unused MulticastDnsMode:Unspecified variant.

### DIFF
--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-* remove non used `MulticastDnsMode::Unspecified` variant [#XXX](https://github.com/webrtc-rs/webrtc/pull/XXX):
+* remove non used `MulticastDnsMode::Unspecified` variant [#404](https://github.com/webrtc-rs/webrtc/pull/404):
 
 ## v0.9.0
 

--- a/ice/CHANGELOG.md
+++ b/ice/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+* remove non used `MulticastDnsMode::Unspecified` variant [#XXX](https://github.com/webrtc-rs/webrtc/pull/XXX):
+
 ## v0.9.0
 
 * Increased minimum support rust version to `1.60.0`.

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -125,10 +125,7 @@ impl Agent {
             return Err(Error::ErrInvalidMulticastDnshostName);
         }
 
-        let mut mdns_mode = config.multicast_dns_mode;
-        if mdns_mode == MulticastDnsMode::Unspecified {
-            mdns_mode = MulticastDnsMode::QueryOnly;
-        }
+        let mdns_mode = config.multicast_dns_mode;
 
         let mdns_conn =
             match create_multicast_dns(mdns_mode, &mdns_name, &config.multicast_dns_dest_addr) {

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -103,13 +103,7 @@ impl RTCIceGatherer {
             _ => CandidateType::Unspecified,
         };
 
-        let mut mdns_mode = self.setting_engine.candidates.multicast_dns_mode;
-        if mdns_mode != ice::mdns::MulticastDnsMode::Disabled
-            && mdns_mode != ice::mdns::MulticastDnsMode::QueryAndGather
-        {
-            // If enum is in state we don't recognized default to MulticastDNSModeQueryOnly
-            mdns_mode = ice::mdns::MulticastDnsMode::QueryOnly;
-        }
+        let mdns_mode = self.setting_engine.candidates.multicast_dns_mode;
 
         let mut config = ice::agent::agent_config::AgentConfig {
             udp_network: self.setting_engine.udp_network.clone(),


### PR DESCRIPTION
Seems to be used only for converting to `::QueryOnly`