### PR TITLE
sctp: set verification tag to zero on the INIT packet.

### DIFF
--- a/sctp/src/association/association_internal.rs
+++ b/sctp/src/association/association_internal.rs
@@ -182,7 +182,7 @@ impl AssociationInternal {
             let outbound = Packet {
                 source_port: self.source_port,
                 destination_port: self.destination_port,
-                verification_tag: self.peer_verification_tag,
+                verification_tag: 0,
                 chunks: vec![Box::new(stored_init)],
             };
 


### PR DESCRIPTION
Hi! We have been getting:
```
[2023-01-23T20:41:10Z WARN  webrtc_sctp::association::association_internal] [] failed validating packet init chunk expects a verification tag of 0 on the packet when out-of-the-blue
[2023-01-23T20:41:10Z WARN  webrtc::peer_connection::peer_connection_internal] failed to open data channel: there already exists a stream with identifier 
```
on the [test-plans](https://github.com/libp2p/test-plans/) CI for the ping interop tests between two node using the `WebRTC` transport which uses `webrtc-rs` underneath, [see here](https://github.com/libp2p/test-plans/actions/runs/3990270518/jobs/6843709448#step:11:9403) for a reproduction which then breaks the test as the node fails to open the data channel. 

While trying to debug the issue I found that when `webrtc_sctp::association::association_internal` sends the `INIT` chunk via `send_init`, the `verification_tag` was copied from `self.verification_tag`. Per the [RFC](https://www.rfc-editor.org/rfc/rfc4960#section-8.5.1) and as `check_packet` rightfully checks:

https://github.com/webrtc-rs/webrtc/blob/95f8c26007a8f6c8354cb7b56385e5619a534ba7/sctp/src/packet.rs#L225-L227

It should always be `0`.

My feeling without knowing much about the protocol nor the implementation is that sometimes `handle_init` is called first and then updates `self.verification_tag` to the received `Initiate Tag` then when calling `send_init` again `self.verification_tag` is sent with the `Initiate Tag`.
This PR tries to address by hardcoding the `verification_tag` field to `0` on the `send_init` 

Thanks
