### PR TITLE
general: apply clippy lints

### DIFF
--- a/constraints/Cargo.toml
+++ b/constraints/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-constraints"
 version = "0.1.0"
 authors = ["Vincent Esche <regexident@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of WebRTC Media Constraints API"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-constraints"

--- a/constraints/src/algorithms/fitness_distance/setting.rs
+++ b/constraints/src/algorithms/fitness_distance/setting.rs
@@ -345,10 +345,10 @@ mod tests {
 
                     let expected = 0.0;
 
-                    println!("constraint: {:?}", constraint);
-                    println!("setting: {:?}", setting);
-                    println!("actual: {:?}", actual);
-                    println!("expected: {:?}", expected);
+                    println!("constraint: {constraint:?}");
+                    println!("setting: {setting:?}");
+                    println!("actual: {actual:?}");
+                    println!("expected: {expected:?}");
 
                     assert_eq!(actual, expected);
                 }
@@ -434,10 +434,10 @@ mod tests {
 
                 let expected = 0.0;
 
-                println!("constraint: {:?}", constraint);
-                println!("setting: {:?}", setting);
-                println!("actual: {:?}", actual);
-                println!("expected: {:?}", expected);
+                println!("constraint: {constraint:?}");
+                println!("setting: {setting:?}");
+                println!("actual: {actual:?}");
+                println!("expected: {expected:?}");
 
                 assert_eq!(actual, expected);
             }

--- a/constraints/src/constraint/value.rs
+++ b/constraints/src/constraint/value.rs
@@ -197,14 +197,14 @@ where
         let mut is_first = true;
         f.write_str("(")?;
         if let Some(ref exact) = &self.exact {
-            f.write_fmt(format_args!("x == {:?}", exact))?;
+            f.write_fmt(format_args!("x == {exact:?}"))?;
             is_first = false;
         }
         if let Some(ref ideal) = &self.ideal {
             if !is_first {
                 f.write_str(" && ")?;
             }
-            f.write_fmt(format_args!("x ~= {:?}", ideal))?;
+            f.write_fmt(format_args!("x ~= {ideal:?}"))?;
             is_first = false;
         }
         if is_first {

--- a/constraints/src/constraint/value_range.rs
+++ b/constraints/src/constraint/value_range.rs
@@ -233,23 +233,23 @@ where
         let mut is_first = true;
         f.write_str("(")?;
         if let Some(exact) = &self.exact {
-            f.write_fmt(format_args!("x == {:?}", exact))?;
+            f.write_fmt(format_args!("x == {exact:?}"))?;
             is_first = false;
         } else if let (Some(min), Some(max)) = (&self.min, &self.max) {
-            f.write_fmt(format_args!("{:?} <= x <= {:?}", min, max))?;
+            f.write_fmt(format_args!("{min:?} <= x <= {max:?}"))?;
             is_first = false;
         } else if let Some(min) = &self.min {
-            f.write_fmt(format_args!("{:?} <= x", min))?;
+            f.write_fmt(format_args!("{min:?} <= x"))?;
             is_first = false;
         } else if let Some(max) = &self.max {
-            f.write_fmt(format_args!("x <= {:?}", max))?;
+            f.write_fmt(format_args!("x <= {max:?}"))?;
             is_first = false;
         }
         if let Some(ideal) = &self.ideal {
             if !is_first {
                 f.write_str(" && ")?;
             }
-            f.write_fmt(format_args!("x ~= {:?}", ideal))?;
+            f.write_fmt(format_args!("x ~= {ideal:?}"))?;
             is_first = false;
         }
         if is_first {

--- a/constraints/src/constraint/value_sequence.rs
+++ b/constraints/src/constraint/value_sequence.rs
@@ -204,14 +204,14 @@ where
         let mut is_first = true;
         f.write_str("(")?;
         if let Some(ref exact) = &self.exact {
-            f.write_fmt(format_args!("x == {:?}", exact))?;
+            f.write_fmt(format_args!("x == {exact:?}"))?;
             is_first = false;
         }
         if let Some(ref ideal) = &self.ideal {
             if !is_first {
                 f.write_str(" && ")?;
             }
-            f.write_fmt(format_args!("x ~= {:?}", ideal))?;
+            f.write_fmt(format_args!("x ~= {ideal:?}"))?;
             is_first = false;
         }
         if is_first {

--- a/constraints/src/errors.rs
+++ b/constraints/src/errors.rs
@@ -31,7 +31,7 @@ impl std::fmt::Display for OverconstrainedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Overconstrained property {:?}", self.constraint)?;
         if let Some(message) = self.message.as_ref() {
-            write!(f, ": {}", message)?;
+            write!(f, ": {message}")?;
         }
         Ok(())
     }
@@ -100,10 +100,10 @@ impl OverconstrainedError {
             [reason] => reason.clone(),
             [reasons @ .., reason] => {
                 let reasons = reasons.join(", ");
-                format!("either {}, or {}", reasons, reason)
+                format!("either {reasons}, or {reason}")
             }
         };
-        let message = Some(format!("Setting was {}.", formatted_reason));
+        let message = Some(format!("Setting was {formatted_reason}."));
 
         Self {
             constraint,

--- a/constraints/src/setting.rs
+++ b/constraints/src/setting.rs
@@ -28,10 +28,10 @@ pub enum MediaTrackSetting {
 impl std::fmt::Display for MediaTrackSetting {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Bool(setting) => f.write_fmt(format_args!("{:?}", setting)),
-            Self::Integer(setting) => f.write_fmt(format_args!("{:?}", setting)),
-            Self::Float(setting) => f.write_fmt(format_args!("{:?}", setting)),
-            Self::String(setting) => f.write_fmt(format_args!("{:?}", setting)),
+            Self::Bool(setting) => f.write_fmt(format_args!("{setting:?}")),
+            Self::Integer(setting) => f.write_fmt(format_args!("{setting:?}")),
+            Self::Float(setting) => f.write_fmt(format_args!("{setting:?}")),
+            Self::String(setting) => f.write_fmt(format_args!("{setting:?}")),
         }
     }
 }

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-data"
 version = "0.6.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of WebRTC DataChannel API"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-data"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-dtls"
 version = "0.7.0"
 authors = ["Rain Liu <yuliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of DTLS"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-dtls"

--- a/dtls/examples/dial/psk/dial_psk.rs
+++ b/dtls/examples/dial/psk/dial_psk.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Error> {
 
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     conn.connect(server).await?;
-    println!("connecting {}..", server);
+    println!("connecting {server}..");
 
     let config = Config {
         psk: Some(Arc::new(|hint: &[u8]| -> Result<Vec<u8>, Error> {

--- a/dtls/examples/dial/selfsign/dial_selfsign.rs
+++ b/dtls/examples/dial/selfsign/dial_selfsign.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Error> {
 
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     conn.connect(server).await?;
-    println!("connecting {}..", server);
+    println!("connecting {server}..");
 
     // Generate a certificate and private key to secure the connection
     let certificate = Certificate::generate_self_signed(vec!["localhost".to_owned()])?;

--- a/dtls/examples/dial/verify/dial_verify.rs
+++ b/dtls/examples/dial/verify/dial_verify.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Error> {
 
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
     conn.connect(server).await?;
-    println!("connecting {}..", server);
+    println!("connecting {server}..");
 
     let certificate = hub::utilities::load_key_and_certificate(
         "examples/certificates/client.pem.private_key.pem".into(),

--- a/dtls/examples/hub/Cargo.toml
+++ b/dtls/examples/hub/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hub"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 util = { path = "../../../util", package = "webrtc-util", default-features = false, features = [

--- a/dtls/examples/hub/src/lib.rs
+++ b/dtls/examples/hub/src/lib.rs
@@ -50,7 +50,7 @@ impl Hub {
 
         while let Ok(n) = conn.recv(&mut b).await {
             let msg = String::from_utf8(b[..n].to_vec())?;
-            print!("Got message: {}", msg);
+            print!("Got message: {msg}");
         }
 
         Hub::unregister(conns, conn).await
@@ -67,9 +67,9 @@ impl Hub {
             }
 
             if let Err(err) = conn.close().await {
-                println!("Failed to disconnect: {} with err {}", remote_addr, err);
+                println!("Failed to disconnect: {remote_addr} with err {err}");
             } else {
-                println!("Disconnected: {} ", remote_addr);
+                println!("Disconnected: {remote_addr} ");
             }
         }
 
@@ -98,7 +98,7 @@ impl Hub {
             match reader.read_line(&mut msg) {
                 Ok(0) => return,
                 Err(err) => {
-                    println!("stdin read err: {}", err);
+                    println!("stdin read err: {err}");
                     return;
                 }
                 _ => {}

--- a/dtls/examples/hub/src/utilities.rs
+++ b/dtls/examples/hub/src/utilities.rs
@@ -45,7 +45,7 @@ pub async fn chat(conn: Arc<dyn Conn + Send + Sync>) -> Result<(), Error> {
 
         while let Ok(n) = conn_rx.recv(&mut b).await {
             let msg = String::from_utf8(b[..n].to_vec()).expect("utf8");
-            print!("Got message: {}", msg);
+            print!("Got message: {msg}");
         }
 
         Result::<(), Error>::Ok(())
@@ -58,7 +58,7 @@ pub async fn chat(conn: Arc<dyn Conn + Send + Sync>) -> Result<(), Error> {
         match reader.read_line(&mut msg) {
             Ok(0) => return Ok(()),
             Err(err) => {
-                println!("stdin read err: {}", err);
+                println!("stdin read err: {err}");
                 return Ok(());
             }
             _ => {}

--- a/dtls/examples/listen/psk/listen_psk.rs
+++ b/dtls/examples/listen/psk/listen_psk.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
         ..Default::default()
     };
 
-    println!("listening {}...\ntype 'exit' to shutdown gracefully", host);
+    println!("listening {host}...\ntype 'exit' to shutdown gracefully");
 
     let listener = Arc::new(listen(host, cfg).await?);
 

--- a/dtls/examples/listen/selfsign/listen_selfsign.rs
+++ b/dtls/examples/listen/selfsign/listen_selfsign.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Error> {
         ..Default::default()
     };
 
-    println!("listening {}...\ntype 'exit' to shutdown gracefully", host);
+    println!("listening {host}...\ntype 'exit' to shutdown gracefully");
 
     let listener = Arc::new(listen(host, cfg).await?);
 

--- a/dtls/examples/listen/verify/listen_verify.rs
+++ b/dtls/examples/listen/verify/listen_verify.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Error> {
         ..Default::default()
     };
 
-    println!("listening {}...\ntype 'exit' to shutdown gracefully", host);
+    println!("listening {host}...\ntype 'exit' to shutdown gracefully");
 
     let listener = Arc::new(listen(host, cfg).await?);
 
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Error> {
                             h2.register(dtls_conn).await;
                         }
                         Err(err) => {
-                            println!("connecting failed with error: {}", err);
+                            println!("connecting failed with error: {err}");
                         }
                     }
                 }

--- a/dtls/src/alert/alert_test.rs
+++ b/dtls/src/alert/alert_test.rs
@@ -31,12 +31,11 @@ fn test_alert() -> Result<()> {
         let result = Alert::unmarshal(&mut reader);
 
         if let Some(err) = unmarshal_error {
-            assert!(result.is_err(), "{} expected error: {}", name, err);
+            assert!(result.is_err(), "{name} expected error: {err}");
         } else if let Ok(alert) = result {
             assert_eq!(
                 wanted, alert,
-                "{} expected {}, but got {}",
-                name, wanted, alert
+                "{name} expected {wanted}, but got {alert}"
             );
 
             let mut data2: Vec<u8> = vec![];
@@ -46,11 +45,10 @@ fn test_alert() -> Result<()> {
             }
             assert_eq!(
                 data, data2,
-                "{} expected {:?}, but got {:?}",
-                name, data, data2
+                "{name} expected {data:?}, but got {data2:?}"
             );
         } else {
-            assert!(result.is_ok(), "{} expected Ok, but has error", name);
+            assert!(result.is_ok(), "{name} expected Ok, but has error");
         }
     }
 

--- a/dtls/src/alert/alert_test.rs
+++ b/dtls/src/alert/alert_test.rs
@@ -33,20 +33,14 @@ fn test_alert() -> Result<()> {
         if let Some(err) = unmarshal_error {
             assert!(result.is_err(), "{name} expected error: {err}");
         } else if let Ok(alert) = result {
-            assert_eq!(
-                wanted, alert,
-                "{name} expected {wanted}, but got {alert}"
-            );
+            assert_eq!(wanted, alert, "{name} expected {wanted}, but got {alert}");
 
             let mut data2: Vec<u8> = vec![];
             {
                 let mut writer = BufWriter::<&mut Vec<u8>>::new(data2.as_mut());
                 alert.marshal(&mut writer)?;
             }
-            assert_eq!(
-                data, data2,
-                "{name} expected {data:?}, but got {data2:?}"
-            );
+            assert_eq!(data, data2, "{name} expected {data:?}, but got {data2:?}");
         } else {
             assert!(result.is_ok(), "{name} expected Ok, but has error");
         }

--- a/dtls/src/change_cipher_spec/change_cipher_spec_test.rs
+++ b/dtls/src/change_cipher_spec/change_cipher_spec_test.rs
@@ -15,8 +15,7 @@ fn test_change_cipher_spec_round_trip() -> Result<()> {
     let cnew = ChangeCipherSpec::unmarshal(&mut reader)?;
     assert_eq!(
         c, cnew,
-        "ChangeCipherSpec round trip: got {:?}, want {:?}",
-        cnew, c
+        "ChangeCipherSpec round trip: got {cnew:?}, want {c:?}"
     );
 
     Ok(())

--- a/dtls/src/conn/conn_test.rs
+++ b/dtls/src/conn/conn_test.rs
@@ -561,9 +561,7 @@ async fn test_psk() -> Result<()> {
             if let Ok(client) = result {
                 client.close().await?;
             } else {
-                panic!(
-                    "{name}: Expected create_test_client successfully, but got error",
-                );
+                panic!("{name}: Expected create_test_client successfully, but got error",);
             }
         }
 
@@ -1614,10 +1612,7 @@ async fn test_cipher_suite_configuration() -> Result<()> {
                 let client = result.unwrap();
                 if let Some(want_cs) = want_selected_cipher_suite {
                     let cipher_suite = client.state.cipher_suite.lock().await;
-                    assert!(
-                        cipher_suite.is_some(),
-                        "{name} expected some, but got none"
-                    );
+                    assert!(cipher_suite.is_some(), "{name} expected some, but got none");
                     if let Some(cs) = &*cipher_suite {
                         assert_eq!(cs.id(), want_cs,
                                    "test_cipher_suite_configuration: Server Selected Bad Cipher Suite '{}': expected({}) actual({})", 

--- a/dtls/src/conn/conn_test.rs
+++ b/dtls/src/conn/conn_test.rs
@@ -363,13 +363,10 @@ async fn test_handshake_with_alert() -> Result<()> {
             assert_eq!(
                 err.to_string(),
                 err_server.to_string(),
-                "{} Server error exp({}) failed({})",
-                name,
-                err_server,
-                err
+                "{name} Server error exp({err_server}) failed({err})"
             );
         } else {
-            panic!("{} expected error but create_test_server return OK", name);
+            panic!("{name} expected error but create_test_server return OK");
         }
 
         let result_client = client_err_rx.recv().await;
@@ -378,13 +375,10 @@ async fn test_handshake_with_alert() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     err_client.to_string(),
-                    "{} Client error exp({}) failed({})",
-                    name,
-                    err_client,
-                    err
+                    "{name} Client error exp({err_client}) failed({err})"
                 );
             } else {
-                panic!("{} expected error but create_test_client return OK", name);
+                panic!("{name} expected error but create_test_client return OK");
             }
         }
     }
@@ -560,8 +554,7 @@ async fn test_psk() -> Result<()> {
         let actual_psk_identity_hint = &server.connection_state().await.identity_hint;
         assert_eq!(
             actual_psk_identity_hint, client_identity,
-            "TestPSK: Server ClientPSKIdentity Mismatch '{}': expected({:?}) actual({:?})",
-            name, client_identity, actual_psk_identity_hint,
+            "TestPSK: Server ClientPSKIdentity Mismatch '{name}': expected({client_identity:?}) actual({actual_psk_identity_hint:?})",
         );
 
         if let Some(result) = client_res_rx.recv().await {
@@ -569,8 +562,7 @@ async fn test_psk() -> Result<()> {
                 client.close().await?;
             } else {
                 panic!(
-                    "{}: Expected create_test_client successfully, but got error",
-                    name,
+                    "{name}: Expected create_test_client successfully, but got error",
                 );
             }
         }
@@ -637,9 +629,7 @@ async fn test_psk_hint_fail() -> Result<()> {
         if let Err(client_err) = client {
             assert!(
                 client_err.to_string().contains(ERR_PSK_REJECTED),
-                "TestPSK: Client error exp({}) failed({})",
-                ERR_PSK_REJECTED,
-                client_err,
+                "TestPSK: Client error exp({ERR_PSK_REJECTED}) failed({client_err})",
             );
         } else {
             panic!("Expected client error, but got OK");
@@ -804,24 +794,20 @@ async fn test_srtp_configuration() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     expected_err.to_string(),
-                    "{} TestPSK: Server error exp({}) failed({})",
-                    name,
-                    expected_err,
-                    err,
+                    "{name} TestPSK: Server error exp({expected_err}) failed({err})",
                 );
             } else {
-                panic!("{} expected error, but got ok", name);
+                panic!("{name} expected error, but got ok");
             }
         } else {
             match result {
                 Ok(server) => {
                     let actual_server_srtp = server.selected_srtpprotection_profile();
                     assert_eq!(actual_server_srtp, expected_profile,
-                               "test_srtp_configuration: Server SRTPProtectionProfile Mismatch '{}': expected({:?}) actual({:?})",
-                               name, expected_profile, actual_server_srtp);
+                               "test_srtp_configuration: Server SRTPProtectionProfile Mismatch '{name}': expected({expected_profile:?}) actual({actual_server_srtp:?})");
                 }
                 Err(err) => {
-                    panic!("{} expected no error: {}", name, err);
+                    panic!("{name} expected no error: {err}");
                 }
             };
         }
@@ -833,23 +819,20 @@ async fn test_srtp_configuration() -> Result<()> {
                     assert_eq!(
                         err.to_string(),
                         expected_err.to_string(),
-                        "TestPSK: Client error exp({}) failed({})",
-                        expected_err,
-                        err,
+                        "TestPSK: Client error exp({expected_err}) failed({err})",
                     );
                 } else {
-                    panic!("{} expected error, but got ok", name);
+                    panic!("{name} expected error, but got ok");
                 }
             } else if let Ok(client) = result {
                 let actual_client_srtp = client.selected_srtpprotection_profile();
                 assert_eq!(actual_client_srtp, expected_profile,
-                           "test_srtp_configuration: Client SRTPProtectionProfile Mismatch '{}': expected({:?}) actual({:?})",
-                           name, expected_profile, actual_client_srtp);
+                           "test_srtp_configuration: Client SRTPProtectionProfile Mismatch '{name}': expected({expected_profile:?}) actual({actual_client_srtp:?})");
             } else {
-                panic!("{} expected no error", name);
+                panic!("{name} expected no error");
             }
         } else {
-            panic!("{} expected client, but got none", name);
+            panic!("{name} expected client, but got none");
         }
     }
 
@@ -1055,7 +1038,7 @@ async fn test_client_certificate() -> Result<()> {
             if result.is_err() {
                 continue;
             }
-            panic!("{} Error expected", name);
+            panic!("{name} Error expected");
         }
 
         assert!(
@@ -1064,7 +1047,7 @@ async fn test_client_certificate() -> Result<()> {
             name,
             result.err().unwrap()
         );
-        assert!(client_result.is_some(), "{}, expected client conn", name);
+        assert!(client_result.is_some(), "{name}, expected client conn");
 
         let res = client_result.unwrap();
         assert!(
@@ -1083,31 +1066,27 @@ async fn test_client_certificate() -> Result<()> {
         {
             assert!(
                 !actual_client_cert.is_empty(),
-                "{} Client did not provide a certificate",
-                name,
+                "{name} Client did not provide a certificate",
             );
             //if actual_client_cert.len() != len(tt.clientCfg.Certificates[0].Certificate) || !bytes.Equal(tt.clientCfg.Certificates[0].Certificate[0], actual_client_cert[0]) {
             assert_eq!(
                 actual_client_cert[0],
                 client_cfg.certificates[0].certificate[0].as_ref(),
-                "{} Client certificate was not communicated correctly",
-                name,
+                "{name} Client certificate was not communicated correctly",
             );
         }
 
         if server_cfg.client_auth == ClientAuthType::NoClientCert {
             assert!(
                 actual_client_cert.is_empty(),
-                "{} Client certificate wasn't expected",
-                name,
+                "{name} Client certificate wasn't expected",
             );
         }
 
         let actual_server_cert = &client.connection_state().await.peer_certificates;
         assert!(
             !actual_server_cert.is_empty(),
-            "{} Server did not provide a certificate",
-            name,
+            "{name} Server did not provide a certificate",
         );
 
         /*if len(actual_server_cert) != len(tt.serverCfg.Certificates[0].Certificate)
@@ -1118,14 +1097,12 @@ async fn test_client_certificate() -> Result<()> {
         assert_eq!(
             actual_server_cert[0].len(),
             server_cfg.certificates[0].certificate[0].as_ref().len(),
-            "{} Server certificate was not communicated correctly",
-            name,
+            "{name} Server certificate was not communicated correctly",
         );
         assert_eq!(
             actual_server_cert[0],
             server_cfg.certificates[0].certificate[0].as_ref(),
-            "{} Server certificate was not communicated correctly",
-            name,
+            "{name} Server certificate was not communicated correctly",
         );
     }
 
@@ -1280,7 +1257,7 @@ async fn test_extended_master_secret() -> Result<()> {
 
         let result = create_test_server(Arc::new(cb), server_cfg.clone(), true).await;
         let client_result = client_res_rx.recv().await;
-        assert!(client_result.is_some(), "{}, expected client conn", name);
+        assert!(client_result.is_some(), "{name}, expected client conn");
         let res = client_result.unwrap();
 
         if let Some(client_err) = expected_client_err {
@@ -1288,15 +1265,13 @@ async fn test_extended_master_secret() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     client_err.to_string(),
-                    "Client error expected: \"{}\" but got \"{}\"",
-                    client_err,
-                    err,
+                    "Client error expected: \"{client_err}\" but got \"{err}\"",
                 );
             } else {
-                panic!("{} expected err, but got ok", name);
+                panic!("{name} expected err, but got ok");
             }
         } else {
-            assert!(res.is_ok(), "{} expected ok, but got err", name);
+            assert!(res.is_ok(), "{name} expected ok, but got err");
         }
 
         if let Some(server_err) = expected_server_err {
@@ -1304,15 +1279,13 @@ async fn test_extended_master_secret() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     server_err.to_string(),
-                    "Server error expected: \"{}\" but got \"{}\"",
-                    server_err,
-                    err,
+                    "Server error expected: \"{server_err}\" but got \"{err}\"",
                 );
             } else {
-                panic!("{} expected err, but got ok", name);
+                panic!("{name} expected err, but got ok");
             }
         } else {
-            assert!(result.is_ok(), "{} expected ok, but got err", name);
+            assert!(result.is_ok(), "{name} expected ok, but got err");
         }
     }
 
@@ -1496,7 +1469,7 @@ async fn test_server_certificate() -> Result<()> {
             panic!("{}: Client failed({})", name, cli_result.err().unwrap());
         }
         if want_err && cli_result.is_ok() {
-            panic!("{}: Error expected", name);
+            panic!("{name}: Error expected");
         }
 
         let _ = res_rx.recv().await;
@@ -1615,16 +1588,13 @@ async fn test_cipher_suite_configuration() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     expected_err.to_string(),
-                    "{} test_cipher_suite_configuration: Server error exp({}) failed({})",
-                    name,
-                    expected_err,
-                    err,
+                    "{name} test_cipher_suite_configuration: Server error exp({expected_err}) failed({err})",
                 );
             } else {
-                panic!("{} expected error, but got ok", name);
+                panic!("{name} expected error, but got ok");
             }
         } else {
-            assert!(result.is_ok(), "{} expected ok, but got error", name)
+            assert!(result.is_ok(), "{name} expected ok, but got error")
         }
 
         let client_result = client_res_rx.recv().await;
@@ -1634,23 +1604,19 @@ async fn test_cipher_suite_configuration() -> Result<()> {
                     assert_eq!(
                         err.to_string(),
                         expected_err.to_string(),
-                        "{} test_cipher_suite_configuration: Client error exp({}) failed({})",
-                        name,
-                        expected_err,
-                        err,
+                        "{name} test_cipher_suite_configuration: Client error exp({expected_err}) failed({err})",
                     );
                 } else {
-                    panic!("{} expected error, but got ok", name);
+                    panic!("{name} expected error, but got ok");
                 }
             } else {
-                assert!(result.is_ok(), "{} expected ok, but got error", name);
+                assert!(result.is_ok(), "{name} expected ok, but got error");
                 let client = result.unwrap();
                 if let Some(want_cs) = want_selected_cipher_suite {
                     let cipher_suite = client.state.cipher_suite.lock().await;
                     assert!(
                         cipher_suite.is_some(),
-                        "{} expected some, but got none",
-                        name
+                        "{name} expected some, but got none"
                     );
                     if let Some(cs) = &*cipher_suite {
                         assert_eq!(cs.id(), want_cs,
@@ -1660,7 +1626,7 @@ async fn test_cipher_suite_configuration() -> Result<()> {
                 }
             }
         } else {
-            panic!("{} expected Some, but got None", name);
+            panic!("{name} expected Some, but got None");
         }
     }
 
@@ -1780,16 +1746,13 @@ async fn test_psk_configuration() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     expected_err.to_string(),
-                    "{} test_psk_configuration: Server error exp({}) failed({})",
-                    name,
-                    expected_err,
-                    err,
+                    "{name} test_psk_configuration: Server error exp({expected_err}) failed({err})",
                 );
             } else {
-                panic!("{} expected error, but got ok", name);
+                panic!("{name} expected error, but got ok");
             }
         } else {
-            assert!(result.is_ok(), "{} expected ok, but got error", name)
+            assert!(result.is_ok(), "{name} expected ok, but got error")
         }
 
         let client_result = client_res_rx.recv().await;
@@ -1799,19 +1762,16 @@ async fn test_psk_configuration() -> Result<()> {
                     assert_eq!(
                         err.to_string(),
                         expected_err.to_string(),
-                        "{} test_psk_configuration: Client error exp({}) failed({})",
-                        name,
-                        expected_err,
-                        err,
+                        "{name} test_psk_configuration: Client error exp({expected_err}) failed({err})",
                     );
                 } else {
-                    panic!("{} expected error, but got ok", name);
+                    panic!("{name} expected error, but got ok");
                 }
             } else {
-                assert!(result.is_ok(), "{} expected ok, but got error", name);
+                assert!(result.is_ok(), "{name} expected ok, but got error");
             }
         } else {
-            panic!("{} expected Some, but got None", name);
+            panic!("{name} expected Some, but got None");
         }
     }
 
@@ -2105,11 +2065,11 @@ async fn test_protocol_version_validation() -> Result<()> {
                                 err,
                             );
                         } else {
-                            panic!("{} expected error, but got ok", name);
+                            panic!("{name} expected error, but got ok");
                         }
                     }
                     Err(err) => {
-                        panic!("server timeout {}", err);
+                        panic!("server timeout {err}");
                     }
                 };
             });
@@ -2245,11 +2205,11 @@ async fn test_protocol_version_validation() -> Result<()> {
                                 err,
                             );
                         } else {
-                            panic!("{} expected error, but got ok", name);
+                            panic!("{name} expected error, but got ok");
                         }
                     }
                     Err(err) => {
-                        panic!("server timeout {}", err);
+                        panic!("server timeout {err}");
                     }
                 };
             });
@@ -2491,8 +2451,7 @@ async fn test_renegotation_info() -> Result<()> {
 
         assert!(
             got_negotation_info,
-            "{}: Received ServerHello without RenegotiationInfo",
-            name
+            "{name}: Received ServerHello without RenegotiationInfo"
         );
 
         ca.close().await?;

--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -1052,7 +1052,7 @@ impl DTLSConn {
                 return (
                     false,
                     Some(a),
-                    Some(Error::Other(format!("Error of Alert {}", a))),
+                    Some(Error::Other(format!("Error of Alert {a}"))),
                 );
             }
             Content::ChangeCipherSpec(_) => {

--- a/dtls/src/crypto/crypto_test.rs
+++ b/dtls/src/crypto/crypto_test.rs
@@ -98,8 +98,7 @@ fn test_generate_key_signature() -> Result<()> {
 
     assert_eq!(
         signature, expected_signature,
-        "Signature generation failed \nexp {:?} \nactual {:?} ",
-        expected_signature, signature
+        "Signature generation failed \nexp {expected_signature:?} \nactual {signature:?} "
     );
 
     Ok(())

--- a/dtls/src/crypto/mod.rs
+++ b/dtls/src/crypto/mod.rs
@@ -77,7 +77,7 @@ impl Certificate {
         }
 
         let keypair = rcgen::KeyPair::from_der(&pems[0].contents)
-            .map_err(|e| Error::InvalidPEM(format!("can't decode keypair: {}", e)))?;
+            .map_err(|e| Error::InvalidPEM(format!("can't decode keypair: {e}")))?;
 
         let mut rustls_certs = Vec::new();
         for p in pems.drain(1..) {

--- a/dtls/src/extension/extension_server_name/extension_server_name_test.rs
+++ b/dtls/src/extension/extension_server_name/extension_server_name_test.rs
@@ -19,8 +19,7 @@ fn test_extension_server_name() -> Result<()> {
 
     assert_eq!(
         new_extension, extension,
-        "extensionServerName marshal: got {:?} expected {:?}",
-        new_extension, extension,
+        "extensionServerName marshal: got {new_extension:?} expected {extension:?}",
     );
 
     Ok(())

--- a/dtls/src/extension/extension_supported_elliptic_curves/extension_supported_elliptic_curves_test.rs
+++ b/dtls/src/extension/extension_supported_elliptic_curves/extension_supported_elliptic_curves_test.rs
@@ -17,8 +17,7 @@ fn test_extension_supported_groups() -> Result<()> {
 
     assert_eq!(
         raw, raw_supported_groups,
-        "extensionSupportedGroups marshal: got {:?}, want {:?}",
-        raw, raw_supported_groups
+        "extensionSupportedGroups marshal: got {raw:?}, want {raw_supported_groups:?}"
     );
 
     let mut reader = BufReader::new(raw.as_slice());
@@ -26,8 +25,7 @@ fn test_extension_supported_groups() -> Result<()> {
 
     assert_eq!(
         new_supported_groups, parsed_supported_groups,
-        "extensionSupportedGroups unmarshal: got {:?}, want {:?}",
-        new_supported_groups, parsed_supported_groups
+        "extensionSupportedGroups unmarshal: got {new_supported_groups:?}, want {parsed_supported_groups:?}"
     );
 
     Ok(())

--- a/dtls/src/extension/extension_supported_point_formats/extension_supported_point_formats_test.rs
+++ b/dtls/src/extension/extension_supported_point_formats/extension_supported_point_formats_test.rs
@@ -17,8 +17,7 @@ fn test_extension_supported_point_formats() -> Result<()> {
 
     assert_eq!(
         raw, raw_extension_supported_point_formats,
-        "extensionSupportedPointFormats marshal: got {:?}, want {:?}",
-        raw, raw_extension_supported_point_formats
+        "extensionSupportedPointFormats marshal: got {raw:?}, want {raw_extension_supported_point_formats:?}"
     );
 
     let mut reader = BufReader::new(raw.as_slice());
@@ -27,8 +26,7 @@ fn test_extension_supported_point_formats() -> Result<()> {
 
     assert_eq!(
         new_extension_supported_point_formats, parsed_extension_supported_point_formats,
-        "extensionSupportedPointFormats unmarshal: got {:?}, want {:?}",
-        new_extension_supported_point_formats, parsed_extension_supported_point_formats
+        "extensionSupportedPointFormats unmarshal: got {new_extension_supported_point_formats:?}, want {parsed_extension_supported_point_formats:?}"
     );
 
     Ok(())

--- a/dtls/src/extension/extension_supported_signature_algorithms/extension_supported_signature_algorithms_test.rs
+++ b/dtls/src/extension/extension_supported_signature_algorithms/extension_supported_signature_algorithms_test.rs
@@ -31,8 +31,7 @@ fn test_extension_supported_signature_algorithms() -> Result<()> {
 
     assert_eq!(
         raw, raw_extension_supported_signature_algorithms,
-        "extensionSupportedSignatureAlgorithms marshal: got {:?}, want {:?}",
-        raw, raw_extension_supported_signature_algorithms
+        "extensionSupportedSignatureAlgorithms marshal: got {raw:?}, want {raw_extension_supported_signature_algorithms:?}"
     );
 
     let mut reader = BufReader::new(raw.as_slice());
@@ -42,9 +41,7 @@ fn test_extension_supported_signature_algorithms() -> Result<()> {
     assert_eq!(
         new_extension_supported_signature_algorithms,
         parsed_extension_supported_signature_algorithms,
-        "extensionSupportedSignatureAlgorithms unmarshal: got {:?}, want {:?}",
-        new_extension_supported_signature_algorithms,
-        parsed_extension_supported_signature_algorithms
+        "extensionSupportedSignatureAlgorithms unmarshal: got {new_extension_supported_signature_algorithms:?}, want {parsed_extension_supported_signature_algorithms:?}"
     );
 
     Ok(())

--- a/dtls/src/extension/extension_use_extended_master_secret/extension_use_extended_master_secret_test.rs
+++ b/dtls/src/extension/extension_use_extended_master_secret/extension_use_extended_master_secret_test.rs
@@ -16,8 +16,7 @@ fn test_extension_use_extended_master_secret() -> Result<()> {
 
     assert_eq!(
         raw, raw_extension_use_extended_master_secret,
-        "extension_use_extended_master_secret marshal: got {:?}, want {:?}",
-        raw, raw_extension_use_extended_master_secret
+        "extension_use_extended_master_secret marshal: got {raw:?}, want {raw_extension_use_extended_master_secret:?}"
     );
 
     let mut reader = BufReader::new(raw.as_slice());
@@ -26,8 +25,7 @@ fn test_extension_use_extended_master_secret() -> Result<()> {
 
     assert_eq!(
         new_extension_use_extended_master_secret, parsed_extension_use_extended_master_secret,
-        "extension_use_extended_master_secret unmarshal: got {:?}, want {:?}",
-        new_extension_use_extended_master_secret, parsed_extension_use_extended_master_secret
+        "extension_use_extended_master_secret unmarshal: got {new_extension_use_extended_master_secret:?}, want {parsed_extension_use_extended_master_secret:?}"
     );
 
     Ok(())

--- a/dtls/src/extension/extension_use_srtp/extension_use_srtp_test.rs
+++ b/dtls/src/extension/extension_use_srtp/extension_use_srtp_test.rs
@@ -17,8 +17,7 @@ fn test_extension_use_srtp() -> Result<()> {
 
     assert_eq!(
         raw, raw_use_srtp,
-        "extensionUseSRTP marshal: got {:?}, want {:?}",
-        raw, raw_use_srtp
+        "extensionUseSRTP marshal: got {raw:?}, want {raw_use_srtp:?}"
     );
 
     let mut reader = BufReader::new(raw.as_slice());
@@ -26,8 +25,7 @@ fn test_extension_use_srtp() -> Result<()> {
 
     assert_eq!(
         new_use_srtp, parsed_use_srtp,
-        "extensionUseSRTP unmarshal: got {:?}, want {:?}",
-        new_use_srtp, parsed_use_srtp
+        "extensionUseSRTP unmarshal: got {new_use_srtp:?}, want {parsed_use_srtp:?}"
     );
 
     Ok(())

--- a/dtls/src/fragment_buffer/fragment_buffer_test.rs
+++ b/dtls/src/fragment_buffer/fragment_buffer_test.rs
@@ -126,8 +126,7 @@ fn test_fragment_buffer() -> Result<()> {
             let status = fragment_buffer.push(&frag)?;
             assert!(
                 status,
-                "fragment_buffer didn't accept fragments for '{}'",
-                name
+                "fragment_buffer didn't accept fragments for '{name}'"
             );
         }
 
@@ -135,22 +134,19 @@ fn test_fragment_buffer() -> Result<()> {
             let (out, epoch) = fragment_buffer.pop()?;
             assert_eq!(
                 out, expected,
-                "fragment_buffer '{}' push/pop: got {:?}, want {:?}",
-                name, out, expected
+                "fragment_buffer '{name}' push/pop: got {out:?}, want {expected:?}"
             );
 
             assert_eq!(
                 epoch, expected_epoch,
-                "fragment_buffer returned wrong epoch: got {}, want {}",
-                epoch, expected_epoch
+                "fragment_buffer returned wrong epoch: got {epoch}, want {expected_epoch}"
             );
         }
 
         let result = fragment_buffer.pop();
         assert!(
             result.is_err(),
-            "fragment_buffer popped single buffer multiple times for '{}'",
-            name
+            "fragment_buffer popped single buffer multiple times for '{name}'"
         );
     }
 

--- a/dtls/src/handshake/handshake_cache/handshake_cache_test.rs
+++ b/dtls/src/handshake/handshake_cache/handshake_cache_test.rs
@@ -328,8 +328,7 @@ async fn test_handshake_cache_single_push() -> Result<()> {
         let verify_data = h.pull_and_merge(&rules).await;
         assert_eq!(
             verify_data, expected,
-            "handshakeCache '{}' exp:{:?} actual {:?}",
-            name, expected, verify_data,
+            "handshakeCache '{name}' exp:{expected:?} actual {verify_data:?}",
         );
     }
 
@@ -651,8 +650,7 @@ async fn test_handshake_cache_session_hash() -> Result<()> {
 
         assert_eq!(
             verify_data, expected,
-            "handshakeCacheSesssionHassh '{}' exp: {:?} actual {:?}",
-            name, expected, verify_data
+            "handshakeCacheSesssionHassh '{name}' exp: {expected:?} actual {verify_data:?}"
         );
     }
 

--- a/dtls/src/handshake/handshake_message_certificate/handshake_message_certificate_test.rs
+++ b/dtls/src/handshake/handshake_message_certificate/handshake_message_certificate_test.rs
@@ -53,8 +53,7 @@ fn test_handshake_message_certificate() -> Result<()> {
     }
     assert_eq!(
         raw, raw_certificate,
-        "handshakeMessageCertificate marshal: got {:?}, want {:?}",
-        raw, raw_certificate
+        "handshakeMessageCertificate marshal: got {raw:?}, want {raw_certificate:?}"
     );
 
     Ok(())
@@ -73,8 +72,7 @@ fn test_empty_handshake_message_certificate() -> Result<()> {
 
     assert_eq!(
         c, expected_certificate,
-        "handshakeMessageCertificate unmarshal: got {:?}, want {:?}",
-        c, expected_certificate,
+        "handshakeMessageCertificate unmarshal: got {c:?}, want {expected_certificate:?}",
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_certificate_request/handshake_message_certificate_request_test.rs
+++ b/dtls/src/handshake/handshake_message_certificate_request/handshake_message_certificate_request_test.rs
@@ -47,8 +47,7 @@ fn test_handshake_message_certificate_request() -> Result<()> {
     let c = HandshakeMessageCertificateRequest::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_certificate_request,
-        "parsedCertificateRequest unmarshal: got {:?}, want {:?}",
-        c, parsed_certificate_request
+        "parsedCertificateRequest unmarshal: got {c:?}, want {parsed_certificate_request:?}"
     );
 
     let mut raw = vec![];
@@ -58,8 +57,7 @@ fn test_handshake_message_certificate_request() -> Result<()> {
     }
     assert_eq!(
         raw, raw_certificate_request,
-        "parsedCertificateRequest marshal: got {:?}, want {:?}",
-        raw, raw_certificate_request
+        "parsedCertificateRequest marshal: got {raw:?}, want {raw_certificate_request:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_certificate_verify/handshake_message_certificate_verify_test.rs
+++ b/dtls/src/handshake/handshake_message_certificate_verify/handshake_message_certificate_verify_test.rs
@@ -23,8 +23,7 @@ fn test_handshake_message_certificate_request() -> Result<()> {
     let c = HandshakeMessageCertificateVerify::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_certificate_verify,
-        "handshakeMessageCertificate unmarshal: got {:?}, want {:?}",
-        c, parsed_certificate_verify
+        "handshakeMessageCertificate unmarshal: got {c:?}, want {parsed_certificate_verify:?}"
     );
 
     let mut raw = vec![];
@@ -34,8 +33,7 @@ fn test_handshake_message_certificate_request() -> Result<()> {
     }
     assert_eq!(
         raw, raw_certificate_verify,
-        "handshakeMessageCertificateVerify marshal: got {:?}, want {:?}",
-        raw, raw_certificate_verify
+        "handshakeMessageCertificateVerify marshal: got {raw:?}, want {raw_certificate_verify:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_client_hello.rs
+++ b/dtls/src/handshake/handshake_message_client_hello.rs
@@ -62,7 +62,7 @@ impl fmt::Debug for HandshakeMessageClientHello {
         let s = vec![
             format!("version: {:?} random: {:?}", self.version, self.random),
             format!("cookie: {:?}", self.cookie),
-            format!("cipher_suites: {:?}", cipher_suites_str),
+            format!("cipher_suites: {cipher_suites_str:?}"),
             format!("compression_methods: {:?}", self.compression_methods),
             format!("extensions: {:?}", self.extensions),
         ];

--- a/dtls/src/handshake/handshake_message_client_hello/handshake_message_client_hello_test.rs
+++ b/dtls/src/handshake/handshake_message_client_hello/handshake_message_client_hello_test.rs
@@ -58,8 +58,7 @@ fn test_handshake_message_client_hello() -> Result<()> {
     let c = HandshakeMessageClientHello::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_client_hello,
-        "handshakeMessageClientHello unmarshal: got {:?}, want {:?}",
-        c, parsed_client_hello
+        "handshakeMessageClientHello unmarshal: got {c:?}, want {parsed_client_hello:?}"
     );
 
     let mut raw = vec![];
@@ -69,8 +68,7 @@ fn test_handshake_message_client_hello() -> Result<()> {
     }
     assert_eq!(
         raw, raw_client_hello,
-        "handshakeMessageClientHello marshal: got {:?}, want {:?}",
-        raw, raw_client_hello
+        "handshakeMessageClientHello marshal: got {raw:?}, want {raw_client_hello:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_client_key_exchange/handshake_message_client_key_exchange_test.rs
+++ b/dtls/src/handshake/handshake_message_client_key_exchange/handshake_message_client_key_exchange_test.rs
@@ -18,8 +18,7 @@ fn test_handshake_message_client_key_exchange() -> Result<()> {
     let c = HandshakeMessageClientKeyExchange::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_client_key_exchange,
-        "parsedCertificateRequest unmarshal: got {:?}, want {:?}",
-        c, parsed_client_key_exchange
+        "parsedCertificateRequest unmarshal: got {c:?}, want {parsed_client_key_exchange:?}"
     );
 
     let mut raw = vec![];
@@ -29,8 +28,7 @@ fn test_handshake_message_client_key_exchange() -> Result<()> {
     }
     assert_eq!(
         raw, raw_client_key_exchange,
-        "handshakeMessageClientKeyExchange marshal: got {:?}, want {:?}",
-        raw, raw_client_key_exchange
+        "handshakeMessageClientKeyExchange marshal: got {raw:?}, want {raw_client_key_exchange:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_finished/handshake_message_finished_test.rs
+++ b/dtls/src/handshake/handshake_message_finished/handshake_message_finished_test.rs
@@ -15,8 +15,7 @@ fn test_handshake_message_finished() -> Result<()> {
     let c = HandshakeMessageFinished::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_finished,
-        "handshakeMessageFinished unmarshal: got {:?}, want {:?}",
-        c, parsed_finished
+        "handshakeMessageFinished unmarshal: got {c:?}, want {parsed_finished:?}"
     );
 
     let mut raw = vec![];
@@ -26,8 +25,7 @@ fn test_handshake_message_finished() -> Result<()> {
     }
     assert_eq!(
         raw, raw_finished,
-        "handshakeMessageFinished marshal: got {:?}, want {:?}",
-        raw, raw_finished
+        "handshakeMessageFinished marshal: got {raw:?}, want {raw_finished:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_hello_verify_request/handshake_message_hello_verify_request_test.rs
+++ b/dtls/src/handshake/handshake_message_hello_verify_request/handshake_message_hello_verify_request_test.rs
@@ -23,8 +23,7 @@ fn test_handshake_message_hello_verify_request() -> Result<()> {
     let c = HandshakeMessageHelloVerifyRequest::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_hello_verify_request,
-        "parsed_hello_verify_request unmarshal: got {:?}, want {:?}",
-        c, parsed_hello_verify_request
+        "parsed_hello_verify_request unmarshal: got {c:?}, want {parsed_hello_verify_request:?}"
     );
 
     let mut raw = vec![];
@@ -34,8 +33,7 @@ fn test_handshake_message_hello_verify_request() -> Result<()> {
     }
     assert_eq!(
         raw, raw_hello_verify_request,
-        "parsed_hello_verify_request marshal: got {:?}, want {:?}",
-        raw, raw_hello_verify_request
+        "parsed_hello_verify_request marshal: got {raw:?}, want {raw_hello_verify_request:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_server_hello/handshake_message_server_hello_test.rs
+++ b/dtls/src/handshake/handshake_message_server_hello/handshake_message_server_hello_test.rs
@@ -39,8 +39,7 @@ fn test_handshake_message_server_hello() -> Result<()> {
     let c = HandshakeMessageServerHello::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_server_hello,
-        "handshakeMessageServerHello unmarshal: got {:?}, want {:?}",
-        c, parsed_server_hello
+        "handshakeMessageServerHello unmarshal: got {c:?}, want {parsed_server_hello:?}"
     );
 
     let mut raw = vec![];
@@ -50,8 +49,7 @@ fn test_handshake_message_server_hello() -> Result<()> {
     }
     assert_eq!(
         raw, raw_server_hello,
-        "handshakeMessageServerHello marshal: got {:?}, want {:?}",
-        raw, raw_server_hello
+        "handshakeMessageServerHello marshal: got {raw:?}, want {raw_server_hello:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_server_hello_done/handshake_message_server_hello_done_test.rs
+++ b/dtls/src/handshake/handshake_message_server_hello_done/handshake_message_server_hello_done_test.rs
@@ -11,8 +11,7 @@ fn test_handshake_message_server_hello_done() -> Result<()> {
     let c = HandshakeMessageServerHelloDone::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_server_hello_done,
-        "handshakeMessageServerHelloDone unmarshal: got {:?}, want {:?}",
-        c, parsed_server_hello_done
+        "handshakeMessageServerHelloDone unmarshal: got {c:?}, want {parsed_server_hello_done:?}"
     );
 
     let mut raw = vec![];
@@ -22,8 +21,7 @@ fn test_handshake_message_server_hello_done() -> Result<()> {
     }
     assert_eq!(
         raw, raw_server_hello_done,
-        "handshakeMessageServerHelloDone marshal: got {:?}, want {:?}",
-        raw, raw_server_hello_done
+        "handshakeMessageServerHelloDone marshal: got {raw:?}, want {raw_server_hello_done:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_message_server_key_exchange/handshake_message_server_key_exchange_test.rs
+++ b/dtls/src/handshake/handshake_message_server_key_exchange/handshake_message_server_key_exchange_test.rs
@@ -33,8 +33,7 @@ fn test_handshake_message_server_key_exchange() -> Result<()> {
     let c = HandshakeMessageServerKeyExchange::unmarshal(&mut reader)?;
     assert_eq!(
         c, parsed_server_key_exchange,
-        "handshakeMessageServerKeyExchange unmarshal: got {:?}, want {:?}",
-        c, parsed_server_key_exchange
+        "handshakeMessageServerKeyExchange unmarshal: got {c:?}, want {parsed_server_key_exchange:?}"
     );
 
     let mut raw = vec![];
@@ -44,8 +43,7 @@ fn test_handshake_message_server_key_exchange() -> Result<()> {
     }
     assert_eq!(
         raw, raw_server_key_exchange,
-        "handshakeMessageServerKeyExchange marshal: got {:?}, want {:?}",
-        raw, raw_server_key_exchange
+        "handshakeMessageServerKeyExchange marshal: got {raw:?}, want {raw_server_key_exchange:?}"
     );
 
     Ok(())

--- a/dtls/src/handshake/handshake_test.rs
+++ b/dtls/src/handshake/handshake_test.rs
@@ -54,8 +54,7 @@ fn test_handshake_message() -> Result<()> {
     let h = Handshake::unmarshal(&mut reader)?;
     assert_eq!(
         h, parsed_handshake,
-        "handshakeMessageClientHello unmarshal: got {:?}, want {:?}",
-        h, parsed_handshake
+        "handshakeMessageClientHello unmarshal: got {h:?}, want {parsed_handshake:?}"
     );
 
     let mut raw = vec![];
@@ -65,8 +64,7 @@ fn test_handshake_message() -> Result<()> {
     }
     assert_eq!(
         raw, raw_handshake_message,
-        "handshakeMessageClientHello marshal: got {:?}, want {:?}",
-        raw, raw_handshake_message
+        "handshakeMessageClientHello marshal: got {raw:?}, want {raw_handshake_message:?}"
     );
 
     Ok(())

--- a/dtls/src/prf/mod.rs
+++ b/dtls/src/prf/mod.rs
@@ -47,7 +47,7 @@ impl fmt::Display for EncryptionKeys {
         out += format!("- client_write_iv: {:?}\n", self.client_write_iv).as_str();
         out += format!("- server_write_iv: {:?}\n", self.server_write_iv).as_str();
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/dtls/src/prf/prf_test.rs
+++ b/dtls/src/prf/prf_test.rs
@@ -26,8 +26,7 @@ fn test_pre_master_secret() -> Result<()> {
 
     assert_eq!(
         expected_pre_master_secret, pre_master_secret,
-        "PremasterSecret exp: {:?} actual: {:?}",
-        expected_pre_master_secret, pre_master_secret
+        "PremasterSecret exp: {expected_pre_master_secret:?} actual: {pre_master_secret:?}"
     );
 
     Ok(())
@@ -66,8 +65,7 @@ fn test_master_secret() -> Result<()> {
 
     assert_eq!(
         expected_master_secret, master_secret,
-        "master_secret exp: {:?} actual: {:?}",
-        expected_master_secret, master_secret
+        "master_secret exp: {expected_master_secret:?} actual: {master_secret:?}"
     );
 
     Ok(())
@@ -120,8 +118,7 @@ fn test_encryption_keys() -> Result<()> {
 
     assert_eq!(
         expected_encryption_keys, keys,
-        "master_secret exp: {:?} actual: {:?}",
-        expected_encryption_keys, keys,
+        "master_secret exp: {expected_encryption_keys:?} actual: {keys:?}",
     );
 
     Ok(())
@@ -257,8 +254,7 @@ fn test_verify_data() -> Result<()> {
 
     assert_eq!(
         expected_verify_data, verify_data,
-        "verify_data exp: {:?} actual: {:?}",
-        expected_verify_data, verify_data
+        "verify_data exp: {expected_verify_data:?} actual: {verify_data:?}"
     );
 
     Ok(())

--- a/dtls/src/record_layer/record_layer_test.rs
+++ b/dtls/src/record_layer/record_layer_test.rs
@@ -57,16 +57,15 @@ fn test_udp_decode() -> Result<()> {
             if let Err(dtls) = dtls_pkts {
                 assert_eq!(err.to_string(), dtls.to_string());
             } else {
-                panic!("something wrong for {} when wanted_err is Some", name);
+                panic!("something wrong for {name} when wanted_err is Some");
             }
         } else if let Ok(pkts) = dtls_pkts {
             assert_eq!(
                 wanted, pkts,
-                "{} UDP decode: got {:?}, want {:?}",
-                name, pkts, wanted,
+                "{name} UDP decode: got {pkts:?}, want {wanted:?}",
             );
         } else {
-            panic!("something wrong for {} when wanted_err is None", name);
+            panic!("something wrong for {name} when wanted_err is None");
         }
     }
 
@@ -101,8 +100,7 @@ fn test_record_layer_round_trip() -> Result<()> {
 
         assert_eq!(
             want, r,
-            "{} recordLayer.unmarshal: got {:?}, want {:?}",
-            name, r, want
+            "{name} recordLayer.unmarshal: got {r:?}, want {want:?}"
         );
 
         let mut data2 = vec![];
@@ -112,8 +110,7 @@ fn test_record_layer_round_trip() -> Result<()> {
         }
         assert_eq!(
             data, data2,
-            "{} recordLayer.marshal: got {:?}, want {:?}",
-            name, data2, data
+            "{name} recordLayer.marshal: got {data2:?}, want {data:?}"
         );
     }
 

--- a/dtls/src/signature_hash_algorithm/signature_hash_algorithm_test.rs
+++ b/dtls/src/signature_hash_algorithm/signature_hash_algorithm_test.rs
@@ -122,21 +122,18 @@ fn test_parse_signature_schemes() -> Result<()> {
                 assert_eq!(
                     err.to_string(),
                     output_err.to_string(),
-                    "Expected error: {:?}, got: {:?}",
-                    err,
-                    output_err
+                    "Expected error: {err:?}, got: {output_err:?}"
                 );
             } else {
-                panic!("expect err, but got non-err for {}", name);
+                panic!("expect err, but got non-err for {name}");
             }
         } else if let Ok(output_val) = output {
             assert_eq!(
                 expected, output_val,
-                "Expected signatureHashAlgorithm:\n{:?}\ngot:\n{:?}",
-                expected, output_val,
+                "Expected signatureHashAlgorithm:\n{expected:?}\ngot:\n{output_val:?}",
             );
         } else {
-            panic!("expect non-err, but got err for {}", name);
+            panic!("expect non-err, but got err for {name}");
         }
     }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples"
 version = "0.5.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "Examples of WebRTC.rs stack"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/examples"

--- a/examples/examples/broadcast/broadcast.rs
+++ b/examples/examples/broadcast/broadcast.rs
@@ -165,10 +165,10 @@ async fn main() -> Result<()> {
             while let Ok((rtp, _)) = track.read_rtp().await {
                 if let Err(err) = local_track.write_rtp(&rtp).await {
                     if Error::ErrClosedPipe != err {
-                        print!("output track write_rtp got error: {} and break", err);
+                        print!("output track write_rtp got error: {err} and break");
                         break;
                     } else {
-                        print!("output track write_rtp got error: {}", err);
+                        print!("output track write_rtp got error: {err}");
                     }
                 }
             }
@@ -180,7 +180,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
         Box::pin(async {})
     }));
 
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }
@@ -267,7 +267,7 @@ async fn main() -> Result<()> {
             // This will notify you when the peer has connected/disconnected
             peer_connection.on_peer_connection_state_change(Box::new(
                 move |s: RTCPeerConnectionState| {
-                    println!("Peer Connection State has changed: {}", s);
+                    println!("Peer Connection State has changed: {s}");
                     Box::pin(async {})
                 },
             ));
@@ -294,7 +294,7 @@ async fn main() -> Result<()> {
             if let Some(local_desc) = peer_connection.local_description().await {
                 let json_str = serde_json::to_string(&local_desc)?;
                 let b64 = signal::encode(&json_str);
-                println!("{}", b64);
+                println!("{b64}");
             } else {
                 println!("generate local_description failed!");
             }

--- a/examples/examples/data-channels-close/data-channels-close.rs
+++ b/examples/examples/data-channels-close/data-channels-close.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -134,7 +134,7 @@ async fn main() -> Result<()> {
         .on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
             let d_label = d.label().to_owned();
             let d_id = d.id();
-            println!("New DataChannel {} {}", d_label, d_id);
+            println!("New DataChannel {d_label} {d_id}");
 
             let close_after2 = Arc::clone(&close_after);
 
@@ -144,12 +144,12 @@ async fn main() -> Result<()> {
                 let d_label2 = d_label.clone();
                 let d_id2 = d_id;
                 d.on_open(Box::new(move || {
-                    println!("Data channel '{}'-'{}' open. Random messages will now be sent to any connected DataChannels every 5 seconds", d_label2, d_id2);
+                    println!("Data channel '{d_label2}'-'{d_id2}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
                     let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<()>(1);
                     let done_tx = Arc::new(Mutex::new(Some(done_tx)));
                     Box::pin(async move {
                         d2.on_close(Box::new(move || {
-                            println!("Data channel '{}'-'{}' closed.", d_label2, d_id2);
+                            println!("Data channel '{d_label2}'-'{d_id2}' closed.");
                             let done_tx2 = Arc::clone(&done_tx);
                             Box::pin(async move{
                                 let mut done = done_tx2.lock().await;
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
                                 }
                                 _ = timeout.as_mut() =>{
                                     let message = math_rand_alpha(15);
-                                    println!("Sending '{}'", message);
+                                    println!("Sending '{message}'");
                                     result = d2.send_text(message).await.map_err(Into::into);
 
                                     let cnt = close_after2.fetch_sub(1, Ordering::SeqCst);
@@ -186,7 +186,7 @@ async fn main() -> Result<()> {
                 // Register text message handling
                 d.on_message(Box::new(move |msg: DataChannelMessage| {
                     let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-                    println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+                    println!("Message from DataChannel '{d_label}': '{msg_str}'");
                     Box::pin(async {})
                 }));
             })
@@ -218,7 +218,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/data-channels-create/data-channels-create.rs
+++ b/examples/examples/data-channels-create/data-channels-create.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
                 tokio::select! {
                     _ = timeout.as_mut() =>{
                         let message = math_rand_alpha(15);
-                        println!("Sending '{}'", message);
+                        println!("Sending '{message}'");
                         result = d2.send_text(message).await.map_err(Into::into);
                     }
                 };
@@ -142,7 +142,7 @@ async fn main() -> Result<()> {
     let d_label = data_channel.label().to_owned();
     data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
         let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-        println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+        println!("Message from DataChannel '{d_label}': '{msg_str}'");
         Box::pin(async {})
     }));
 
@@ -164,7 +164,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/data-channels-detach-create/data-channels-detach-create.rs
+++ b/examples/examples/data-channels-detach-create/data-channels-detach-create.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -137,7 +137,7 @@ async fn main() -> Result<()> {
             let raw = match d2.detach().await {
                 Ok(raw) => raw,
                 Err(err) => {
-                    println!("data channel detach got err: {}", err);
+                    println!("data channel detach got err: {err}");
                     return;
                 }
             };
@@ -173,7 +173,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }
@@ -208,7 +208,7 @@ async fn read_loop(d: Arc<webrtc::data::data_channel::DataChannel>) -> Result<()
         let n = match d.read(&mut buffer).await {
             Ok(n) => n,
             Err(err) => {
-                println!("Datachannel closed; Exit the read_loop: {}", err);
+                println!("Datachannel closed; Exit the read_loop: {err}");
                 return Ok(());
             }
         };
@@ -230,7 +230,7 @@ async fn write_loop(d: Arc<webrtc::data::data_channel::DataChannel>) -> Result<(
         tokio::select! {
             _ = timeout.as_mut() =>{
                 let message = math_rand_alpha(15);
-                println!("Sending '{}'", message);
+                println!("Sending '{message}'");
                 result = d.write(&Bytes::from(message)).await.map_err(Into::into);
             }
         };

--- a/examples/examples/data-channels-detach/data-channels-detach.rs
+++ b/examples/examples/data-channels-detach/data-channels-detach.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
     peer_connection.on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
         let d_label = d.label().to_owned();
         let d_id = d.id();
-        println!("New DataChannel {} {}", d_label, d_id);
+        println!("New DataChannel {d_label} {d_id}");
 
         // Register channel opening handling
         Box::pin(async move {
@@ -137,13 +137,13 @@ async fn main() -> Result<()> {
             let d_label2 = d_label.clone();
             let d_id2 = d_id;
             d.on_open(Box::new(move || {
-                println!("Data channel '{}'-'{}' open.", d_label2, d_id2);
+                println!("Data channel '{d_label2}'-'{d_id2}' open.");
 
                 Box::pin(async move {
                     let raw = match d2.detach().await {
                         Ok(raw) => raw,
                         Err(err) => {
-                            println!("data channel detach got err: {}", err);
+                            println!("data channel detach got err: {err}");
                             return;
                         }
                     };
@@ -189,7 +189,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }
@@ -216,7 +216,7 @@ async fn read_loop(d: Arc<webrtc::data::data_channel::DataChannel>) -> Result<()
         let n = match d.read(&mut buffer).await {
             Ok(n) => n,
             Err(err) => {
-                println!("Datachannel closed; Exit the read_loop: {}", err);
+                println!("Datachannel closed; Exit the read_loop: {err}");
                 return Ok(());
             }
         };
@@ -238,7 +238,7 @@ async fn write_loop(d: Arc<webrtc::data::data_channel::DataChannel>) -> Result<(
         tokio::select! {
             _ = timeout.as_mut() =>{
                 let message = math_rand_alpha(15);
-                println!("Sending '{}'", message);
+                println!("Sending '{message}'");
                 result = d.write(&Bytes::from(message)).await.map_err(Into::into);
             }
         };

--- a/examples/examples/data-channels/data-channels.rs
+++ b/examples/examples/data-channels/data-channels.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -118,7 +118,7 @@ async fn main() -> Result<()> {
         .on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
             let d_label = d.label().to_owned();
             let d_id = d.id();
-            println!("New DataChannel {} {}", d_label, d_id);
+            println!("New DataChannel {d_label} {d_id}");
 
             // Register channel opening handling
             Box::pin(async move {
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
                 let d_label2 = d_label.clone();
                 let d_id2 = d_id;
                 d.on_open(Box::new(move || {
-                    println!("Data channel '{}'-'{}' open. Random messages will now be sent to any connected DataChannels every 5 seconds", d_label2, d_id2);
+                    println!("Data channel '{d_label2}'-'{d_id2}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
 
                     Box::pin(async move {
                         let mut result = Result::<usize>::Ok(0);
@@ -137,7 +137,7 @@ async fn main() -> Result<()> {
                             tokio::select! {
                                 _ = timeout.as_mut() =>{
                                     let message = math_rand_alpha(15);
-                                    println!("Sending '{}'", message);
+                                    println!("Sending '{message}'");
                                     result = d2.send_text(message).await.map_err(Into::into);
                                 }
                             };
@@ -148,7 +148,7 @@ async fn main() -> Result<()> {
                 // Register text message handling
                 d.on_message(Box::new(move |msg: DataChannelMessage| {
                     let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-                    println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+                    println!("Message from DataChannel '{d_label}': '{msg_str}'");
                     Box::pin(async {})
                 }));
             })
@@ -180,7 +180,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/ice-restart/ice-restart.rs
+++ b/examples/examples/ice-restart/ice-restart.rs
@@ -111,7 +111,7 @@ async fn do_signaling(req: Request<Body>) -> Result<Response<Body>, hyper::Error
             // This will notify you when the peer has connected/disconnected
             pc.on_ice_connection_state_change(Box::new(
                 |connection_state: RTCIceConnectionState| {
-                    println!("ICE Connection State has changed: {}", connection_state);
+                    println!("ICE Connection State has changed: {connection_state}");
                     Box::pin(async {})
                 },
             ));
@@ -246,7 +246,7 @@ async fn main() -> Result<()> {
         let server = Server::bind(&addr).serve(service);
         // Run this server for... forever!
         if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
+            eprintln!("server error: {e}");
         }
     });
 

--- a/examples/examples/insertable-streams/insertable-streams.rs
+++ b/examples/examples/insertable-streams/insertable-streams.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
 
     let video_file = matches.value_of("video").unwrap();
     if !Path::new(video_file).exists() {
-        return Err(Error::new(format!("video file: '{}' not exist", video_file)).into());
+        return Err(Error::new(format!("video file: '{video_file}' not exist")).into());
     }
 
     // Everything below is the WebRTC-rs API! Thanks for using it ❤️.
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
             let mut frame = match ivf.parse_next_frame() {
                 Ok((frame, _)) => frame,
                 Err(err) => {
-                    println!("All video frames parsed and sent: {}", err);
+                    println!("All video frames parsed and sent: {err}");
                     break;
                 }
             };
@@ -198,7 +198,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
@@ -209,7 +209,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -248,7 +248,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/offer-answer/offer.rs
+++ b/examples/examples/offer-answer/offer.rs
@@ -39,13 +39,13 @@ async fn signal_candidate(addr: &str, c: &RTCIceCandidate) -> Result<()> {
     let payload = c.to_json()?.candidate;
     let req = match Request::builder()
         .method(Method::POST)
-        .uri(format!("http://{}/candidate", addr))
+        .uri(format!("http://{addr}/candidate"))
         .header("content-type", "application/json; charset=utf-8")
         .body(Body::from(payload))
     {
         Ok(req) => req,
         Err(err) => {
-            println!("{}", err);
+            println!("{err}");
             return Err(err.into());
         }
     };
@@ -53,7 +53,7 @@ async fn signal_candidate(addr: &str, c: &RTCIceCandidate) -> Result<()> {
     let _resp = match Client::new().request(req).await {
         Ok(resp) => resp,
         Err(err) => {
-            println!("{}", err);
+            println!("{err}");
             return Err(err.into());
         }
     };
@@ -259,7 +259,7 @@ async fn main() -> Result<()> {
         })
     }));
 
-    println!("Listening on http://{}", offer_addr);
+    println!("Listening on http://{offer_addr}");
     {
         let mut pcm = PEER_CONNECTION_MUTEX.lock().await;
         *pcm = Some(Arc::clone(&peer_connection));
@@ -272,7 +272,7 @@ async fn main() -> Result<()> {
         let server = Server::bind(&addr).serve(service);
         // Run this server for... forever!
         if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
+            eprintln!("server error: {e}");
         }
     });
 
@@ -284,7 +284,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -312,7 +312,7 @@ async fn main() -> Result<()> {
                 tokio::select! {
                     _ = timeout.as_mut() =>{
                         let message = math_rand_alpha(15);
-                        println!("Sending '{}'", message);
+                        println!("Sending '{message}'");
                         result = d2.send_text(message).await.map_err(Into::into);
                     }
                 };
@@ -324,7 +324,7 @@ async fn main() -> Result<()> {
     let d_label = data_channel.label().to_owned();
     data_channel.on_message(Box::new(move |msg: DataChannelMessage| {
         let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-        println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+        println!("Message from DataChannel '{d_label}': '{msg_str}'");
         Box::pin(async {})
     }));
 
@@ -344,7 +344,7 @@ async fn main() -> Result<()> {
     //println!("Post: {}", format!("http://{}/sdp", answer_addr));
     let req = match Request::builder()
         .method(Method::POST)
-        .uri(format!("http://{}/sdp", answer_addr))
+        .uri(format!("http://{answer_addr}/sdp"))
         .header("content-type", "application/json; charset=utf-8")
         .body(Body::from(payload))
     {
@@ -355,7 +355,7 @@ async fn main() -> Result<()> {
     let _resp = match Client::new().request(req).await {
         Ok(resp) => resp,
         Err(err) => {
-            println!("{}", err);
+            println!("{err}");
             return Err(err.into());
         }
     };

--- a/examples/examples/ortc/ortc.rs
+++ b/examples/examples/ortc/ortc.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<()> {
     sctp.on_data_channel(Box::new(move |d: Arc<RTCDataChannel>| {
         let d_label = d.label().to_owned();
         let d_id = d.id();
-        println!("New DataChannel {} {}", d_label, d_id);
+        println!("New DataChannel {d_label} {d_id}");
 
         let done_answer1 = done_answer.clone();
         // Register the handlers
@@ -127,7 +127,7 @@ async fn main() -> Result<()> {
             // Register text message handling
             d.on_message(Box::new(move |msg: DataChannelMessage| {
                 let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-                println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+                println!("Message from DataChannel '{d_label}': '{msg_str}'");
                 Box::pin(async {})
             }));
         })
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
     // Exchange the information
     let json_str = serde_json::to_string(&local_signal)?;
     let b64 = signal::encode(&json_str);
-    println!("{}", b64);
+    println!("{b64}");
 
     let line = signal::must_read_stdin()?;
     let json_str = signal::decode(line.as_str())?;
@@ -222,7 +222,7 @@ async fn main() -> Result<()> {
         let d_label = d.label().to_owned();
         d.on_message(Box::new(move |msg: DataChannelMessage| {
             let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-            println!("Message from DataChannel '{}': '{}'", d_label, msg_str);
+            println!("Message from DataChannel '{d_label}': '{msg_str}'");
             Box::pin(async {})
         }));
     }
@@ -267,7 +267,7 @@ async fn handle_on_open(d: Arc<RTCDataChannel>) -> Result<()> {
         tokio::select! {
             _ = timeout.as_mut() =>{
                 let message = math_rand_alpha(15);
-                println!("Sending '{}'", message);
+                println!("Sending '{message}'");
                 result = d.send_text(message).await.map_err(Into::into);
             }
         };

--- a/examples/examples/play-from-disk-h264/play-from-disk-h264.rs
+++ b/examples/examples/play-from-disk-h264/play-from-disk-h264.rs
@@ -91,12 +91,12 @@ async fn main() -> Result<()> {
 
     if let Some(video_path) = &video_file {
         if !Path::new(video_path).exists() {
-            return Err(Error::new(format!("video file: '{}' not exist", video_path)).into());
+            return Err(Error::new(format!("video file: '{video_path}' not exist")).into());
         }
     }
     if let Some(audio_path) = &audio_file {
         if !Path::new(audio_path).exists() {
-            return Err(Error::new(format!("audio file: '{}' not exist", audio_path)).into());
+            return Err(Error::new(format!("audio file: '{audio_path}' not exist")).into());
         }
     }
 
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
             // Wait for connection established
             notify_video.notified().await;
 
-            println!("play video from disk file {}", video_file_name);
+            println!("play video from disk file {video_file_name}");
 
             // It is important to use a time.Ticker instead of time.Sleep because
             // * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
@@ -187,7 +187,7 @@ async fn main() -> Result<()> {
                 let nal = match h264.next_nal() {
                     Ok(nal) => nal,
                     Err(err) => {
-                        println!("All video frames parsed and sent: {}", err);
+                        println!("All video frames parsed and sent: {err}");
                         break;
                     }
                 };
@@ -290,7 +290,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
@@ -301,7 +301,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -340,7 +340,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
+++ b/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
@@ -279,7 +279,7 @@ async fn main() -> Result<()> {
 
     if let Some(video_file) = video_file {
         if !Path::new(video_file).exists() {
-            return Err(Error::new(format!("video file: '{}' not exist", video_file)).into());
+            return Err(Error::new(format!("video file: '{video_file}' not exist")).into());
         }
         let mut vf = VIDEO_FILE.lock().await;
         *vf = Some(video_file.to_owned());
@@ -324,7 +324,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -351,7 +351,7 @@ async fn main() -> Result<()> {
         let server = Server::bind(&addr).serve(service);
         // Run this server for... forever!
         if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
+            eprintln!("server error: {e}");
         }
     });
 
@@ -373,7 +373,7 @@ async fn main() -> Result<()> {
 // Read a video file from disk and write it to a webrtc.Track
 // When the video has been completely read this exits without error
 async fn write_video_to_track(video_file: String, t: Arc<TrackLocalStaticSample>) -> Result<()> {
-    println!("play video from disk file {}", video_file);
+    println!("play video from disk file {video_file}");
 
     // Open a IVF file and start reading using our IVFReader
     let file = File::open(video_file)?;
@@ -393,7 +393,7 @@ async fn write_video_to_track(video_file: String, t: Arc<TrackLocalStaticSample>
         let frame = match ivf.parse_next_frame() {
             Ok((frame, _)) => frame,
             Err(err) => {
-                println!("All video frames parsed and sent: {}", err);
+                println!("All video frames parsed and sent: {err}");
                 return Err(err.into());
             }
         };

--- a/examples/examples/play-from-disk-vpx/play-from-disk-vpx.rs
+++ b/examples/examples/play-from-disk-vpx/play-from-disk-vpx.rs
@@ -97,12 +97,12 @@ async fn main() -> Result<()> {
 
     if let Some(video_path) = &video_file {
         if !Path::new(video_path).exists() {
-            return Err(Error::new(format!("video file: '{}' not exist", video_path)).into());
+            return Err(Error::new(format!("video file: '{video_path}' not exist")).into());
         }
     }
     if let Some(audio_path) = &audio_file {
         if !Path::new(audio_path).exists() {
-            return Err(Error::new(format!("audio file: '{}' not exist", audio_path)).into());
+            return Err(Error::new(format!("audio file: '{audio_path}' not exist")).into());
         }
     }
 
@@ -187,7 +187,7 @@ async fn main() -> Result<()> {
             // Wait for connection established
             notify_video.notified().await;
 
-            println!("play video from disk file {}", video_file_name);
+            println!("play video from disk file {video_file_name}");
 
             // It is important to use a time.Ticker instead of time.Sleep because
             // * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
@@ -202,7 +202,7 @@ async fn main() -> Result<()> {
                 let frame = match ivf.parse_next_frame() {
                     Ok((frame, _)) => frame,
                     Err(err) => {
-                        println!("All video frames parsed and sent: {}", err);
+                        println!("All video frames parsed and sent: {err}");
                         break;
                     }
                 };
@@ -258,7 +258,7 @@ async fn main() -> Result<()> {
             let (mut ogg, _) = match OggReader::new(reader, true) {
                 Ok(tup) => tup,
                 Err(err) => {
-                    println!("error while opening audio file output.ogg: {}", err);
+                    println!("error while opening audio file output.ogg: {err}");
                     return Err(err.into());
                 }
             };
@@ -301,7 +301,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
             if connection_state == RTCIceConnectionState::Connected {
                 notify_tx.notify_waiters();
             }
@@ -312,7 +312,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -351,7 +351,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/reflect/reflect.rs
+++ b/examples/examples/reflect/reflect.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<()> {
                 },
                 ..Default::default()
             },
-            format!("track-{}", s),
+            format!("track-{s}"),
             "webrtc-rs".to_owned(),
         ));
 
@@ -178,7 +178,7 @@ async fn main() -> Result<()> {
         tokio::spawn(async move {
             let mut rtcp_buf = vec![0u8; 1500];
             while let Ok((_, _)) = rtp_sender.read(&mut rtcp_buf).await {}
-            println!("{} rtp_sender.read loop exit", m);
+            println!("{m} rtp_sender.read loop exit");
             Result::<()>::Ok(())
         });
 
@@ -233,7 +233,7 @@ async fn main() -> Result<()> {
         let output_track = if let Some(output_track) = output_tracks.get(kind) {
             Arc::clone(output_track)
         } else {
-            println!("output_track not found for type = {}", kind);
+            println!("output_track not found for type = {kind}");
             return Box::pin(async {});
         };
 
@@ -247,7 +247,7 @@ async fn main() -> Result<()> {
             // Read RTP packets being sent to webrtc-rs
             while let Ok((rtp, _)) = track.read_rtp().await {
                 if let Err(err) = output_track2.write_rtp(&rtp).await {
-                    println!("output track write_rtp got error: {}", err);
+                    println!("output track write_rtp got error: {err}");
                     break;
                 }
             }
@@ -267,7 +267,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -298,7 +298,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/rtp-forwarder/rtp-forwarder.rs
+++ b/examples/examples/rtp-forwarder/rtp-forwarder.rs
@@ -233,7 +233,7 @@ async fn main() -> Result<()> {
                     if err.to_string().contains("Connection refused") {
                         continue;
                     } else {
-                        println!("conn send err: {}", err);
+                        println!("conn send err: {err}");
                         break;
                     }
                 }
@@ -249,7 +249,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
             if connection_state == RTCIceConnectionState::Connected {
                 println!("Ctrl+C the remote client to stop the demo");
             }
@@ -262,7 +262,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -301,7 +301,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/rtp-to-webrtc/rtp-to-webrtc.rs
+++ b/examples/examples/rtp-to-webrtc/rtp-to-webrtc.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
             if connection_state == RTCIceConnectionState::Failed {
                 let _ = done_tx1.try_send(());
             }
@@ -139,7 +139,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -178,7 +178,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }
@@ -195,7 +195,7 @@ async fn main() -> Result<()> {
                 if Error::ErrClosedPipe == err {
                     // The peerConnection has been closed.
                 } else {
-                    println!("video_track write err: {}", err);
+                    println!("video_track write err: {err}");
                 }
                 let _ = done_tx3.try_send(());
                 return;

--- a/examples/examples/save-to-disk-h264/save-to-disk-h264.rs
+++ b/examples/examples/save-to-disk-h264/save-to-disk-h264.rs
@@ -36,7 +36,7 @@ async fn save_to_disk(
                     println!("file closing begin after read_rtp error");
                     let mut w = writer.lock().await;
                     if let Err(err) = w.close() {
-                        println!("file close err: {}", err);
+                        println!("file close err: {err}");
                     }
                     println!("file closing end after read_rtp error");
                     return Ok(());
@@ -46,7 +46,7 @@ async fn save_to_disk(
                 println!("file closing begin after notified");
                 let mut w = writer.lock().await;
                 if let Err(err) = w.close() {
-                    println!("file close err: {}", err);
+                    println!("file close err: {err}");
                 }
                 println!("file closing end after notified");
                 return Ok(());
@@ -255,7 +255,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
 
             if connection_state == RTCIceConnectionState::Connected {
                 println!("Ctrl+C the remote client to stop the demo");
@@ -296,7 +296,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/save-to-disk-vpx/save-to-disk-vpx.rs
+++ b/examples/examples/save-to-disk-vpx/save-to-disk-vpx.rs
@@ -37,7 +37,7 @@ async fn save_to_disk(
                     println!("file closing begin after read_rtp error");
                     let mut w = writer.lock().await;
                     if let Err(err) = w.close() {
-                        println!("file close err: {}", err);
+                        println!("file close err: {err}");
                     }
                     println!("file closing end after read_rtp error");
                     return Ok(());
@@ -47,7 +47,7 @@ async fn save_to_disk(
                 println!("file closing begin after notified");
                 let mut w = writer.lock().await;
                 if let Err(err) = w.close() {
-                    println!("file close err: {}", err);
+                    println!("file close err: {err}");
                 }
                 println!("file closing end after notified");
                 return Ok(());
@@ -285,7 +285,7 @@ async fn main() -> Result<()> {
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_ice_connection_state_change(Box::new(
         move |connection_state: RTCIceConnectionState| {
-            println!("Connection State has changed {}", connection_state);
+            println!("Connection State has changed {connection_state}");
 
             if connection_state == RTCIceConnectionState::Connected {
                 println!("Ctrl+C the remote client to stop the demo");
@@ -326,7 +326,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/signal/Cargo.toml
+++ b/examples/examples/signal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "signal"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/examples/signal/src/lib.rs
+++ b/examples/examples/signal/src/lib.rs
@@ -58,13 +58,13 @@ pub async fn http_sdp_server(port: u16) -> mpsc::Receiver<String> {
     }
 
     tokio::spawn(async move {
-        let addr = SocketAddr::from_str(&format!("0.0.0.0:{}", port)).unwrap();
+        let addr = SocketAddr::from_str(&format!("0.0.0.0:{port}")).unwrap();
         let service =
             make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(remote_handler)) });
         let server = Server::bind(&addr).serve(service);
         // Run this server for... forever!
         if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
+            eprintln!("server error: {e}");
         }
     });
 

--- a/examples/examples/simulcast/simulcast.rs
+++ b/examples/examples/simulcast/simulcast.rs
@@ -169,9 +169,7 @@ async fn main() -> Result<()> {
         tokio::spawn(async move {
             let mut result = Result::<usize>::Ok(0);
             while result.is_ok() {
-                println!(
-                    "Sending pli for stream with rid: {rid}, ssrc: {media_ssrc}"
-                );
+                println!("Sending pli for stream with rid: {rid}, ssrc: {media_ssrc}");
 
                 let timeout = tokio::time::sleep(Duration::from_secs(3));
                 tokio::pin!(timeout);

--- a/examples/examples/simulcast/simulcast.rs
+++ b/examples/examples/simulcast/simulcast.rs
@@ -121,8 +121,8 @@ async fn main() -> Result<()> {
                 mime_type: MIME_TYPE_VP8.to_owned(),
                 ..Default::default()
             },
-            format!("video_{}", s),
-            format!("webrtc-rs_{}", s),
+            format!("video_{s}"),
+            format!("webrtc-rs_{s}"),
         ));
 
         // Add this newly created track to the PeerConnection
@@ -159,7 +159,7 @@ async fn main() -> Result<()> {
         let output_track = if let Some(output_track) = output_tracks.get(&rid) {
             Arc::clone(output_track)
         } else {
-            println!("output_track not found for rid = {}", rid);
+            println!("output_track not found for rid = {rid}");
             return Box::pin(async {});
         };
 
@@ -170,8 +170,7 @@ async fn main() -> Result<()> {
             let mut result = Result::<usize>::Ok(0);
             while result.is_ok() {
                 println!(
-                    "Sending pli for stream with rid: {}, ssrc: {}",
-                    rid, media_ssrc
+                    "Sending pli for stream with rid: {rid}, ssrc: {media_ssrc}"
                 );
 
                 let timeout = tokio::time::sleep(Duration::from_secs(3));
@@ -198,10 +197,10 @@ async fn main() -> Result<()> {
             while let Ok((rtp, _)) = track.read_rtp().await {
                 if let Err(err) = output_track.write_rtp(&rtp).await {
                     if Error::ErrClosedPipe != err {
-                        println!("output track write_rtp got error: {} and break", err);
+                        println!("output track write_rtp got error: {err} and break");
                         break;
                     } else {
-                        println!("output track write_rtp got error: {}", err);
+                        println!("output track write_rtp got error: {err}");
                     }
                 }
             }
@@ -216,7 +215,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
 
         if s == RTCPeerConnectionState::Failed {
             // Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
@@ -247,7 +246,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/examples/examples/swap-tracks/swap-tracks.rs
+++ b/examples/examples/swap-tracks/swap-tracks.rs
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
                                 })])
                                 .await
                             {
-                                println!("write_rtcp err: {}", err);
+                                println!("write_rtcp err: {err}");
                             }
                         } else {
                             break;
@@ -209,7 +209,7 @@ async fn main() -> Result<()> {
     // Set the handler for Peer connection state
     // This will notify you when the peer has connected/disconnected
     peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-        println!("Peer Connection State has changed: {}", s);
+        println!("Peer Connection State has changed: {s}");
         if s == RTCPeerConnectionState::Connected {
             let _ = connected_tx.try_send(());
         } else if s == RTCPeerConnectionState::Failed {
@@ -239,7 +239,7 @@ async fn main() -> Result<()> {
     if let Some(local_desc) = peer_connection.local_description().await {
         let json_str = serde_json::to_string(&local_desc)?;
         let b64 = signal::encode(&json_str);
-        println!("{}", b64);
+        println!("{b64}");
     } else {
         println!("generate local_description failed!");
     }

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-ice"
 version = "0.9.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of ICE"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-ice"

--- a/ice/src/agent/agent_gather_test.rs
+++ b/ice/src/agent/agent_gather_test.rs
@@ -59,7 +59,7 @@ async fn test_vnet_gather_dynamic_ip_address() -> Result<()> {
             panic!("should not return loopback IP");
         }
         if !ipnet.contains(ip) {
-            panic!("{} should be contained in the CIDR {}", ip, ipnet);
+            panic!("{ip} should be contained in the CIDR {ipnet}");
         }
     }
 
@@ -101,8 +101,7 @@ async fn test_vnet_gather_listen_udp() -> Result<()> {
         let port = conn.local_addr()?.port();
         assert_eq!(
             port, 5000,
-            "listenUDP with port restriction of 5000 listened on incorrect port ({})",
-            port
+            "listenUDP with port restriction of 5000 listened on incorrect port ({port})"
         );
     }
 
@@ -117,8 +116,8 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<()> {
     let external_ip1 = "1.2.3.5";
     let local_ip0 = "10.0.0.1";
     let local_ip1 = "10.0.0.2";
-    let map0 = format!("{}/{}", external_ip0, local_ip0);
-    let map1 = format!("{}/{}", external_ip1, local_ip1);
+    let map0 = format!("{external_ip0}/{local_ip0}");
+    let map1 = format!("{external_ip1}/{local_ip1}");
 
     let wan = Arc::new(Mutex::new(router::Router::new(router::RouterConfig {
         cidr: "1.2.3.0/24".to_owned(),

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -151,9 +151,7 @@ async fn test_pair_priority() -> Result<()> {
                         ..Default::default()
                     }
                     .to_string(),
-                    "Unexpected bestPair {} (expected remote: {})",
-                    best_pair,
-                    remote,
+                    "Unexpected bestPair {best_pair} (expected remote: {remote})",
                 );
             } else {
                 panic!("expected Some, but got None");
@@ -1481,8 +1479,7 @@ async fn test_init_ext_ip_mapping() -> Result<()> {
         assert_eq!(
             Error::ErrIneffectiveNat1to1IpMappingHost,
             err,
-            "Unexpected error: {}",
-            err
+            "Unexpected error: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -1501,8 +1498,7 @@ async fn test_init_ext_ip_mapping() -> Result<()> {
         assert_eq!(
             Error::ErrIneffectiveNat1to1IpMappingSrflx,
             err,
-            "Unexpected error: {}",
-            err
+            "Unexpected error: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -1521,8 +1517,7 @@ async fn test_init_ext_ip_mapping() -> Result<()> {
         assert_eq!(
             Error::ErrMulticastDnsWithNat1to1IpMapping,
             err,
-            "Unexpected error: {}",
-            err
+            "Unexpected error: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -1539,8 +1534,7 @@ async fn test_init_ext_ip_mapping() -> Result<()> {
         assert_eq!(
             Error::ErrInvalidNat1to1IpMapping,
             err,
-            "Unexpected error: {}",
-            err
+            "Unexpected error: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -1730,7 +1724,7 @@ async fn test_connection_state_connecting_to_failed() -> Result<()> {
                     let mut c = wc_clone.lock().await;
                     c.take();
                 } else if c == ConnectionState::Connected || c == ConnectionState::Completed {
-                    panic!("Unexpected ConnectionState: {}", c);
+                    panic!("Unexpected ConnectionState: {c}");
                 }
             })
         });

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -84,7 +84,7 @@ pub(crate) async fn build_simple_vnet(
 
     // LAN
     let lan = Arc::new(Mutex::new(router::Router::new(router::RouterConfig {
-        cidr: format!("{}/{}", VNET_LOCAL_IPA, VNET_LOCAL_SUBNET_MASK_A),
+        cidr: format!("{VNET_LOCAL_IPA}/{VNET_LOCAL_SUBNET_MASK_A}"),
         ..Default::default()
     })?));
 
@@ -134,11 +134,11 @@ pub(crate) async fn build_vnet(
     // LAN 0
     let lan0 = Arc::new(Mutex::new(router::Router::new(router::RouterConfig {
         static_ips: if nat_type0.mode == nat::NatMode::Nat1To1 {
-            vec![format!("{}/{}", VNET_GLOBAL_IPA, VNET_LOCAL_IPA)]
+            vec![format!("{VNET_GLOBAL_IPA}/{VNET_LOCAL_IPA}")]
         } else {
             vec![VNET_GLOBAL_IPA.to_owned()]
         },
-        cidr: format!("{}/{}", VNET_LOCAL_IPA, VNET_LOCAL_SUBNET_MASK_A),
+        cidr: format!("{VNET_LOCAL_IPA}/{VNET_LOCAL_SUBNET_MASK_A}"),
         nat_type: Some(nat_type0),
         ..Default::default()
     })?));
@@ -154,11 +154,11 @@ pub(crate) async fn build_vnet(
     // LAN 1
     let lan1 = Arc::new(Mutex::new(router::Router::new(router::RouterConfig {
         static_ips: if nat_type1.mode == nat::NatMode::Nat1To1 {
-            vec![format!("{}/{}", VNET_GLOBAL_IPB, VNET_LOCAL_IPB)]
+            vec![format!("{VNET_GLOBAL_IPB}/{VNET_LOCAL_IPB}")]
         } else {
             vec![VNET_GLOBAL_IPB.to_owned()]
         },
-        cidr: format!("{}/{}", VNET_LOCAL_IPB, VNET_LOCAL_SUBNET_MASK_B),
+        cidr: format!("{VNET_LOCAL_IPB}/{VNET_LOCAL_SUBNET_MASK_B}"),
         nat_type: Some(nat_type1),
         ..Default::default()
     })?));
@@ -219,8 +219,7 @@ pub(crate) async fn add_vnet_stun(wan_net: Arc<net::Net>) -> Result<turn::server
     // Run TURN(STUN) server
     let conn = wan_net
         .bind(SocketAddr::from_str(&format!(
-            "{}:{}",
-            VNET_STUN_SERVER_IP, VNET_STUN_SERVER_PORT
+            "{VNET_STUN_SERVER_IP}:{VNET_STUN_SERVER_PORT}"
         ))?)
         .await?;
 

--- a/ice/src/candidate/candidate_base.rs
+++ b/ice/src/candidate/candidate_base.rs
@@ -130,7 +130,7 @@ impl Candidate for CandidateBase {
 
         let checksum = Crc::<u32>::new(&CRC_32_ISCSI).checksum(&buf);
 
-        format!("{}", checksum)
+        format!("{checksum}")
     }
 
     /// Returns Candidate ID.

--- a/ice/src/candidate/candidate_pair_test.rs
+++ b/ice/src/candidate/candidate_pair_test.rs
@@ -130,8 +130,7 @@ fn test_candidate_pair_priority() -> Result<()> {
         let got = pair.priority();
         assert_eq!(
             got, want,
-            "CandidatePair({}).Priority() = {}, want {}",
-            pair, got, want
+            "CandidatePair({pair}).Priority() = {got}, want {want}"
         );
     }
 
@@ -151,7 +150,7 @@ fn test_candidate_pair_equality() -> Result<()> {
         false,
     );
 
-    assert_eq!(pair_a, pair_b, "Expected {} to equal {}", pair_a, pair_b);
+    assert_eq!(pair_a, pair_b, "Expected {pair_a} to equal {pair_b}");
 
     Ok(())
 }

--- a/ice/src/candidate/candidate_test.rs
+++ b/ice/src/candidate/candidate_test.rs
@@ -103,8 +103,7 @@ fn test_candidate_priority() -> Result<()> {
         let got = candidate.priority();
         assert_eq!(
             got, want,
-            "Candidate({}).Priority() = {}, want {}",
-            candidate, got, want
+            "Candidate({candidate}).Priority() = {got}, want {want}"
         );
     }
 

--- a/ice/src/candidate/mod.rs
+++ b/ice/src/candidate/mod.rs
@@ -111,7 +111,7 @@ impl fmt::Display for CandidateType {
             CandidateType::Relay => "relay",
             CandidateType::Unspecified => "Unknown candidate type",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -220,7 +220,7 @@ impl fmt::Display for CandidatePairState {
             Self::Unspecified => "unspecified",
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/ice/src/control/mod.rs
+++ b/ice/src/control/mod.rs
@@ -138,6 +138,6 @@ impl fmt::Display for Role {
             Self::Controlled => "controlled",
             Self::Unspecified => "unspecified",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/ice/src/mdns/mdns_test.rs
+++ b/ice/src/mdns/mdns_test.rs
@@ -139,8 +139,7 @@ fn test_generate_multicast_dnsname() -> Result<()> {
     if let Ok(re) = re {
         assert!(
             re.is_match(&name),
-            "mDNS name must be UUID v4 + \".local\" suffix, got {}",
-            name
+            "mDNS name must be UUID v4 + \".local\" suffix, got {name}"
         );
     } else {
         panic!("expected ok, but got err");

--- a/ice/src/mdns/mod.rs
+++ b/ice/src/mdns/mod.rs
@@ -36,7 +36,7 @@ pub(crate) fn generate_multicast_dns_name() -> String {
     // https://tools.ietf.org/id/draft-ietf-rtcweb-mdns-ice-candidates-02.html#gathering
     // The unique name MUST consist of a version 4 UUID as defined in [RFC4122], followed by “.local”.
     let u = Uuid::new_v4();
-    format!("{}.local", u)
+    format!("{u}.local")
 }
 
 pub(crate) fn create_multicast_dns(

--- a/ice/src/network_type/mod.rs
+++ b/ice/src/network_type/mod.rs
@@ -64,7 +64,7 @@ impl fmt::Display for NetworkType {
             Self::Tcp6 => "tcp6",
             Self::Unspecified => "unspecified",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/ice/src/network_type/network_type_test.rs
+++ b/ice/src/network_type/network_type_test.rs
@@ -18,8 +18,7 @@ fn test_network_type_parsing_success() -> Result<()> {
 
         assert_eq!(
             actual, expected,
-            "NetworkTypeParsing: '{}' -- input:{} expected:{} actual:{}",
-            name, in_network, expected, actual
+            "NetworkTypeParsing: '{name}' -- input:{in_network} expected:{expected} actual:{actual}"
         );
     }
 
@@ -35,9 +34,7 @@ fn test_network_type_parsing_failure() -> Result<()> {
         let result = determine_network_type(in_network, &in_ip);
         assert!(
             result.is_err(),
-            "NetworkTypeParsing should fail: '{}' -- input:{}",
-            name,
-            in_network,
+            "NetworkTypeParsing should fail: '{name}' -- input:{in_network}",
         );
     }
 

--- a/ice/src/rand/rand_test.rs
+++ b/ice/src/rand/rand_test.rs
@@ -58,7 +58,7 @@ async fn test_random_generator_collision() -> Result<()> {
             wg.wait().await;
 
             let rs = rands.lock().await;
-            assert_eq!(rs.len(), N, "{} Failed to generate randoms", name);
+            assert_eq!(rs.len(), N, "{name} Failed to generate randoms");
 
             for i in 0..N {
                 for j in i + 1..N {

--- a/ice/src/state/mod.rs
+++ b/ice/src/state/mod.rs
@@ -48,7 +48,7 @@ impl fmt::Display for ConnectionState {
             Self::Disconnected => "Disconnected",
             Self::Closed => "Closed",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -107,6 +107,6 @@ impl fmt::Display for GatheringState {
             Self::Complete => "complete",
             Self::Unspecified => "unspecified",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/ice/src/state/state_test.rs
+++ b/ice/src/state/state_test.rs
@@ -18,9 +18,7 @@ fn test_connected_state_string() -> Result<()> {
         assert_eq!(
             connection_state.to_string(),
             expected_string,
-            "testCase: {} vs {}",
-            expected_string,
-            connection_state,
+            "testCase: {expected_string} vs {connection_state}",
         )
     }
 
@@ -40,9 +38,7 @@ fn test_gathering_state_string() -> Result<()> {
         assert_eq!(
             gathering_state.to_string(),
             expected_string,
-            "testCase: {} vs {}",
-            expected_string,
-            gathering_state,
+            "testCase: {expected_string} vs {gathering_state}",
         )
     }
 

--- a/ice/src/tcp_type/mod.rs
+++ b/ice/src/tcp_type/mod.rs
@@ -37,7 +37,7 @@ impl fmt::Display for TcpType {
             Self::SimultaneousOpen => "so",
             Self::Unspecified => "unspecified",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/ice/src/udp_mux/udp_mux_test.rs
+++ b/ice/src/udp_mux/udp_mux_test.rs
@@ -30,8 +30,8 @@ impl Network {
     /// Connnect ip from the "remote".
     fn connect_ip(self, port: u16) -> String {
         match self {
-            Network::Ipv4 => format!("127.0.0.1:{}", port),
-            Network::Ipv6 => format!("[::1]:{}", port),
+            Network::Ipv4 => format!("127.0.0.1:{port}"),
+            Network::Ipv6 => format!("[::1]:{port}"),
         }
     }
 }
@@ -114,18 +114,18 @@ async fn test_udp_mux() -> Result<()> {
         // Timeout error
         match timeout_result {
             Err(timeout_err) => {
-                panic!("Mux test timedout: {:?}", timeout_err);
+                panic!("Mux test timedout: {timeout_err:?}");
             }
 
             // Join error
             Ok(join_result) => match join_result {
                 Err(err) => {
-                    panic!("Mux test failed with join error: {:?}", err);
+                    panic!("Mux test failed with join error: {err:?}");
                 }
                 // Actual error
                 Ok(mux_result) => {
                     if let Err(err) = mux_result {
-                        panic!("Mux test failed with error: {:?}", err);
+                        panic!("Mux test failed with error: {err:?}");
                     }
                 }
             },
@@ -135,8 +135,7 @@ async fn test_udp_mux() -> Result<()> {
     let timeout = all_results.iter().find_map(|r| r.as_ref().err());
     assert!(
         timeout.is_none(),
-        "At least one of the muxed tasks timedout {:?}",
-        all_results
+        "At least one of the muxed tasks timedout {all_results:?}"
     );
 
     let res = udp_mux.close().await;
@@ -186,7 +185,7 @@ async fn test_mux_connection(
             ..Message::default()
         };
 
-        m.add(ATTR_USERNAME, format!("{}:otherufrag", ufrag).as_bytes());
+        m.add(ATTR_USERNAME, format!("{ufrag}:otherufrag").as_bytes());
 
         m.marshal_binary().unwrap()
     };
@@ -273,7 +272,7 @@ async fn test_mux_connection(
     assert!(r1.is_ok() && r2.is_ok());
 
     let res = conn.close().await;
-    assert!(res.is_ok(), "Failed to close Conn: {:?}", res);
+    assert!(res.is_ok(), "Failed to close Conn: {res:?}");
 
     Ok(())
 }

--- a/ice/src/url/mod.rs
+++ b/ice/src/url/mod.rs
@@ -55,7 +55,7 @@ impl fmt::Display for SchemeType {
             SchemeType::Turns => "turns",
             SchemeType::Unknown => "unknown",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -98,7 +98,7 @@ impl fmt::Display for ProtoType {
             Self::Tcp => "tcp",
             Self::Unknown => "unknown",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/ice/src/url/url_test.rs
+++ b/ice/src/url/url_test.rs
@@ -89,17 +89,16 @@ fn test_parse_url_success() -> Result<()> {
     {
         let url = Url::parse_url(raw_url)?;
 
-        assert_eq!(url.scheme, expected_scheme, "testCase: {:?}", raw_url);
+        assert_eq!(url.scheme, expected_scheme, "testCase: {raw_url:?}");
         assert_eq!(
             expected_url_string,
             url.to_string(),
-            "testCase: {:?}",
-            raw_url
+            "testCase: {raw_url:?}"
         );
-        assert_eq!(url.is_secure(), expected_secure, "testCase: {:?}", raw_url);
-        assert_eq!(url.host, expected_host, "testCase: {:?}", raw_url);
-        assert_eq!(url.port, expected_port, "testCase: {:?}", raw_url);
-        assert_eq!(url.proto, expected_proto, "testCase: {:?}", raw_url);
+        assert_eq!(url.is_secure(), expected_secure, "testCase: {raw_url:?}");
+        assert_eq!(url.host, expected_host, "testCase: {raw_url:?}");
+        assert_eq!(url.port, expected_port, "testCase: {raw_url:?}");
+        assert_eq!(url.proto, expected_proto, "testCase: {raw_url:?}");
     }
 
     Ok(())
@@ -132,10 +131,7 @@ fn test_parse_url_failure() -> Result<()> {
             assert_eq!(
                 err.to_string(),
                 expected_err.to_string(),
-                "testCase: '{}', expected err '{}', but got err '{}'",
-                raw_url,
-                expected_err,
-                err
+                "testCase: '{raw_url}', expected err '{expected_err}', but got err '{err}'"
             );
         } else {
             panic!("expected error, but got ok");

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "interceptor"
 version = "0.8.2"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of Pluggable RTP/RTCP processors"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/interceptor"

--- a/interceptor/src/nack/generator/generator_stream.rs
+++ b/interceptor/src/nack/generator/generator_stream.rs
@@ -205,7 +205,7 @@ mod test {
             let assert_get = |rl: &GeneratorStreamInternal, nums: &[u16]| {
                 for n in nums {
                     let seq = start.wrapping_add(*n);
-                    assert!(rl.get(seq), "not found: {}", seq);
+                    assert!(rl.get(seq), "not found: {seq}");
                 }
             };
 

--- a/interceptor/src/nack/responder/responder_stream.rs
+++ b/interceptor/src/nack/responder/responder_stream.rs
@@ -132,7 +132,7 @@ mod test {
                             seq, packet.header.sequence_number
                         );
                     } else {
-                        panic!("packet not found: {}", seq);
+                        panic!("packet not found: {seq}");
                     }
                 }
             };

--- a/interceptor/src/nack/responder/responder_test.rs
+++ b/interceptor/src/nack/responder/responder_test.rs
@@ -60,10 +60,10 @@ async fn test_responder_interceptor() -> Result<()> {
             if let Some(p) = r {
                 assert_eq!(p.header.sequence_number, seq_num);
             } else {
-                panic!("seq_num {} is not sent due to channel closed", seq_num);
+                panic!("seq_num {seq_num} is not sent due to channel closed");
             }
         } else {
-            panic!("seq_num {} is not sent yet", seq_num);
+            panic!("seq_num {seq_num} is not sent yet");
         }
     }
 

--- a/mdns/Cargo.toml
+++ b/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-mdns"
 version = "0.5.2"
 authors = ["Rain Liu <yuliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of mDNS"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-mdns"

--- a/mdns/examples/mdns_query.rs
+++ b/mdns/examples/mdns_query.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Error> {
 
     let (answer, src) = server.query(local_name, b).await.unwrap();
     log::info!("dns queried");
-    println!("answer = {}, src = {}", answer, src);
+    println!("answer = {answer}, src = {src}");
 
     server.close().await.unwrap();
     Ok(())

--- a/mdns/examples/mdns_server_query.rs
+++ b/mdns/examples/mdns_server_query.rs
@@ -36,7 +36,7 @@ async fn main() {
     });
 
     let (answer, src) = server_b.query("webrtc-rs-mdns-1.local", b).await.unwrap();
-    println!("webrtc-rs-mdns-1.local answer = {}, src = {}", answer, src);
+    println!("webrtc-rs-mdns-1.local answer = {answer}, src = {src}");
 
     let (a, b) = mpsc::channel(1);
 
@@ -46,7 +46,7 @@ async fn main() {
     });
 
     let (answer, src) = server_b.query("webrtc-rs-mdns-2.local", b).await.unwrap();
-    println!("webrtc-rs-mdns-2.local answer = {}, src = {}", answer, src);
+    println!("webrtc-rs-mdns-2.local answer = {answer}, src = {src}");
 
     server_a.close().await.unwrap();
     server_b.close().await.unwrap();

--- a/mdns/src/message/header.rs
+++ b/mdns/src/message/header.rs
@@ -96,7 +96,7 @@ impl fmt::Display for Section {
             Section::Additionals => "additional",
             Section::Done => "Done",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/mdns/src/message/message_test.rs
+++ b/mdns/src/message/message_test.rs
@@ -273,8 +273,7 @@ fn test_question_pack_unpack() -> Result<()> {
     );
     assert_eq!(
         got, want,
-        "got from Parser.Question() = {}, want = {}",
-        got, want
+        "got from Parser.Question() = {got}, want = {want}"
     );
 
     Ok(())
@@ -297,7 +296,7 @@ fn test_name() -> Result<()> {
     for test in tests {
         let name = Name::new(test)?;
         let ns = name.to_string();
-        assert_eq!(ns, test, "got {} = {}, want = {}", name, ns, test);
+        assert_eq!(ns, test, "got {name} = {ns}, want = {test}");
     }
 
     Ok(())
@@ -348,8 +347,7 @@ fn test_name_pack_unpack() -> Result<()> {
 
         assert_eq!(
             got, want,
-            "unpacking packing of {}: got = {}, want = {}",
-            input, got, want
+            "unpacking packing of {input}: got = {got}, want = {want}"
         );
     }
 
@@ -456,7 +454,7 @@ fn test_resource_not_started() -> Result<()> {
     for (name, test_fn) in tests {
         let mut p = Parser::default();
         if let Err(err) = test_fn(&mut p) {
-            assert_eq!(err, Error::ErrNotStarted, "{}", name);
+            assert_eq!(err, Error::ErrNotStarted, "{name}");
         }
     }
 
@@ -673,7 +671,7 @@ fn test_skip_not_started() -> Result<()> {
         if let Err(err) = test_fn(&mut p) {
             assert_eq!(err, Error::ErrNotStarted);
         } else {
-            panic!("{} expected error, but got ok", name);
+            panic!("{name} expected error, but got ok");
         }
     }
 
@@ -740,8 +738,7 @@ fn test_too_many_records() -> Result<()> {
         if let Err(got) = msg.pack() {
             assert_eq!(
                 got, want,
-                "got Message.Pack() for {} = {}, want = {}",
-                name, got, want
+                "got Message.Pack() for {name} = {got}, want = {want}"
             )
         } else {
             panic!("expected error, but got ok");
@@ -861,11 +858,10 @@ fn test_start_error() -> Result<()> {
             if let Err(got_err) = test_fn(&mut b) {
                 assert_eq!(
                     got_err, *env_err,
-                    "got Builder{}.{} = {}, want = {}",
-                    env_name, test_name, got_err, env_err
+                    "got Builder{env_name}.{test_name} = {got_err}, want = {env_err}"
                 );
             } else {
-                panic!("{}.{}expected error, but got ok", env_name, test_name);
+                panic!("{env_name}.{test_name}expected error, but got ok");
             }
         }
     }
@@ -1017,11 +1013,10 @@ fn test_builder_resource_error() -> Result<()> {
             if let Err(got_err) = test_fn(&mut b) {
                 assert_eq!(
                     got_err, *env_err,
-                    "got Builder{}.{} = {}, want = {}",
-                    env_name, test_name, got_err, env_err
+                    "got Builder{env_name}.{test_name} = {got_err}, want = {env_err}"
                 );
             } else {
-                panic!("{}.{}expected error, but got ok", env_name, test_name);
+                panic!("{env_name}.{test_name}expected error, but got ok");
             }
         }
     }
@@ -1034,7 +1029,7 @@ fn test_finish_error() -> Result<()> {
     let mut b = Builder::default();
     let want = Error::ErrNotStarted;
     if let Err(got) = b.finish() {
-        assert_eq!(got, want, "got Builder.Finish() = {}, want = {}", got, want);
+        assert_eq!(got, want, "got Builder.Finish() = {got}, want = {want}");
     } else {
         panic!("expected error, but got ok");
     }
@@ -1162,7 +1157,7 @@ fn test_resource_pack_length() -> Result<()> {
     hdr.unpack(&buf, 0, 0)?;
 
     let (got, want) = (hdr.length as usize, buf.len() - hb.len());
-    assert_eq!(got, want, "got hdr.Length = {}, want = {}", got, want);
+    assert_eq!(got, want, "got hdr.Length = {got}, want = {want}");
 
     Ok(())
 }

--- a/mdns/src/message/mod.rs
+++ b/mdns/src/message/mod.rs
@@ -98,7 +98,7 @@ impl fmt::Display for DnsType {
             DnsType::All => "ALL",
             _ => "Unsupported",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -142,7 +142,7 @@ impl fmt::Display for DnsClass {
             DNSCLASS_ANY => "ClassANY",
             _ => other.as_str(),
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -210,7 +210,7 @@ impl fmt::Display for RCode {
             RCode::Refused => "RCodeRefused",
             RCode::Unsupported => "RCodeUnsupported",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -271,7 +271,7 @@ impl fmt::Display for Message {
         let v: Vec<String> = self.additionals.iter().map(|q| q.to_string()).collect();
         s += &v.join(", ");
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-media"
 version = "0.5.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of WebRTC Media API"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-media"

--- a/media/src/io/h264_writer/h264_writer_test.rs
+++ b/media/src/io/h264_writer/h264_writer_test.rs
@@ -26,7 +26,7 @@ fn test_is_key_frame() -> Result<()> {
 
     for (name, payload, want) in tests {
         let got = is_key_frame(&payload);
-        assert_eq!(got, want, "{} failed", name);
+        assert_eq!(got, want, "{name} failed");
     }
 
     Ok(())

--- a/media/src/io/ivf_writer/ivf_writer_test.rs
+++ b/media/src/io/ivf_writer/ivf_writer_test.rs
@@ -166,7 +166,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             assert!(result.is_ok(), "{}", msg1);
         }
 
-        assert_eq!(seen_key_frame, writer.seen_key_frame, "{} failed", msg1);
+        assert_eq!(seen_key_frame, writer.seen_key_frame, "{msg1} failed");
         if count == 1 {
             assert_eq!(writer.count, 0);
         } else if count == 2 {

--- a/media/src/io/sample_builder/sample_builder_test.rs
+++ b/media/src/io/sample_builder/sample_builder_test.rs
@@ -1437,9 +1437,7 @@ fn test_sample_builder_clean_reference() {
             assert_eq!(
                 s.buffer[seq_start.wrapping_add(i) as usize],
                 None,
-                "Old packet ({}) is not unreferenced (seq_start: {}, max_late: 10, pushed: 12)",
-                i,
-                seq_start
+                "Old packet ({i}) is not unreferenced (seq_start: {seq_start}, max_late: 10, pushed: 12)"
             );
         }
         assert_eq!(s.buffer[seq_start.wrapping_add(14) as usize], Some(pkt4));

--- a/media/src/io/sample_builder/sample_sequence_location.rs
+++ b/media/src/io/sample_builder/sample_sequence_location.rs
@@ -71,7 +71,7 @@ impl SampleSequenceLocation {
         Comparison::After
     }
 
-    pub(crate) fn range<'s, 'a, T>(&'s self, data: &'a [Option<T>]) -> Iterator<'a, T> {
+    pub(crate) fn range<'a, T>(&self, data: &'a [Option<T>]) -> Iterator<'a, T> {
         Iterator {
             data,
             sample: *self,

--- a/rtcp/Cargo.toml
+++ b/rtcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rtcp"
 version = "0.7.2"
 authors = ["Rain Liu <yliu@webrtc.rs>", "Michael Uti <utimichael9@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of RTCP"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/rtcp"

--- a/rtcp/src/compound_packet/compound_packet_test.rs
+++ b/rtcp/src/compound_packet/compound_packet_test.rs
@@ -304,10 +304,7 @@ fn test_compound_packet_roundtrip() {
         let result = packet.marshal();
         if let Some(err) = marshal_error {
             if let Err(got) = result {
-                assert_eq!(
-                    err, got,
-                    "marshal {name} header: err = {got}, want {err}"
-                );
+                assert_eq!(err, got, "marshal {name} header: err = {got}, want {err}");
             } else {
                 panic!("want error in test {name}");
             }

--- a/rtcp/src/compound_packet/compound_packet_test.rs
+++ b/rtcp/src/compound_packet/compound_packet_test.rs
@@ -61,9 +61,7 @@ fn test_bad_compound() {
             assert_eq!(
                 Error::BadFirstPacket,
                 err,
-                "Unmarshal(badcompound) err={:?}, want {:?}",
-                err,
-                a,
+                "Unmarshal(badcompound) err={err:?}, want {a:?}",
             );
         }
     };
@@ -163,7 +161,7 @@ fn test_valid_packet() {
         let result = packet.validate();
         assert_eq!(result.is_ok(), error.is_none());
         if let (Some(err), Err(got)) = (error, result) {
-            assert_eq!(err, got, "Valid({}) = {:?}, want {:?}", name, got, err);
+            assert_eq!(err, got, "Valid({name}) = {got:?}, want {err:?}");
         }
     }
 }
@@ -250,7 +248,7 @@ fn test_cname() {
         let err = compound_packet.validate();
         assert_eq!(err.is_err(), want_error.is_some());
         if let (Some(want), Err(err)) = (&want_error, err) {
-            assert_eq!(*want, err, "Valid({}) = {:?}, want {:?}", name, err, want);
+            assert_eq!(*want, err, "Valid({name}) = {err:?}, want {want:?}");
         }
 
         let name_result = compound_packet.cname();
@@ -258,12 +256,12 @@ fn test_cname() {
 
         match name_result {
             Ok(e) => {
-                assert_eq!(e, text, "CNAME({}) = {:?}, want {}", name, e, text,);
+                assert_eq!(e, text, "CNAME({name}) = {e:?}, want {text}",);
             }
 
             Err(err) => {
                 if let Some(want) = &want_error {
-                    assert_eq!(*want, err, "CNAME({}) = {:?}, want {:?}", name, err, want);
+                    assert_eq!(*want, err, "CNAME({name}) = {err:?}, want {want:?}");
                 }
             }
         }
@@ -308,29 +306,27 @@ fn test_compound_packet_roundtrip() {
             if let Err(got) = result {
                 assert_eq!(
                     err, got,
-                    "marshal {} header: err = {}, want {}",
-                    name, got, err
+                    "marshal {name} header: err = {got}, want {err}"
                 );
             } else {
-                panic!("want error in test {}", name);
+                panic!("want error in test {name}");
             }
             continue;
         } else {
-            assert!(result.is_ok(), "must no error in test {}", name);
+            assert!(result.is_ok(), "must no error in test {name}");
         }
 
         let data1 = result.unwrap();
         let c = CompoundPacket::unmarshal(&mut data1.clone())
-            .unwrap_or_else(|_| panic!("unmarshal {} error", name));
+            .unwrap_or_else(|_| panic!("unmarshal {name} error"));
 
         let data2 = c
             .marshal()
-            .unwrap_or_else(|_| panic!("marshal {} error", name));
+            .unwrap_or_else(|_| panic!("marshal {name} error"));
 
         assert_eq!(
             data1, data2,
-            "Unmarshal(Marshal({:?})) = {:?}, want {:?}",
-            name, data1, data2
+            "Unmarshal(Marshal({name:?})) = {data1:?}, want {data2:?}"
         )
     }
 }

--- a/rtcp/src/compound_packet/mod.rs
+++ b/rtcp/src/compound_packet/mod.rs
@@ -30,7 +30,7 @@ pub struct CompoundPacket(pub Vec<Box<dyn Packet + Send + Sync>>);
 
 impl fmt::Display for CompoundPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/dlrr.rs
+++ b/rtcp/src/extended_report/dlrr.rs
@@ -12,7 +12,7 @@ pub struct DLRRReport {
 
 impl fmt::Display for DLRRReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -41,7 +41,7 @@ pub struct DLRRReportBlock {
 
 impl fmt::Display for DLRRReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/mod.rs
+++ b/rtcp/src/extended_report/mod.rs
@@ -78,7 +78,7 @@ impl fmt::Display for BlockType {
             BlockType::VoIPMetrics => "VoIPMetricsReportBlockType",
             _ => "UnknownReportBlockType",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -166,7 +166,7 @@ pub struct ExtendedReport {
 
 impl fmt::Display for ExtendedReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/prt.rs
+++ b/rtcp/src/extended_report/prt.rs
@@ -36,7 +36,7 @@ pub struct PacketReceiptTimesReportBlock {
 
 impl fmt::Display for PacketReceiptTimesReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/rle.rs
+++ b/rtcp/src/extended_report/rle.rs
@@ -141,7 +141,7 @@ impl RLEReportBlock {
 
 impl fmt::Display for RLEReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/rrt.rs
+++ b/rtcp/src/extended_report/rrt.rs
@@ -21,7 +21,7 @@ pub struct ReceiverReferenceTimeReportBlock {
 
 impl fmt::Display for ReceiverReferenceTimeReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/ssr.rs
+++ b/rtcp/src/extended_report/ssr.rs
@@ -54,7 +54,7 @@ pub struct StatisticsSummaryReportBlock {
 
 impl fmt::Display for StatisticsSummaryReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -90,7 +90,7 @@ impl fmt::Display for TTLorHopLimitType {
             TTLorHopLimitType::IPv4 => "[ToH = IPv4]",
             TTLorHopLimitType::IPv6 => "[ToH = IPv6]",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/rtcp/src/extended_report/unknown.rs
+++ b/rtcp/src/extended_report/unknown.rs
@@ -9,7 +9,7 @@ pub struct UnknownReportBlock {
 
 impl fmt::Display for UnknownReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/extended_report/vm.rs
+++ b/rtcp/src/extended_report/vm.rs
@@ -54,7 +54,7 @@ pub struct VoIPMetricsReportBlock {
 
 impl fmt::Display for VoIPMetricsReportBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/goodbye/goodbye_test.rs
+++ b/rtcp/src/goodbye/goodbye_test.rs
@@ -109,25 +109,20 @@ fn test_goodbye_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} bye: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} bye: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -207,28 +202,23 @@ fn test_goodbye_round_trip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual =
-                Goodbye::unmarshal(&mut data).unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                Goodbye::unmarshal(&mut data).unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/goodbye/mod.rs
+++ b/rtcp/src/goodbye/mod.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Goodbye {
         }
         out += format!("\tReason: {:?}\n", self.reason).as_str();
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/header.rs
+++ b/rtcp/src/header.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for PacketType {
             PacketType::PayloadSpecificFeedback => "PSFB",
             PacketType::ExtendedReport => "XR",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -235,25 +235,20 @@ mod test {
             assert_eq!(
                 got.is_err(),
                 want_error.is_some(),
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name,
-                got,
-                want_error
+                "Unmarshal {name}: err = {got:?}, want {want_error:?}"
             );
 
             if let Some(want_error) = want_error {
                 let got_err = got.err().unwrap();
                 assert_eq!(
                     want_error, got_err,
-                    "Unmarshal {}: err = {:?}, want {:?}",
-                    name, got_err, want_error,
+                    "Unmarshal {name}: err = {got_err:?}, want {want_error:?}",
                 );
             } else {
                 let actual = got.unwrap();
                 assert_eq!(
                     actual, want,
-                    "Unmarshal {}: got {:?}, want {:?}",
-                    name, actual, want
+                    "Unmarshal {name}: got {actual:?}, want {want:?}"
                 );
             }
         }
@@ -300,29 +295,24 @@ mod test {
             assert_eq!(
                 got.is_ok(),
                 want_error.is_none(),
-                "Marshal {}: err = {:?}, want {:?}",
-                name,
-                got,
-                want_error
+                "Marshal {name}: err = {got:?}, want {want_error:?}"
             );
 
             if let Some(err) = want_error {
                 let got_err = got.err().unwrap();
                 assert_eq!(
                     err, got_err,
-                    "Unmarshal {} rr: err = {:?}, want {:?}",
-                    name, got_err, err,
+                    "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
                 );
             } else {
                 let data = got.ok().unwrap();
                 let buf = &mut data.clone();
                 let actual =
-                    Header::unmarshal(buf).unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                    Header::unmarshal(buf).unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
                 assert_eq!(
                     actual, want,
-                    "{} round trip: got {:?}, want {:?}",
-                    name, actual, want
+                    "{name} round trip: got {actual:?}, want {want:?}"
                 )
             }
         }

--- a/rtcp/src/header.rs
+++ b/rtcp/src/header.rs
@@ -307,8 +307,7 @@ mod test {
             } else {
                 let data = got.ok().unwrap();
                 let buf = &mut data.clone();
-                let actual =
-                    Header::unmarshal(buf).unwrap_or_else(|_| panic!("Unmarshal {name}"));
+                let actual = Header::unmarshal(buf).unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
                 assert_eq!(
                     actual, want,

--- a/rtcp/src/packet.rs
+++ b/rtcp/src/packet.rs
@@ -210,7 +210,7 @@ mod test {
         let result = unmarshal(&mut Bytes::new());
         if let Err(got) = result {
             let want = Error::InvalidHeader;
-            assert_eq!(got, want, "Unmarshal(nil) err = {}, want {}", got, want);
+            assert_eq!(got, want, "Unmarshal(nil) err = {got}, want {want}");
         } else {
             panic!("want error");
         }
@@ -231,8 +231,7 @@ mod test {
             let want = Error::PacketTooShort;
             assert_eq!(
                 got, want,
-                "Unmarshal(invalid_header_length) err = {}, want {}",
-                got, want
+                "Unmarshal(invalid_header_length) err = {got}, want {want}"
             );
         } else {
             panic!("want error");

--- a/rtcp/src/payload_feedbacks/full_intra_request/full_intra_request_test.rs
+++ b/rtcp/src/payload_feedbacks/full_intra_request/full_intra_request_test.rs
@@ -97,25 +97,20 @@ fn test_full_intra_request_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} rr: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} rr: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -156,28 +151,23 @@ fn test_full_intra_request_round_trip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = FullIntraRequest::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }
@@ -205,9 +195,7 @@ fn test_full_intra_request_unmarshal_header() {
 
         assert!(
             result.is_ok(),
-            "Unmarshal header {} rr: want {:?}",
-            name,
-            result,
+            "Unmarshal header {name} rr: want {result:?}",
         );
 
         match result {
@@ -218,8 +206,7 @@ fn test_full_intra_request_unmarshal_header() {
 
                 assert_eq!(
                     h, want,
-                    "Unmarshal header {} rr: got {:?}, want {:?}",
-                    name, h, want
+                    "Unmarshal header {name} rr: got {h:?}, want {want:?}"
                 )
             }
         }

--- a/rtcp/src/payload_feedbacks/full_intra_request/mod.rs
+++ b/rtcp/src/payload_feedbacks/full_intra_request/mod.rs
@@ -35,7 +35,7 @@ impl fmt::Display for FullIntraRequest {
         for e in &self.fir {
             out += format!(" ({} {})", e.ssrc, e.sequence_number).as_str();
         }
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/payload_feedbacks/picture_loss_indication/picture_loss_indication_test.rs
+++ b/rtcp/src/payload_feedbacks/picture_loss_indication/picture_loss_indication_test.rs
@@ -59,25 +59,20 @@ fn test_picture_loss_indication_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} rr: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} rr: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -110,28 +105,23 @@ fn test_picture_loss_indication_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = PictureLossIndication::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/payload_feedbacks/slice_loss_indication/slice_loss_indication_test.rs
+++ b/rtcp/src/payload_feedbacks/slice_loss_indication/slice_loss_indication_test.rs
@@ -63,25 +63,20 @@ fn test_slice_loss_indication_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} rr: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} rr: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -116,28 +111,23 @@ fn test_slice_loss_indication_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = SliceLossIndication::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/raw_packet.rs
+++ b/rtcp/src/raw_packet.rs
@@ -13,7 +13,7 @@ pub struct RawPacket(pub Bytes);
 
 impl fmt::Display for RawPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RawPacket: {:?}", self)
+        write!(f, "RawPacket: {self:?}")
     }
 }
 
@@ -131,10 +131,7 @@ mod test {
             assert_eq!(
                 result.is_err(),
                 unmarshal_error.is_some(),
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name,
-                result,
-                unmarshal_error
+                "Unmarshal {name}: err = {result:?}, want {unmarshal_error:?}"
             );
 
             if result.is_err() {
@@ -148,10 +145,7 @@ mod test {
             assert_eq!(
                 result.is_err(),
                 unmarshal_error.is_some(),
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name,
-                result,
-                unmarshal_error
+                "Unmarshal {name}: err = {result:?}, want {unmarshal_error:?}"
             );
 
             if result.is_err() {
@@ -162,8 +156,7 @@ mod test {
 
             assert_eq!(
                 decoded, pkt,
-                "{} raw round trip: got {:?}, want {:?}",
-                name, decoded, pkt
+                "{name} raw round trip: got {decoded:?}, want {pkt:?}"
             )
         }
 

--- a/rtcp/src/receiver_report/mod.rs
+++ b/rtcp/src/receiver_report/mod.rs
@@ -41,7 +41,7 @@ impl fmt::Display for ReceiverReport {
         }
         out += format!("\tProfile Extension Data: {:?}\n", self.profile_extensions).as_str();
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/receiver_report/receiver_report_test.rs
+++ b/rtcp/src/receiver_report/receiver_report_test.rs
@@ -230,8 +230,8 @@ fn test_receiver_report_roundtrip() {
             );
         } else {
             let mut data = got.ok().unwrap();
-            let actual = ReceiverReport::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
+            let actual =
+                ReceiverReport::unmarshal(&mut data).unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,

--- a/rtcp/src/receiver_report/receiver_report_test.rs
+++ b/rtcp/src/receiver_report/receiver_report_test.rs
@@ -118,25 +118,20 @@ fn test_receiver_report_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name}: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {}: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name}: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -224,28 +219,23 @@ fn test_receiver_report_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = ReceiverReport::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/reception_report.rs
+++ b/rtcp/src/reception_report.rs
@@ -47,7 +47,7 @@ pub struct ReceptionReport {
 
 impl fmt::Display for ReceptionReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rtcp/src/sender_report/mod.rs
+++ b/rtcp/src/sender_report/mod.rs
@@ -76,7 +76,7 @@ impl fmt::Display for SenderReport {
         }
         out += format!("\tProfile Extension Data: {:?}\n", self.profile_extensions).as_str();
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/sender_report/sender_report_test.rs
+++ b/rtcp/src/sender_report/sender_report_test.rs
@@ -118,25 +118,20 @@ fn test_sender_report_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name}: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {}: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name}: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -234,28 +229,23 @@ fn test_sender_report_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual =
-                SenderReport::unmarshal(&mut data).unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                SenderReport::unmarshal(&mut data).unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/source_description/mod.rs
+++ b/rtcp/src/source_description/mod.rs
@@ -53,7 +53,7 @@ impl fmt::Display for SdesType {
             SdesType::SdesNote => "NOTE",
             SdesType::SdesPrivate => "PRIV",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -285,10 +285,10 @@ impl fmt::Display for SourceDescription {
         for c in &self.chunks {
             out += format!("\t{:x}\n", c.source).as_str();
             for it in &c.items {
-                out += format!("\t\t{:?}\n", it).as_str();
+                out += format!("\t\t{it:?}\n").as_str();
             }
         }
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/source_description/source_description_test.rs
+++ b/rtcp/src/source_description/source_description_test.rs
@@ -199,25 +199,20 @@ fn test_source_description_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {}: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name}: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {}: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name}: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -341,28 +336,23 @@ fn test_source_description_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = SourceDescription::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/transport_feedbacks/rapid_resynchronization_request/rapid_resynchronization_request_test.rs
+++ b/rtcp/src/transport_feedbacks/rapid_resynchronization_request/rapid_resynchronization_request_test.rs
@@ -56,25 +56,20 @@ fn test_rapid_resynchronization_request_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} rr: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} rr: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -97,28 +92,23 @@ fn test_rapid_resynchronization_request_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = RapidResynchronizationRequest::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }

--- a/rtcp/src/transport_feedbacks/transport_layer_cc/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_cc/mod.rs
@@ -473,11 +473,11 @@ impl fmt::Display for TransportLayerCc {
         out += "\tpacket_chunks ";
         out += "\n\trecv_deltas ";
         for delta in &self.recv_deltas {
-            out += format!("{:?} ", delta).as_str();
+            out += format!("{delta:?} ").as_str();
         }
         out += "\n";
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/transport_feedbacks/transport_layer_cc/transport_layer_cc_test.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_cc/transport_layer_cc_test.rs
@@ -28,7 +28,7 @@ fn test_transport_layer_cc_run_length_chunk_unmarshal() -> Result<()> {
 
     for (name, mut data, want) in tests {
         let got = RunLengthChunk::unmarshal(&mut data)?;
-        assert_eq!(got, want, "Unmarshal {} : err", name,);
+        assert_eq!(got, want, "Unmarshal {name} : err",);
     }
 
     Ok(())
@@ -61,7 +61,7 @@ fn test_transport_layer_cc_run_length_chunk_marshal() -> Result<()> {
 
     for (name, chunk, want) in tests {
         let got = chunk.marshal()?;
-        assert_eq!(got, want, "Marshal {}: err", name,);
+        assert_eq!(got, want, "Marshal {name}: err",);
     }
 
     Ok(())
@@ -117,7 +117,7 @@ fn test_transport_layer_cc_status_vector_chunk_unmarshal() -> Result<()> {
 
     for (name, mut data, want) in tests {
         let got = StatusVectorChunk::unmarshal(&mut data)?;
-        assert_eq!(got, want, "Unmarshal {} : err", name,);
+        assert_eq!(got, want, "Unmarshal {name} : err",);
     }
 
     Ok(())
@@ -173,7 +173,7 @@ fn test_transport_layer_cc_status_vector_chunk_marshal() -> Result<()> {
 
     for (name, chunk, want) in tests {
         let got = chunk.marshal()?;
-        assert_eq!(got, want, "Marshal {}: err", name,);
+        assert_eq!(got, want, "Marshal {name}: err",);
     }
 
     Ok(())
@@ -213,7 +213,7 @@ fn test_transport_layer_cc_recv_delta_unmarshal() -> Result<()> {
 
     for (name, mut data, want) in tests {
         let got = RecvDelta::unmarshal(&mut data)?;
-        assert_eq!(got, want, "Unmarshal {} : err", name,);
+        assert_eq!(got, want, "Unmarshal {name} : err",);
     }
 
     Ok(())
@@ -253,7 +253,7 @@ fn test_transport_layer_cc_recv_delta_marshal() -> Result<()> {
 
     for (name, chunk, want) in tests {
         let got = chunk.marshal()?;
-        assert_eq!(got, want, "Marshal {}: err", name,);
+        assert_eq!(got, want, "Marshal {name}: err",);
     }
 
     Ok(())
@@ -604,7 +604,7 @@ fn test_transport_layer_cc_unmarshal() -> Result<()> {
 
     for (name, mut data, want) in tests {
         let got = TransportLayerCc::unmarshal(&mut data)?;
-        assert!(got == want, "Unmarshal {} : err", name,);
+        assert!(got == want, "Unmarshal {name} : err",);
     }
 
     Ok(())
@@ -919,7 +919,7 @@ fn test_transport_layer_cc_marshal() -> Result<()> {
 
     for (name, chunk, want) in tests {
         let got = chunk.marshal()?;
-        assert_eq!(got, want, "Marshal {}: err", name);
+        assert_eq!(got, want, "Marshal {name}: err");
     }
 
     Ok(())

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -120,7 +120,7 @@ impl fmt::Display for TransportLayerNack {
         for nack in &self.nacks {
             out += format!("\t{}\t{:b}\n", nack.packet_id, nack.lost_packets).as_str();
         }
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/transport_layer_nack_test.rs
@@ -65,25 +65,20 @@ fn test_transport_layer_nack_unmarshal() {
         assert_eq!(
             got.is_err(),
             want_error.is_some(),
-            "Unmarshal {} rr: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Unmarshal {name} rr: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let actual = got.unwrap();
             assert_eq!(
                 actual, want,
-                "Unmarshal {} rr: got {:?}, want {:?}",
-                name, actual, want
+                "Unmarshal {name} rr: got {actual:?}, want {want:?}"
             );
         }
     }
@@ -116,28 +111,23 @@ fn test_transport_layer_nack_roundtrip() {
         assert_eq!(
             got.is_ok(),
             want_error.is_none(),
-            "Marshal {}: err = {:?}, want {:?}",
-            name,
-            got,
-            want_error
+            "Marshal {name}: err = {got:?}, want {want_error:?}"
         );
 
         if let Some(err) = want_error {
             let got_err = got.err().unwrap();
             assert_eq!(
                 err, got_err,
-                "Unmarshal {} rr: err = {:?}, want {:?}",
-                name, got_err, err,
+                "Unmarshal {name} rr: err = {got_err:?}, want {err:?}",
             );
         } else {
             let mut data = got.ok().unwrap();
             let actual = TransportLayerNack::unmarshal(&mut data)
-                .unwrap_or_else(|_| panic!("Unmarshal {}", name));
+                .unwrap_or_else(|_| panic!("Unmarshal {name}"));
 
             assert_eq!(
                 actual, want,
-                "{} round trip: got {:?}, want {:?}",
-                name, actual, want
+                "{name} round trip: got {actual:?}, want {want:?}"
             )
         }
     }
@@ -148,7 +138,7 @@ fn test_nack_pair() {
     let test_nack = |s: Vec<u16>, n: NackPair| {
         let l = n.packet_list();
 
-        assert_eq!(s, l, "{:?}: expected {:?}, got {:?}", n, s, l);
+        assert_eq!(s, l, "{n:?}: expected {s:?}, got {l:?}");
     };
 
     test_nack(
@@ -354,8 +344,7 @@ fn test_transport_layer_nack_pair_generation() {
 
         assert_eq!(
             actual, expected,
-            "{} NackPair generation mismatch: got {:#?}, want {:#?}",
-            name, actual, expected
+            "{name} NackPair generation mismatch: got {actual:#?}, want {expected:#?}"
         )
     }
 }

--- a/rtcp/src/util.rs
+++ b/rtcp/src/util.rs
@@ -68,8 +68,7 @@ mod test {
             assert_eq!(
                 get_padding_size(n),
                 p,
-                "Test case returned wrong value for input {}",
-                n
+                "Test case returned wrong value for input {n}"
             );
         }
 
@@ -106,11 +105,11 @@ mod test {
         for (name, source, size, index, value, result, err) in tests {
             let res = set_nbits_of_uint16(source, size, index, value);
             if err.is_some() {
-                assert!(res.is_err(), "setNBitsOfUint16 {} : should be error", name);
+                assert!(res.is_err(), "setNBitsOfUint16 {name} : should be error");
             } else if let Ok(got) = res {
-                assert_eq!(got, result, "setNBitsOfUint16 {}", name);
+                assert_eq!(got, result, "setNBitsOfUint16 {name}");
             } else {
-                panic!("setNBitsOfUint16 {} :unexpected error result", name);
+                panic!("setNBitsOfUint16 {name} :unexpected error result");
             }
         }
 

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rtp"
 version = "0.6.8"
 authors = ["Rain Liu <yliu@webrtc.rs>", "Michael Uti <utimichael9@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of RTP"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/rtp"

--- a/rtp/benches/packet_bench.rs
+++ b/rtp/benches/packet_bench.rs
@@ -32,8 +32,7 @@ fn benchmark_packet(c: &mut Criterion) {
     let p = Packet::unmarshal(buf).unwrap();
     if pkt != p {
         panic!(
-            "marshal or unmarshal not correct: \npkt: {:?} \nvs \np: {:?}",
-            pkt, p
+            "marshal or unmarshal not correct: \npkt: {pkt:?} \nvs \np: {p:?}"
         );
     }
 

--- a/rtp/benches/packet_bench.rs
+++ b/rtp/benches/packet_bench.rs
@@ -31,9 +31,7 @@ fn benchmark_packet(c: &mut Criterion) {
     let buf = &mut raw.clone();
     let p = Packet::unmarshal(buf).unwrap();
     if pkt != p {
-        panic!(
-            "marshal or unmarshal not correct: \npkt: {pkt:?} \nvs \np: {p:?}"
-        );
+        panic!("marshal or unmarshal not correct: \npkt: {pkt:?} \nvs \np: {p:?}");
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/rtp/src/codecs/vp8/vp8_test.rs
+++ b/rtp/src/codecs/vp8/vp8_test.rs
@@ -167,10 +167,7 @@ fn test_vp8_payload() -> Result<()> {
     for (name, mut pck, mtu, payloads, expected) in tests {
         for (i, payload) in payloads.iter().enumerate() {
             let actual = pck.payload(mtu, payload)?;
-            assert_eq!(
-                expected[i], actual,
-                "{name}: Generated packet[{i}] differs"
-            );
+            assert_eq!(expected[i], actual, "{name}: Generated packet[{i}] differs");
         }
     }
 

--- a/rtp/src/codecs/vp8/vp8_test.rs
+++ b/rtp/src/codecs/vp8/vp8_test.rs
@@ -169,8 +169,7 @@ fn test_vp8_payload() -> Result<()> {
             let actual = pck.payload(mtu, payload)?;
             assert_eq!(
                 expected[i], actual,
-                "{}: Generated packet[{}] differs",
-                name, i
+                "{name}: Generated packet[{i}] differs"
             );
         }
     }

--- a/rtp/src/codecs/vp9/vp9_test.rs
+++ b/rtp/src/codecs/vp9/vp9_test.rs
@@ -217,15 +217,14 @@ fn test_vp9_packet_unmarshal() -> Result<()> {
             if let Err(actual) = p.depacketize(&b) {
                 assert_eq!(
                     expected, actual,
-                    "{}: expected {}, but got {}",
-                    name, expected, actual
+                    "{name}: expected {expected}, but got {actual}"
                 );
             } else {
-                panic!("{}: expected error, but got passed", name);
+                panic!("{name}: expected error, but got passed");
             }
         } else {
             let payload = p.depacketize(&b)?;
-            assert_eq!(pkt, p, "{}: expected {:?}, but got {:?}", name, pkt, p);
+            assert_eq!(pkt, p, "{name}: expected {pkt:?}, but got {p:?}");
             assert_eq!(payload, expected);
         }
     }
@@ -304,7 +303,7 @@ fn test_vp9_payloader_payload() -> Result<()> {
         for b in &bs {
             actual.extend(pck.payload(mtu, b)?);
         }
-        assert_eq!(actual, expected, "{}: Payloaded packet", name);
+        assert_eq!(actual, expected, "{name}: Payloaded packet");
     }
 
     //"PictureIDOverflow"

--- a/rtp/src/extension/abs_send_time_extension/abs_send_time_extension_test.rs
+++ b/rtp/src/extension/abs_send_time_extension/abs_send_time_extension_test.rs
@@ -59,8 +59,7 @@ fn test_ntp_conversion() -> Result<()> {
         let diff = input.duration_since(output).unwrap().as_nanos() as i128;
         if !(-ABS_SEND_TIME_RESOLUTION..=ABS_SEND_TIME_RESOLUTION).contains(&diff) {
             panic!(
-                "Converted time.Time from NTP time differs, expected: {:?}, got: {:?}",
-                input, output,
+                "Converted time.Time from NTP time differs, expected: {input:?}, got: {output:?}",
             );
         }
     }
@@ -112,8 +111,7 @@ fn test_abs_send_time_extension_estimate() -> Result<()> {
         let diff = estimated.duration_since(in_time).unwrap().as_nanos() as i128;
         if !(-ABS_SEND_TIME_RESOLUTION..=ABS_SEND_TIME_RESOLUTION).contains(&diff) {
             panic!(
-                "Converted time.Time from NTP time differs, expected: {:?}, got: {:?}",
-                in_time, estimated,
+                "Converted time.Time from NTP time differs, expected: {in_time:?}, got: {estimated:?}",
             );
         }
     }

--- a/rtp/src/extension/video_orientation_extension/mod.rs
+++ b/rtp/src/extension/video_orientation_extension/mod.rs
@@ -106,8 +106,7 @@ impl TryFrom<u8> for CameraDirection {
             0 => Ok(CameraDirection::Front),
             1 => Ok(CameraDirection::Back),
             _ => Err(util::Error::Other(format!(
-                "Unhandled camera direction: {}",
-                value
+                "Unhandled camera direction: {value}"
             ))),
         }
     }
@@ -123,8 +122,7 @@ impl TryFrom<u8> for VideoRotation {
             2 => Ok(VideoRotation::Degree180),
             3 => Ok(VideoRotation::Degree270),
             _ => Err(util::Error::Other(format!(
-                "Unhandled video rotation: {}",
-                value
+                "Unhandled video rotation: {value}"
             ))),
         }
     }

--- a/rtp/src/packet/mod.rs
+++ b/rtp/src/packet/mod.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Packet {
         out += format!("\tSSRC: {} ({:x})\n", self.header.ssrc, self.header.ssrc).as_str();
         out += format!("\tPayload Length: {}\n", self.payload.len()).as_str();
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/rtp/src/packet/packet_test.rs
+++ b/rtp/src/packet/packet_test.rs
@@ -42,8 +42,7 @@ fn test_basic() -> Result<()> {
     let packet = Packet::unmarshal(buf)?;
     assert_eq!(
         packet, parsed_packet,
-        "TestBasic unmarshal: got {}, want {}",
-        packet, parsed_packet
+        "TestBasic unmarshal: got {packet}, want {parsed_packet}"
     );
     assert_eq!(
         packet.header.marshal_size(),
@@ -69,8 +68,7 @@ fn test_basic() -> Result<()> {
     );
     assert_eq!(
         raw, raw_pkt,
-        "TestBasic marshal: got {:?}, want {:?}",
-        raw, raw_pkt
+        "TestBasic marshal: got {raw:?}, want {raw_pkt:?}"
     );
 
     Ok(())
@@ -335,8 +333,7 @@ fn test_rfc_8285_one_byte_multiple_extensions_with_padding() -> Result<()> {
         assert_eq!(
             &buf[..size],
             &raw_pkg_marshal[..],
-            "Marshalled fields are not equal for {}.",
-            name
+            "Marshalled fields are not equal for {name}."
         );
 
         Ok(())
@@ -406,9 +403,7 @@ fn test_rfc_8285_one_byte_multiple_extension() -> Result<()> {
     assert_eq!(
         &dst_data[..],
         raw_pkt,
-        "Marshal failed raw \nMarshaled:\n{:?}\nrawPkt:\n{:?}",
-        dst_data,
-        raw_pkt,
+        "Marshal failed raw \nMarshaled:\n{dst_data:?}\nrawPkt:\n{raw_pkt:?}",
     );
 
     Ok(())
@@ -449,8 +444,7 @@ fn test_rfc_8285_two_byte_extension() -> Result<()> {
     let dst_data = p.marshal()?;
     assert_eq!(
         dst_data, raw_pkt,
-        "Marshal failed raw \nMarshaled:\n{:?}\nrawPkt:\n{:?}",
-        dst_data, raw_pkt
+        "Marshal failed raw \nMarshaled:\n{dst_data:?}\nrawPkt:\n{raw_pkt:?}"
     );
     Ok(())
 }
@@ -480,24 +474,21 @@ fn test_rfc8285_two_byte_multiple_extension_with_padding() -> Result<()> {
     let ext_expect = Some(Bytes::from_static(&[]));
     assert_eq!(
         ext, ext_expect,
-        "Extension has incorrect data. Got: {:?}, Expected: {:?}",
-        ext, ext_expect
+        "Extension has incorrect data. Got: {ext:?}, Expected: {ext_expect:?}"
     );
 
     let ext = p.header.get_extension(2);
     let ext_expect = Some(Bytes::from_static(&[0xBB]));
     assert_eq!(
         ext, ext_expect,
-        "Extension has incorrect data. Got: {:?}, Expected: {:?}",
-        ext, ext_expect
+        "Extension has incorrect data. Got: {ext:?}, Expected: {ext_expect:?}"
     );
 
     let ext = p.header.get_extension(3);
     let ext_expect = Some(Bytes::from_static(&[0xCC, 0xCC, 0xCC, 0xCC]));
     assert_eq!(
         ext, ext_expect,
-        "Extension has incorrect data. Got: {:?}, Expected: {:?}",
-        ext, ext_expect
+        "Extension has incorrect data. Got: {ext:?}, Expected: {ext_expect:?}"
     );
 
     Ok(())
@@ -565,9 +556,7 @@ fn test_rfc8285_two_byte_multiple_extension_with_large_extension() -> Result<()>
     assert_eq!(
         dst_data,
         raw_pkt[..],
-        "Marshal failed raw \nMarshaled: {:?}, \nraw_pkt:{:?}",
-        dst_data,
-        raw_pkt
+        "Marshal failed raw \nMarshaled: {dst_data:?}, \nraw_pkt:{raw_pkt:?}"
     );
 
     Ok(())
@@ -686,7 +675,7 @@ fn test_rfc8285_get_extension_ids() {
 
     for id in ids {
         let ext = p.header.get_extension(id);
-        assert!(ext.is_some(), "Extension should exist for id: {}", id)
+        assert!(ext.is_some(), "Extension should exist for id: {id}")
     }
 }
 
@@ -1241,8 +1230,7 @@ fn test_round_trip() -> Result<()> {
 
     assert_eq!(
         raw_pkt, buf,
-        "buf must be the same as raw_pkt. \n buf: {:?},\nraw_pkt: {:?}",
-        buf, raw_pkt,
+        "buf must be the same as raw_pkt. \n buf: {buf:?},\nraw_pkt: {raw_pkt:?}",
     );
     assert_eq!(
         payload, p.payload,

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-sctp"
 version = "0.7.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of SCTP"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-sctp"

--- a/sctp/examples/ping.rs
+++ b/sctp/examples/ping.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Error> {
 
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await.unwrap());
     conn.connect(server).await.unwrap();
-    println!("connecting {}..", server);
+    println!("connecting {server}..");
 
     let config = Config {
         net_conn: conn,
@@ -81,8 +81,8 @@ async fn main() -> Result<(), Error> {
     tokio::spawn(async move {
         let mut ping_seq_num = 0;
         while ping_seq_num < 10 {
-            let ping_msg = format!("ping {}", ping_seq_num);
-            println!("sent: {}", ping_msg);
+            let ping_msg = format!("ping {ping_seq_num}");
+            println!("sent: {ping_msg}");
             stream_tx.write(&Bytes::from(ping_msg)).await?;
 
             ping_seq_num += 1;
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Error> {
         let mut buff = vec![0u8; 1024];
         while let Ok(n) = stream_rx.read(&mut buff).await {
             let pong_msg = String::from_utf8(buff[..n].to_vec()).unwrap();
-            println!("received: {}", pong_msg);
+            println!("received: {pong_msg}");
         }
 
         println!("finished recv pong");

--- a/sctp/examples/pong.rs
+++ b/sctp/examples/pong.rs
@@ -82,10 +82,10 @@ async fn main() -> Result<(), Error> {
         let mut buff = vec![0u8; 1024];
         while let Ok(n) = stream2.read(&mut buff).await {
             let ping_msg = String::from_utf8(buff[..n].to_vec()).unwrap();
-            println!("received: {}", ping_msg);
+            println!("received: {ping_msg}");
 
-            let pong_msg = format!("pong [{}]", ping_msg);
-            println!("sent: {}", pong_msg);
+            let pong_msg = format!("pong [{ping_msg}]");
+            println!("sent: {pong_msg}");
             stream2.write(&Bytes::from(pong_msg)).await?;
 
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/sctp/examples/throughput.rs
+++ b/sctp/examples/throughput.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
             .unwrap()
             .block_on(async move {
                 let conn = DisconnectedPacketConn::new(Arc::new(
-                    UdpSocket::bind(format!("127.0.0.1:{}", port1))
+                    UdpSocket::bind(format!("127.0.0.1:{port1}"))
                         .await
                         .unwrap(),
                 ));
@@ -91,8 +91,7 @@ fn main() -> Result<(), Error> {
                     loop_num += 1;
                     if now.elapsed().as_secs() == 1 {
                         println!(
-                            "Throughput: {} Bytes/s, {} pkts, {} loops",
-                            recv, pkt_num, loop_num
+                            "Throughput: {recv} Bytes/s, {pkt_num} pkts, {loop_num} loops"
                         );
                         now = tokio::time::Instant::now();
                         recv = 0;
@@ -109,8 +108,8 @@ fn main() -> Result<(), Error> {
             .unwrap()
             .block_on(async move {
                 let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await.unwrap());
-                conn.connect(format!("127.0.0.1:{}", port2)).await.unwrap();
-                println!("connecting 127.0.0.1:{}..", port2);
+                conn.connect(format!("127.0.0.1:{port2}")).await.unwrap();
+                println!("connecting 127.0.0.1:{port2}..");
 
                 let config = Config {
                     net_conn: conn,
@@ -137,7 +136,7 @@ fn main() -> Result<(), Error> {
                 while stream.write(&bytes).await.is_ok() {
                     pkt_num += 1;
                     if now.elapsed().as_secs() == 1 {
-                        println!("Send {} pkts", pkt_num);
+                        println!("Send {pkt_num} pkts");
                         now = tokio::time::Instant::now();
                         pkt_num = 0;
                     }

--- a/sctp/examples/throughput.rs
+++ b/sctp/examples/throughput.rs
@@ -57,9 +57,7 @@ fn main() -> Result<(), Error> {
             .unwrap()
             .block_on(async move {
                 let conn = DisconnectedPacketConn::new(Arc::new(
-                    UdpSocket::bind(format!("127.0.0.1:{port1}"))
-                        .await
-                        .unwrap(),
+                    UdpSocket::bind(format!("127.0.0.1:{port1}")).await.unwrap(),
                 ));
                 println!("listening {}...", conn.local_addr().unwrap());
 
@@ -90,9 +88,7 @@ fn main() -> Result<(), Error> {
                     }
                     loop_num += 1;
                     if now.elapsed().as_secs() == 1 {
-                        println!(
-                            "Throughput: {recv} Bytes/s, {pkt_num} pkts, {loop_num} loops"
-                        );
+                        println!("Throughput: {recv} Bytes/s, {pkt_num} pkts, {loop_num} loops");
                         now = tokio::time::Instant::now();
                         recv = 0;
                         loop_num = 0;

--- a/sctp/fuzz/Cargo.toml
+++ b/sctp/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "webrtc-sctp-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sctp/src/association/association_internal.rs
+++ b/sctp/src/association/association_internal.rs
@@ -1588,7 +1588,7 @@ impl AssociationInternal {
 
         let mut stream_str = String::new();
         for (si, ssn) in &stream_map {
-            stream_str += format!("(si={} ssn={})", si, ssn).as_str();
+            stream_str += format!("(si={si} ssn={ssn})").as_str();
             fwd_tsn.streams.push(ChunkForwardTsnStream {
                 identifier: *si,
                 sequence: *ssn,

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -333,7 +333,7 @@ async fn test_assoc_create_new_stream() -> Result<()> {
             let result = a.streams.get(&s.stream_identifier);
             assert!(result.is_some(), "should be in a.streams map");
         } else {
-            panic!("{} should success", i);
+            panic!("{i} should success");
         }
     }
 
@@ -383,10 +383,10 @@ async fn handle_init_test(name: &str, initial_state: AssociationState, expect_er
 
     let result = a.handle_init(&pkt, &init).await;
     if expect_err {
-        assert!(result.is_err(), "{} should fail", name);
+        assert!(result.is_err(), "{name} should fail");
         return;
     } else {
-        assert!(result.is_ok(), "{} should be ok", name);
+        assert!(result.is_ok(), "{name} should be ok");
     }
     assert_eq!(
         a.peer_last_tsn,
@@ -395,15 +395,14 @@ async fn handle_init_test(name: &str, initial_state: AssociationState, expect_er
         } else {
             init.initial_tsn - 1
         },
-        "{} should match",
-        name
+        "{name} should match"
     );
-    assert_eq!(a.my_max_num_outbound_streams, 1001, "{} should match", name);
-    assert_eq!(a.my_max_num_inbound_streams, 1002, "{} should match", name);
-    assert_eq!(a.peer_verification_tag, 5678, "{} should match", name);
-    assert_eq!(a.destination_port, pkt.source_port, "{} should match", name);
-    assert_eq!(a.source_port, pkt.destination_port, "{} should match", name);
-    assert!(a.use_forward_tsn, "{} should be set to true", name);
+    assert_eq!(a.my_max_num_outbound_streams, 1001, "{name} should match");
+    assert_eq!(a.my_max_num_inbound_streams, 1002, "{name} should match");
+    assert_eq!(a.peer_verification_tag, 5678, "{name} should match");
+    assert_eq!(a.destination_port, pkt.source_port, "{name} should match");
+    assert_eq!(a.source_port, pkt.destination_port, "{name} should match");
+    assert!(a.use_forward_tsn, "{name} should be set to true");
 }
 
 #[tokio::test]

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -2613,7 +2613,7 @@ async fn test_association_handle_packet_before_init() -> Result<()> {
 
         let packet = packet.marshal()?;
         let result = charlie_conn.send(&packet).await;
-        assert!(result.is_ok(), "{} charlie_conn.send should be ok", name);
+        assert!(result.is_ok(), "{name} charlie_conn.send should be ok");
 
         // Should not panic.
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/sctp/src/association/mod.rs
+++ b/sctp/src/association/mod.rs
@@ -102,7 +102,7 @@ impl fmt::Display for AssociationState {
             AssociationState::ShutdownReceived => "ShutdownReceived",
             AssociationState::ShutdownAckSent => "ShutdownAckSent",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -131,7 +131,7 @@ impl fmt::Display for RtxTimerId {
             RtxTimerId::T3RTX => "T3RTX",
             RtxTimerId::Reconfig => "Reconfig",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -155,7 +155,7 @@ impl fmt::Display for AckMode {
             AckMode::NoDelay => "NoDelay",
             AckMode::AlwaysDelay => "AlwaysDelay",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -180,7 +180,7 @@ impl fmt::Display for AckState {
             AckState::Immediate => "Immediate",
             AckState::Delay => "Delay",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/chunk/chunk_abort.rs
+++ b/sctp/src/chunk/chunk_abort.rs
@@ -34,7 +34,7 @@ impl fmt::Display for ChunkAbort {
         let mut res = vec![self.header().to_string()];
 
         for cause in &self.error_causes {
-            res.push(format!(" - {}", cause));
+            res.push(format!(" - {cause}"));
         }
 
         write!(f, "{}", res.join("\n"))

--- a/sctp/src/chunk/chunk_error.rs
+++ b/sctp/src/chunk/chunk_error.rs
@@ -36,7 +36,7 @@ impl fmt::Display for ChunkError {
         let mut res = vec![self.header().to_string()];
 
         for cause in &self.error_causes {
-            res.push(format!(" - {}", cause));
+            res.push(format!(" - {cause}"));
         }
 
         write!(f, "{}", res.join("\n"))

--- a/sctp/src/chunk/chunk_init.rs
+++ b/sctp/src/chunk/chunk_init.rs
@@ -110,7 +110,7 @@ impl fmt::Display for ChunkInit {
         );
 
         for (i, param) in self.params.iter().enumerate() {
-            res += format!("Param {}:\n {}", i, param).as_str();
+            res += format!("Param {i}:\n {param}").as_str();
         }
         write!(f, "{} {}", self.header(), res)
     }

--- a/sctp/src/chunk/chunk_payload_data.rs
+++ b/sctp/src/chunk/chunk_payload_data.rs
@@ -42,7 +42,7 @@ impl fmt::Display for PayloadProtocolIdentifier {
             PayloadProtocolIdentifier::BinaryEmpty => "WebRTC Binary (Empty)",
             _ => "Unknown Payload Protocol Identifier",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/chunk/chunk_reconfig.rs
+++ b/sctp/src/chunk/chunk_reconfig.rs
@@ -41,12 +41,12 @@ impl fmt::Display for ChunkReconfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut res = String::new();
         if let Some(param_a) = &self.param_a {
-            res += format!("Param A:\n {}", param_a).as_str();
+            res += format!("Param A:\n {param_a}").as_str();
         }
         if let Some(param_b) = &self.param_b {
-            res += format!("Param B:\n {}", param_b).as_str()
+            res += format!("Param B:\n {param_b}").as_str()
         }
-        write!(f, "{}", res)
+        write!(f, "{res}")
     }
 }
 

--- a/sctp/src/chunk/chunk_selective_ack.rs
+++ b/sctp/src/chunk/chunk_selective_ack.rs
@@ -65,10 +65,10 @@ impl fmt::Display for ChunkSelectiveAck {
         );
 
         for gap in &self.gap_ack_blocks {
-            res += format!("\n gap ack: {}", gap).as_str();
+            res += format!("\n gap ack: {gap}").as_str();
         }
 
-        write!(f, "{}", res)
+        write!(f, "{res}")
     }
 }
 

--- a/sctp/src/chunk/chunk_test.rs
+++ b/sctp/src/chunk/chunk_test.rs
@@ -32,9 +32,7 @@ fn test_chunk_type_string() -> Result<()> {
         assert_eq!(
             ct.to_string(),
             expected,
-            "failed to stringify chunkType {}, expected {}",
-            ct,
-            expected
+            "failed to stringify chunkType {ct}, expected {expected}"
         );
     }
 
@@ -225,7 +223,7 @@ fn test_chunk_forward_tsn_unmarshal_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ChunkForwardTsn::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -321,7 +319,7 @@ fn test_chunk_reconfig_unmarshal_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ChunkReconfig::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -374,7 +372,7 @@ fn test_chunk_shutdown_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ChunkShutdown::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -414,7 +412,7 @@ fn test_chunk_shutdown_ack_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ChunkShutdownAck::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -454,7 +452,7 @@ fn test_chunk_shutdown_complete_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ChunkShutdownComplete::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())

--- a/sctp/src/chunk/chunk_type.rs
+++ b/sctp/src/chunk/chunk_type.rs
@@ -47,7 +47,7 @@ impl fmt::Display for ChunkType {
             CT_FORWARD_TSN => "FORWARD-TSN",
             _ => others.as_str(),
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -82,9 +82,7 @@ mod test {
             assert_eq!(
                 ct.to_string(),
                 expected,
-                "failed to stringify chunkType {}, expected {}",
-                ct,
-                expected
+                "failed to stringify chunkType {ct}, expected {expected}"
             );
         }
     }

--- a/sctp/src/error_cause.rs
+++ b/sctp/src/error_cause.rs
@@ -42,7 +42,7 @@ impl fmt::Display for ErrorCauseCode {
             PROTOCOL_VIOLATION => "Protocol Violation",
             _ => others.as_str(),
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/packet.rs
+++ b/sctp/src/packet.rs
@@ -72,9 +72,9 @@ impl fmt::Display for Packet {
             self.source_port, self.destination_port, self.verification_tag,
         );
         for chunk in &self.chunks {
-            res += format!("Chunk: {}", chunk).as_str();
+            res += format!("Chunk: {chunk}").as_str();
         }
-        write!(f, "{}", res)
+        write!(f, "{res}")
     }
 }
 
@@ -289,7 +289,7 @@ mod test {
         ]);
         let pkt = Packet::unmarshal(&header_only)?;
         let header_only_marshaled = pkt.marshal()?;
-        assert_eq!(header_only, header_only_marshaled, "Unmarshal/Marshaled header only packet did not match \nheaderOnly: {:?} \nheader_only_marshaled {:?}", header_only, header_only_marshaled);
+        assert_eq!(header_only, header_only_marshaled, "Unmarshal/Marshaled header only packet did not match \nheaderOnly: {header_only:?} \nheader_only_marshaled {header_only_marshaled:?}");
 
         Ok(())
     }

--- a/sctp/src/param/param_reconfig_response.rs
+++ b/sctp/src/param/param_reconfig_response.rs
@@ -36,7 +36,7 @@ impl fmt::Display for ReconfigResult {
             ReconfigResult::InProgress => "6: In progress",
             _ => "Unknown ReconfigResult",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/param/param_requested_hmac_algorithm.rs
+++ b/sctp/src/param/param_requested_hmac_algorithm.rs
@@ -22,7 +22,7 @@ impl fmt::Display for HmacAlgorithm {
             HmacAlgorithm::HmacSha256 => "HMAC SHA-256",
             _ => "Unknown HMAC Algorithm",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/param/param_test.rs
+++ b/sctp/src/param/param_test.rs
@@ -61,7 +61,7 @@ fn test_param_header_unmarshal_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ParamHeader::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -97,7 +97,7 @@ fn test_param_forward_tsn_supported_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ParamForwardTsnSupported::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -158,7 +158,7 @@ fn test_param_outgoing_reset_request_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ParamOutgoingResetRequest::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -205,7 +205,7 @@ fn test_param_reconfig_response_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = ParamReconfigResponse::unmarshal(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())
@@ -231,7 +231,7 @@ fn test_reconfig_result_stringer() -> Result<()> {
 
     for (result, expected) in tests {
         let actual = result.to_string();
-        assert_eq!(actual, expected, "Test case {}", expected);
+        assert_eq!(actual, expected, "Test case {expected}");
     }
 
     Ok(())
@@ -263,7 +263,7 @@ fn test_build_param_failure() -> Result<()> {
 
     for (name, binary) in tests {
         let result = build_param(&binary);
-        assert!(result.is_err(), "expected unmarshal: {} to fail.", name);
+        assert!(result.is_err(), "expected unmarshal: {name} to fail.");
     }
 
     Ok(())

--- a/sctp/src/param/param_type.rs
+++ b/sctp/src/param/param_type.rs
@@ -92,7 +92,7 @@ impl fmt::Display for ParamType {
             ParamType::AdaptLayerInd => "Adaptation Layer Indication",
             _ => "Unknown ParamType",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/queue/payload_queue.rs
+++ b/sctp/src/queue/payload_queue.rs
@@ -132,7 +132,7 @@ impl PayloadQueue {
     }
 
     pub(crate) fn get_gap_ack_blocks_string(&self, cumulative_tsn: u32) -> String {
-        let mut s = format!("cumTSN={}", cumulative_tsn);
+        let mut s = format!("cumTSN={cumulative_tsn}");
         for b in self.get_gap_ack_blocks(cumulative_tsn) {
             s += format!(",{}-{}", b.start, b.end).as_str();
         }

--- a/sctp/src/queue/queue_test.rs
+++ b/sctp/src/queue/queue_test.rs
@@ -290,7 +290,7 @@ async fn test_pending_queue_push_and_pop() -> Result<()> {
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
         let result = pq.pop(beginning_fragment, unordered);
-        assert!(result.is_some(), "should not error: {}", i);
+        assert!(result.is_some(), "should not error: {i}");
     }
 
     assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
@@ -308,7 +308,7 @@ async fn test_pending_queue_push_and_pop() -> Result<()> {
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
 
         let result = pq.pop(beginning_fragment, unordered);
-        assert!(result.is_some(), "should not error: {}", i);
+        assert!(result.is_some(), "should not error: {i}");
     }
 
     assert_eq!(pq.get_num_bytes(), 0, "total bytes mismatch");
@@ -385,7 +385,7 @@ async fn test_pending_queue_fragments() -> Result<()> {
         assert_eq!(c.tsn, exp, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
         let result = pq.pop(beginning_fragment, unordered);
-        assert!(result.is_some(), "should not error: {}", exp);
+        assert!(result.is_some(), "should not error: {exp}");
     }
 
     Ok(())
@@ -419,7 +419,7 @@ async fn test_pending_queue_selection_persistence() -> Result<()> {
         assert_eq!(c.tsn, exp, "TSN should match");
         let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
         let result = pq.pop(beginning_fragment, unordered);
-        assert!(result.is_some(), "should not error: {}", exp);
+        assert!(result.is_some(), "should not error: {exp}");
     }
 
     Ok(())

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -48,7 +48,7 @@ impl fmt::Display for ReliabilityType {
             ReliabilityType::Rexmit => "Rexmit",
             ReliabilityType::Timed => "Timed",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sctp/src/timer/timer_test.rs
+++ b/sctp/src/timer/timer_test.rs
@@ -102,7 +102,7 @@ mod test_rto_manager {
         for i in 0..5 {
             m.set_new_rtt(600);
             let rto = m.get_rto();
-            assert_eq!(rto, exp[i], "should be equal: {}", i);
+            assert_eq!(rto, exp[i], "should be equal: {i}");
         }
 
         Ok(())
@@ -121,7 +121,7 @@ mod test_rto_manager {
         for i in 0..5 {
             m.set_new_rtt(30000);
             let rto = m.get_rto();
-            assert_eq!(rto, exp[i], "should be equal: {}", i);
+            assert_eq!(rto, exp[i], "should be equal: {i}");
         }
 
         Ok(())
@@ -197,7 +197,7 @@ mod test_rtx_timer {
             // 60 : 2 (90)
             // 120: 3 (210)
             // 240: 4 (550) <== expected in 650 msec
-            assert_eq!(self.timer_id, timer_id, "unexpected timer ID: {}", timer_id);
+            assert_eq!(self.timer_id, timer_id, "unexpected timer ID: {timer_id}");
             if (self.max_rtos > 0 && n_rtos == self.max_rtos) || self.max_rtos == usize::MAX {
                 if let Some(done) = &self.done_tx {
                     let elapsed = SystemTime::now();
@@ -209,7 +209,7 @@ mod test_rtx_timer {
         async fn on_retransmission_failure(&mut self, timer_id: RtxTimerId) {
             if self.max_rtos == 0 {
                 if let Some(done) = &self.done_tx {
-                    assert_eq!(self.timer_id, timer_id, "unexpted timer ID: {}", timer_id);
+                    assert_eq!(self.timer_id, timer_id, "unexpted timer ID: {timer_id}");
                     let elapsed = SystemTime::now();
                     //t.Logf("onRtxFailure: elapsed=%.03f\n", elapsed)
                     let _ = done.send(elapsed).await;

--- a/sctp/src/util.rs
+++ b/sctp/src/util.rs
@@ -96,112 +96,80 @@ mod test {
             if let (Some(s2f), Some(s2b)) = (s2f, s2b) {
                 assert!(
                     sna32lt(s1, s2f),
-                    "s1 < s2 should be true: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 < s2 should be true: s1={s1} s2={s2f}"
                 );
                 assert!(
                     !sna32lt(s1, s2b),
-                    "s1 < s2 should be false: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 < s2 should be false: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     !sna32gt(s1, s2f),
-                    "s1 > s2 should be false: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 > s2 should be false: s1={s1} s2={s2f}"
                 );
                 assert!(
                     sna32gt(s1, s2b),
-                    "s1 > s2 should be true: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 > s2 should be true: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     sna32lte(s1, s2f),
-                    "s1 <= s2 should be true: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 <= s2 should be true: s1={s1} s2={s2f}"
                 );
                 assert!(
                     !sna32lte(s1, s2b),
-                    "s1 <= s2 should be false: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 <= s2 should be false: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     !sna32gte(s1, s2f),
-                    "s1 >= s2 should be fales: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 >= s2 should be fales: s1={s1} s2={s2f}"
                 );
                 assert!(
                     sna32gte(s1, s2b),
-                    "s1 >= s2 should be true: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 >= s2 should be true: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     sna32eq(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
                 assert!(
                     sna32lte(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
                 assert!(
                     sna32gte(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
             }
 
             if let Some(s1add1) = s1.checked_add(1) {
                 assert!(
                     !sna32eq(s1, s1add1),
-                    "s1 == s1+1 should be false: s1={} s1+1={}",
-                    s1,
-                    s1add1
+                    "s1 == s1+1 should be false: s1={s1} s1+1={s1add1}"
                 );
             }
 
             if let Some(s1sub1) = s1.checked_sub(1) {
                 assert!(
                     !sna32eq(s1, s1sub1),
-                    "s1 == s1-1 hould be false: s1={} s1-1={}",
-                    s1,
-                    s1sub1
+                    "s1 == s1-1 hould be false: s1={s1} s1-1={s1sub1}"
                 );
             }
 
             assert!(
                 sna32eq(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
             assert!(
                 sna32lte(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
 
             assert!(
                 sna32gte(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
         }
 
@@ -223,111 +191,79 @@ mod test {
             if let (Some(s2f), Some(s2b)) = (s2f, s2b) {
                 assert!(
                     sna16lt(s1, s2f),
-                    "s1 < s2 should be true: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 < s2 should be true: s1={s1} s2={s2f}"
                 );
                 assert!(
                     !sna16lt(s1, s2b),
-                    "s1 < s2 should be false: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 < s2 should be false: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     !sna16gt(s1, s2f),
-                    "s1 > s2 should be fales: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 > s2 should be fales: s1={s1} s2={s2f}"
                 );
                 assert!(
                     sna16gt(s1, s2b),
-                    "s1 > s2 should be true: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 > s2 should be true: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     sna16lte(s1, s2f),
-                    "s1 <= s2 should be true: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 <= s2 should be true: s1={s1} s2={s2f}"
                 );
                 assert!(
                     !sna16lte(s1, s2b),
-                    "s1 <= s2 should be false: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 <= s2 should be false: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     !sna16gte(s1, s2f),
-                    "s1 >= s2 should be fales: s1={} s2={}",
-                    s1,
-                    s2f
+                    "s1 >= s2 should be fales: s1={s1} s2={s2f}"
                 );
                 assert!(
                     sna16gte(s1, s2b),
-                    "s1 >= s2 should be true: s1={} s2={}",
-                    s1,
-                    s2b
+                    "s1 >= s2 should be true: s1={s1} s2={s2b}"
                 );
 
                 assert!(
                     sna16eq(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
                 assert!(
                     sna16lte(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
                 assert!(
                     sna16gte(s2b, s2b),
-                    "s2 == s2 should be true: s2={} s2={}",
-                    s2b,
-                    s2b
+                    "s2 == s2 should be true: s2={s2b} s2={s2b}"
                 );
             }
 
             assert!(
                 sna16eq(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
 
             if let Some(s1add1) = s1.checked_add(1) {
                 assert!(
                     !sna16eq(s1, s1add1),
-                    "s1 == s1+1 should be false: s1={} s1+1={}",
-                    s1,
-                    s1add1
+                    "s1 == s1+1 should be false: s1={s1} s1+1={s1add1}"
                 );
             }
             if let Some(s1sub1) = s1.checked_sub(1) {
                 assert!(
                     !sna16eq(s1, s1sub1),
-                    "s1 == s1-1 hould be false: s1={} s1-1={}",
-                    s1,
-                    s1sub1
+                    "s1 == s1-1 hould be false: s1={s1} s1-1={s1sub1}"
                 );
             }
 
             assert!(
                 sna16lte(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
             assert!(
                 sna16gte(s1, s1),
-                "s1 == s1 should be true: s1={} s2={}",
-                s1,
-                s1
+                "s1 == s1 should be true: s1={s1} s2={s1}"
             );
         }
 

--- a/sctp/src/util.rs
+++ b/sctp/src/util.rs
@@ -94,10 +94,7 @@ mod test {
             let s2b = s1.checked_add(MAX_BACKWARD_DISTANCE);
 
             if let (Some(s2f), Some(s2b)) = (s2f, s2b) {
-                assert!(
-                    sna32lt(s1, s2f),
-                    "s1 < s2 should be true: s1={s1} s2={s2f}"
-                );
+                assert!(sna32lt(s1, s2f), "s1 < s2 should be true: s1={s1} s2={s2f}");
                 assert!(
                     !sna32lt(s1, s2b),
                     "s1 < s2 should be false: s1={s1} s2={s2b}"
@@ -107,10 +104,7 @@ mod test {
                     !sna32gt(s1, s2f),
                     "s1 > s2 should be false: s1={s1} s2={s2f}"
                 );
-                assert!(
-                    sna32gt(s1, s2b),
-                    "s1 > s2 should be true: s1={s1} s2={s2b}"
-                );
+                assert!(sna32gt(s1, s2b), "s1 > s2 should be true: s1={s1} s2={s2b}");
 
                 assert!(
                     sna32lte(s1, s2f),
@@ -158,19 +152,10 @@ mod test {
                 );
             }
 
-            assert!(
-                sna32eq(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
-            assert!(
-                sna32lte(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
+            assert!(sna32eq(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
+            assert!(sna32lte(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
 
-            assert!(
-                sna32gte(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
+            assert!(sna32gte(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
         }
 
         Ok(())
@@ -189,10 +174,7 @@ mod test {
             let s2b = s1.checked_add(MAX_BACKWARD_DISTANCE);
 
             if let (Some(s2f), Some(s2b)) = (s2f, s2b) {
-                assert!(
-                    sna16lt(s1, s2f),
-                    "s1 < s2 should be true: s1={s1} s2={s2f}"
-                );
+                assert!(sna16lt(s1, s2f), "s1 < s2 should be true: s1={s1} s2={s2f}");
                 assert!(
                     !sna16lt(s1, s2b),
                     "s1 < s2 should be false: s1={s1} s2={s2b}"
@@ -202,10 +184,7 @@ mod test {
                     !sna16gt(s1, s2f),
                     "s1 > s2 should be fales: s1={s1} s2={s2f}"
                 );
-                assert!(
-                    sna16gt(s1, s2b),
-                    "s1 > s2 should be true: s1={s1} s2={s2b}"
-                );
+                assert!(sna16gt(s1, s2b), "s1 > s2 should be true: s1={s1} s2={s2b}");
 
                 assert!(
                     sna16lte(s1, s2f),
@@ -239,10 +218,7 @@ mod test {
                 );
             }
 
-            assert!(
-                sna16eq(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
+            assert!(sna16eq(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
 
             if let Some(s1add1) = s1.checked_add(1) {
                 assert!(
@@ -257,14 +233,8 @@ mod test {
                 );
             }
 
-            assert!(
-                sna16lte(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
-            assert!(
-                sna16gte(s1, s1),
-                "s1 == s1 should be true: s1={s1} s2={s1}"
-            );
+            assert!(sna16lte(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
+            assert!(sna16gte(s1, s1), "s1 == s1 should be true: s1={s1} s2={s1}");
         }
 
         Ok(())

--- a/sdp/Cargo.toml
+++ b/sdp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdp"
 version = "0.5.3"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of SDP"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/sdp"

--- a/sdp/fuzz/Cargo.toml
+++ b/sdp/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "sdp-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdp/src/description/description_test.rs
+++ b/sdp/src/description/description_test.rs
@@ -173,9 +173,7 @@ fn test_marshal() -> Result<()> {
     let actual = sd.marshal();
     assert!(
         actual == CANONICAL_MARSHAL_SDP,
-        "error:\n\nEXPECTED:\n{}\nACTUAL:\n{}!!!!\n",
-        CANONICAL_MARSHAL_SDP,
-        actual
+        "error:\n\nEXPECTED:\n{CANONICAL_MARSHAL_SDP}\nACTUAL:\n{actual}!!!!\n"
     );
 
     Ok(())
@@ -537,12 +535,12 @@ fn test_round_trip() -> Result<()> {
         if let Ok(sdp) = sdp {
             let actual = sdp.marshal();
             if let Some(expected) = expected {
-                assert_eq!(actual.as_str(), expected, "{}\n{}", name, sdp_str);
+                assert_eq!(actual.as_str(), expected, "{name}\n{sdp_str}");
             } else {
-                assert_eq!(actual.as_str(), sdp_str, "{}\n{}", name, sdp_str);
+                assert_eq!(actual.as_str(), sdp_str, "{name}\n{sdp_str}");
             }
         } else {
-            panic!("{}\n{}", name, sdp_str);
+            panic!("{name}\n{sdp_str}");
         }
     }
 

--- a/sdp/src/description/media.rs
+++ b/sdp/src/description/media.rs
@@ -136,14 +136,14 @@ impl MediaDescription {
         fmtp: String,
     ) -> Self {
         self.media_name.formats.push(payload_type.to_string());
-        let mut rtpmap = format!("{} {}/{}", payload_type, name, clockrate);
+        let mut rtpmap = format!("{payload_type} {name}/{clockrate}");
         if channels > 0 {
-            rtpmap += format!("/{}", channels).as_str();
+            rtpmap += format!("/{channels}").as_str();
         }
 
         if !fmtp.is_empty() {
             self.with_value_attribute("rtpmap".to_string(), rtpmap)
-                .with_value_attribute("fmtp".to_string(), format!("{} {}", payload_type, fmtp))
+                .with_value_attribute("fmtp".to_string(), format!("{payload_type} {fmtp}"))
         } else {
             self.with_value_attribute("rtpmap".to_string(), rtpmap)
         }
@@ -158,10 +158,10 @@ impl MediaDescription {
         label: String,
     ) -> Self {
         self.
-            with_value_attribute("ssrc".to_string(), format!("{} cname:{}", ssrc, cname)). // Deprecated but not phased out?
-            with_value_attribute("ssrc".to_string(), format!("{} msid:{} {}", ssrc, stream_label, label)).
-            with_value_attribute("ssrc".to_string(), format!("{} mslabel:{}", ssrc, stream_label)). // Deprecated but not phased out?
-            with_value_attribute("ssrc".to_string(), format!("{} label:{}", ssrc, label))
+            with_value_attribute("ssrc".to_string(), format!("{ssrc} cname:{cname}")). // Deprecated but not phased out?
+            with_value_attribute("ssrc".to_string(), format!("{ssrc} msid:{stream_label} {label}")).
+            with_value_attribute("ssrc".to_string(), format!("{ssrc} mslabel:{stream_label}")). // Deprecated but not phased out?
+            with_value_attribute("ssrc".to_string(), format!("{ssrc} label:{label}"))
         // Deprecated but not phased out?
     }
 

--- a/sdp/src/description/session.rs
+++ b/sdp/src/description/session.rs
@@ -152,7 +152,7 @@ impl fmt::Display for RepeatTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fields = vec![format!("{}", self.interval), format!("{}", self.duration)];
         for value in &self.offsets {
-            fields.push(format!("{}", value));
+            fields.push(format!("{value}"));
         }
         write!(f, "{}", fields.join(" "))
     }
@@ -408,7 +408,7 @@ impl SessionDescription {
         result += key_value_build("i=", self.session_information.as_ref()).as_str();
 
         if let Some(uri) = &self.uri {
-            result += key_value_build("u=", Some(&format!("{}", uri))).as_str();
+            result += key_value_build("u=", Some(&format!("{uri}"))).as_str();
         }
         result += key_value_build("e=", self.email_address.as_ref()).as_str();
         result += key_value_build("p=", self.phone_number.as_ref()).as_str();
@@ -928,7 +928,7 @@ fn unmarshal_origin<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() != 6 {
-        return Err(Error::SdpInvalidSyntax(format!("`o={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`o={value}`")));
     }
 
     let session_id = fields[1].parse::<u64>()?;
@@ -1013,7 +1013,7 @@ fn unmarshal_session_connection_information<'a, R: io::BufRead + io::Seek>(
 fn unmarshal_connection_information(value: &str) -> Result<Option<ConnectionInformation>> {
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 2 {
-        return Err(Error::SdpInvalidSyntax(format!("`c={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`c={value}`")));
     }
 
     // Set according to currently registered with IANA
@@ -1058,7 +1058,7 @@ fn unmarshal_session_bandwidth<'a, R: io::BufRead + io::Seek>(
 fn unmarshal_bandwidth(value: &str) -> Result<Bandwidth> {
     let mut parts: Vec<&str> = value.split(':').collect();
     if parts.len() != 2 {
-        return Err(Error::SdpInvalidSyntax(format!("`b={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`b={value}`")));
     }
 
     let experimental = parts[0].starts_with("X-");
@@ -1089,7 +1089,7 @@ fn unmarshal_timing<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 2 {
-        return Err(Error::SdpInvalidSyntax(format!("`t={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`t={value}`")));
     }
 
     let start_time = fields[0].parse::<u64>()?;
@@ -1113,7 +1113,7 @@ fn unmarshal_repeat_times<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 3 {
-        return Err(Error::SdpInvalidSyntax(format!("`r={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`r={value}`")));
     }
 
     if let Some(latest_time_desc) = lexer.desc.time_descriptions.last_mut() {
@@ -1146,7 +1146,7 @@ fn unmarshal_time_zones<'a, R: io::BufRead + io::Seek>(
     // so we are making sure that there are actually multiple of 2 total.
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() % 2 != 0 {
-        return Err(Error::SdpInvalidSyntax(format!("`t={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`t={value}`")));
     }
 
     for i in (0..fields.len()).step_by(2) {
@@ -1199,7 +1199,7 @@ fn unmarshal_media_description<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 4 {
-        return Err(Error::SdpInvalidSyntax(format!("`m={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`m={value}`")));
     }
 
     // <media>

--- a/sdp/src/direction/mod.rs
+++ b/sdp/src/direction/mod.rs
@@ -32,7 +32,7 @@ impl fmt::Display for Direction {
             Direction::Inactive => DIRECTION_INACTIVE_STR,
             _ => DIRECTION_UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sdp/src/extmap/extmap_test.rs
+++ b/sdp/src/extmap/extmap_test.rs
@@ -16,10 +16,8 @@ const FAILING_ATTR_EXTMAP2: &str = "extmap:2/blorg http://example.com/082005/ext
 fn test_extmap() -> Result<()> {
     let example_attr_extmap1_line = EXAMPLE_ATTR_EXTMAP1;
     let example_attr_extmap2_line = EXAMPLE_ATTR_EXTMAP2;
-    let failing_attr_extmap1_line =
-        format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP1}{END_LINE}");
-    let failing_attr_extmap2_line =
-        format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP2}{END_LINE}");
+    let failing_attr_extmap1_line = format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP1}{END_LINE}");
+    let failing_attr_extmap2_line = format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP2}{END_LINE}");
     let passingtests = vec![
         (EXAMPLE_ATTR_EXTMAP1, example_attr_extmap1_line),
         (EXAMPLE_ATTR_EXTMAP2, example_attr_extmap2_line),

--- a/sdp/src/extmap/extmap_test.rs
+++ b/sdp/src/extmap/extmap_test.rs
@@ -17,9 +17,9 @@ fn test_extmap() -> Result<()> {
     let example_attr_extmap1_line = EXAMPLE_ATTR_EXTMAP1;
     let example_attr_extmap2_line = EXAMPLE_ATTR_EXTMAP2;
     let failing_attr_extmap1_line =
-        format!("{}{}{}", ATTRIBUTE_KEY, FAILING_ATTR_EXTMAP1, END_LINE);
+        format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP1}{END_LINE}");
     let failing_attr_extmap2_line =
-        format!("{}{}{}", ATTRIBUTE_KEY, FAILING_ATTR_EXTMAP2, END_LINE);
+        format!("{ATTRIBUTE_KEY}{FAILING_ATTR_EXTMAP2}{END_LINE}");
     let passingtests = vec![
         (EXAMPLE_ATTR_EXTMAP1, example_attr_extmap1_line),
         (EXAMPLE_ATTR_EXTMAP2, example_attr_extmap2_line),

--- a/sdp/src/extmap/mod.rs
+++ b/sdp/src/extmap/mod.rs
@@ -40,14 +40,14 @@ impl fmt::Display for ExtMap {
         }
 
         if let Some(uri) = &self.uri {
-            output += format!(" {}", uri).as_str();
+            output += format!(" {uri}").as_str();
         }
 
         if let Some(ext_attr) = &self.ext_attr {
-            output += format!(" {}", ext_attr).as_str();
+            output += format!(" {ext_attr}").as_str();
         }
 
-        write!(f, "{}", output)
+        write!(f, "{output}")
     }
 }
 

--- a/sdp/src/lexer/mod.rs
+++ b/sdp/src/lexer/mod.rs
@@ -59,7 +59,7 @@ pub fn index_of(element: &str, data: &[&str]) -> i32 {
 
 pub fn key_value_build(key: &str, value: Option<&String>) -> String {
     if let Some(val) = value {
-        format!("{}{}{}", key, val, END_LINE)
+        format!("{key}{val}{END_LINE}")
     } else {
         "".to_string()
     }

--- a/sdp/src/util/mod.rs
+++ b/sdp/src/util/mod.rs
@@ -46,7 +46,7 @@ impl fmt::Display for ConnectionRole {
             ConnectionRole::Holdconn => CONNECTION_ROLE_HOLDCONN_STR,
             _ => "Unspecified",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/sdp/src/util/util_test.rs
+++ b/sdp/src/util/util_test.rs
@@ -157,7 +157,7 @@ fn test_new_session_id() -> Result<()> {
         let r = new_session_id();
 
         if r > (1 << 63) - 1 {
-            panic!("Session ID must be less than 2**64-1, got {}", r)
+            panic!("Session ID must be less than 2**64-1, got {r}")
         }
         if r < min {
             min = r

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-srtp"
 version = "0.9.1"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of SRTP"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-srtp"

--- a/srtp/src/context/context_test.rs
+++ b/srtp/src/context/context_test.rs
@@ -26,7 +26,7 @@ fn test_context_roc() -> Result<()> {
     c.set_roc(123, 100);
     let roc = c.get_roc(123);
     if let Some(r) = roc {
-        assert_eq!(r, 100, "ROC is set to 100, but returned {}", r)
+        assert_eq!(r, 100, "ROC is set to 100, but returned {r}")
     } else {
         panic!("ROC must return value for used SSRC");
     }
@@ -53,7 +53,7 @@ fn test_context_index() -> Result<()> {
     c.set_index(123, 100);
     let index = c.get_index(123);
     if let Some(i) = index {
-        assert_eq!(i, 100, "Index is set to 100, but returned {}", i);
+        assert_eq!(i, 100, "Index is set to 100, but returned {i}");
     } else {
         panic!("Index must return true for used SSRC")
     }
@@ -116,8 +116,7 @@ fn test_valid_packet_counter() -> Result<()> {
     let counter = generate_counter(32846, s.rollover_counter, s.ssrc, &srtp_session_salt)?;
     assert_eq!(
         counter, expected_counter,
-        "Session Key {:?} does not match expected {:?}",
-        counter, expected_counter,
+        "Session Key {counter:?} does not match expected {expected_counter:?}",
     );
 
     Ok(())
@@ -199,8 +198,7 @@ fn test_rollover_count() -> Result<()> {
     let roc = s.next_rollover_count(0);
     assert_eq!(
         roc, 2,
-        "rolloverCounter must be incremented after wrapping, got {}",
-        roc
+        "rolloverCounter must be incremented after wrapping, got {roc}"
     );
 
     Ok(())

--- a/srtp/src/key_derivation.rs
+++ b/srtp/src/key_derivation.rs
@@ -129,8 +129,7 @@ mod test {
         )?;
         assert_eq!(
             session_key, expected_session_key,
-            "Session Key:\n{:?} \ndoes not match expected:\n{:?}\nMaster Key:\n{:?}\nMaster Salt:\n{:?}\n",
-            session_key, expected_session_key, master_key, master_salt,
+            "Session Key:\n{session_key:?} \ndoes not match expected:\n{expected_session_key:?}\nMaster Key:\n{master_key:?}\nMaster Salt:\n{master_salt:?}\n",
         );
 
         let session_salt = aes_cm_key_derivation(
@@ -142,8 +141,7 @@ mod test {
         )?;
         assert_eq!(
             session_salt, expected_session_salt,
-            "Session Salt {:?} does not match expected {:?}",
-            session_salt, expected_session_salt
+            "Session Salt {session_salt:?} does not match expected {expected_session_salt:?}"
         );
 
         let auth_key_len = ProtectionProfile::Aes128CmHmacSha1_80.auth_key_len();
@@ -157,8 +155,7 @@ mod test {
         )?;
         assert_eq!(
             session_auth_tag, expected_session_auth_tag,
-            "Session Auth Tag {:?} does not match expected {:?}",
-            session_auth_tag, expected_session_auth_tag,
+            "Session Auth Tag {session_auth_tag:?} does not match expected {expected_session_auth_tag:?}",
         );
 
         Ok(())

--- a/srtp/src/session/session_rtcp_test.rs
+++ b/srtp/src/session/session_rtcp_test.rs
@@ -88,8 +88,7 @@ async fn test_session_srtcp_accept() -> Result<()> {
     let ssrc = read_stream.get_ssrc();
     assert_eq!(
         ssrc, TEST_SSRC,
-        "SSRC mismatch during accept exp({}) actual({})",
-        TEST_SSRC, ssrc
+        "SSRC mismatch during accept exp({TEST_SSRC}) actual({ssrc})"
     );
 
     let mut read_buffer = BytesMut::with_capacity(test_payload.len());

--- a/srtp/src/session/session_rtp_test.rs
+++ b/srtp/src/session/session_rtp_test.rs
@@ -97,8 +97,7 @@ async fn test_session_srtp_accept() -> Result<()> {
     let ssrc = read_stream.get_ssrc();
     assert_eq!(
         ssrc, TEST_SSRC,
-        "SSRC mismatch during accept exp({}) actual({})",
-        TEST_SSRC, ssrc
+        "SSRC mismatch during accept exp({TEST_SSRC}) actual({ssrc})"
     );
 
     read_stream.read(&mut read_buffer).await?;

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stun"
 version = "0.4.4"
 authors = ["Rain Liu <yuliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of STUN"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/stun"

--- a/stun/examples/stun_client.rs
+++ b/stun/examples/stun_client.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Error> {
     let conn = UdpSocket::bind("0:0").await?;
     println!("Local address: {}", conn.local_addr()?);
 
-    println!("Connecting to: {}", server);
+    println!("Connecting to: {server}");
     conn.connect(server).await?;
 
     let mut client = ClientBuilder::new().with_conn(Arc::new(conn)).build()?;
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Error> {
         let msg = event.event_body?;
         let mut xor_addr = XorMappedAddress::default();
         xor_addr.get_from(&msg)?;
-        println!("Got response: {}", xor_addr);
+        println!("Got response: {xor_addr}");
     }
 
     client.close().await?;

--- a/stun/examples/stun_decode.rs
+++ b/stun/examples/stun_decode.rs
@@ -30,14 +30,14 @@ fn main() {
     let encoded_data = matches.value_of("data").unwrap();
     let decoded_data = match base64::decode(encoded_data) {
         Ok(d) => d,
-        Err(e) => panic!("Unable to decode base64 value: {}", e),
+        Err(e) => panic!("Unable to decode base64 value: {e}"),
     };
 
     let mut message = Message::new();
     message.raw = decoded_data;
 
     match message.decode() {
-        Ok(_) => println!("{}", message),
-        Err(e) => panic!("Unable to decode message: {}", e),
+        Ok(_) => println!("{message}"),
+        Err(e) => panic!("Unable to decode message: {e}"),
     }
 }

--- a/stun/src/addr.rs
+++ b/stun/src/addr.rs
@@ -71,7 +71,7 @@ impl MappedAddress {
 
         let family = u16::from_be_bytes([v[0], v[1]]);
         if family != FAMILY_IPV6 && family != FAMILY_IPV4 {
-            return Err(Error::Other(format!("bad value {}", family)));
+            return Err(Error::Other(format!("bad value {family}")));
         }
         self.port = u16::from_be_bytes([v[2], v[3]]);
 

--- a/stun/src/addr/addr_test.rs
+++ b/stun/src/addr/addr_test.rs
@@ -8,7 +8,7 @@ fn test_mapped_address() -> Result<()> {
         ip: "122.12.34.5".parse().unwrap(),
         port: 5412,
     };
-    assert_eq!(addr.to_string(), "122.12.34.5:5412", "bad string {}", addr);
+    assert_eq!(addr.to_string(), "122.12.34.5:5412", "bad string {addr}");
 
     //"add_to"
     {
@@ -28,8 +28,7 @@ fn test_mapped_address() -> Result<()> {
                     assert_eq!(
                         Error::ErrAttributeNotFound,
                         err,
-                        "should be not found: {}",
-                        err
+                        "should be not found: {err}"
                     );
                 } else {
                     panic!("expected error, but got ok");

--- a/stun/src/attributes.rs
+++ b/stun/src/attributes.rs
@@ -69,7 +69,7 @@ impl fmt::Display for AttrType {
             _ => other.as_str(),
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/stun/src/attributes/attributes_test.rs
+++ b/stun/src/attributes/attributes_test.rs
@@ -58,7 +58,7 @@ fn test_padding() -> Result<()> {
 
     for (i, o) in tt {
         let got = nearest_padded_value_length(i);
-        assert_eq!(got, o, "padd({}) {} (got) != {} (expected)", i, got, o,);
+        assert_eq!(got, o, "padd({i}) {got} (got) != {o} (expected)",);
     }
 
     Ok(())

--- a/stun/src/integrity/integrity_test.rs
+++ b/stun/src/integrity/integrity_test.rs
@@ -55,7 +55,7 @@ fn test_message_integrity_with_fingerprint() -> Result<()> {
     a.add_to(&mut m)?;
 
     let i = MessageIntegrity::new_short_term_integrity("pwd".to_owned());
-    assert_eq!(i.to_string(), "KEY: 0x[70, 77, 64]", "bad string {}", i);
+    assert_eq!(i.to_string(), "KEY: 0x[70, 77, 64]", "bad string {i}");
     let result = i.check(&mut m);
     assert!(result.is_err(), "should error");
 

--- a/stun/src/message.rs
+++ b/stun/src/message.rs
@@ -283,8 +283,7 @@ impl Message {
 
         if cookie != MAGIC_COOKIE {
             return Err(Error::Other(format!(
-                "{:x} is invalid magic cookie (should be {:x})",
-                cookie, MAGIC_COOKIE
+                "{cookie:x} is invalid magic cookie (should be {MAGIC_COOKIE:x})"
             )));
         }
         if buf.len() < full_size {
@@ -465,7 +464,7 @@ impl fmt::Display for MessageClass {
             _ => "unknown message class",
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -507,7 +506,7 @@ impl fmt::Display for Method {
             _ => unknown.as_str(),
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/stun/src/message/message_test.rs
+++ b/stun/src/message/message_test.rs
@@ -21,7 +21,7 @@ fn test_message_buffer() -> Result<()> {
     let mut reader = BufReader::new(m.raw.as_slice());
     m_decoded.read_from(&mut reader)?;
 
-    assert_eq!(m_decoded, m, "{} != {}", m_decoded, m);
+    assert_eq!(m_decoded, m, "{m_decoded} != {m}");
 
     Ok(())
 }
@@ -61,7 +61,7 @@ fn test_message_type_value() -> Result<()> {
 
     for (input, output) in tests {
         let b = input.value();
-        assert_eq!(b, output, "Value({}) -> {}, want {}", input, b, output);
+        assert_eq!(b, output, "Value({input}) -> {b}, want {output}");
     }
 
     Ok(())
@@ -96,7 +96,7 @@ fn test_message_type_read_value() -> Result<()> {
     for (input, output) in tests {
         let mut m = MessageType::default();
         m.read_value(input);
-        assert_eq!(m, output, "ReadValue({}) -> {}, want {}", input, m, output);
+        assert_eq!(m, output, "ReadValue({input}) -> {m}, want {output}");
     }
 
     Ok(())
@@ -129,8 +129,7 @@ fn test_message_type_read_write_value() -> Result<()> {
         m.read_value(v);
         assert_eq!(
             m, test,
-            "ReadValue({} -> {}) = {}, should be {}",
-            test, v, m, test
+            "ReadValue({test} -> {v}) = {m}, should be {test}"
         );
     }
 
@@ -156,7 +155,7 @@ fn test_message_write_to() -> Result<()> {
     let mut m_decoded = Message::new();
     let mut reader = BufReader::new(buf.as_slice());
     m_decoded.read_from(&mut reader)?;
-    assert_eq!(m_decoded, m, "{} != {}", m_decoded, m);
+    assert_eq!(m_decoded, m, "{m_decoded} != {m}");
 
     Ok(())
 }
@@ -288,13 +287,13 @@ fn test_message_class_string() -> Result<()> {
 
     for k in v {
         if k.to_string() == *"unknown message class" {
-            panic!("bad stringer {}", k);
+            panic!("bad stringer {k}");
         }
     }
 
     // should panic
     let p = MessageClass(0x05).to_string();
-    assert_eq!(p, "unknown message class", "should be error {}", p);
+    assert_eq!(p, "unknown message class", "should be error {p}");
 
     Ok(())
 }
@@ -600,7 +599,7 @@ fn test_is_message() -> Result<()> {
 
     for (input, output) in tests {
         let got = is_message(&input);
-        assert_eq!(got, output, "IsMessage({:?}) {} != {}", input, got, output);
+        assert_eq!(got, output, "IsMessage({input:?}) {got} != {output}");
     }
 
     Ok(())

--- a/stun/src/message/message_test.rs
+++ b/stun/src/message/message_test.rs
@@ -127,10 +127,7 @@ fn test_message_type_read_write_value() -> Result<()> {
         let mut m = MessageType::default();
         let v = test.value();
         m.read_value(v);
-        assert_eq!(
-            m, test,
-            "ReadValue({test} -> {v}) = {m}, should be {test}"
-        );
+        assert_eq!(m, test, "ReadValue({test} -> {v}) = {m}, should be {test}");
     }
 
     Ok(())

--- a/stun/src/textattrs.rs
+++ b/stun/src/textattrs.rs
@@ -85,7 +85,7 @@ impl TextAttribute {
             ATTR_REALM => {}
             ATTR_SOFTWARE => {}
             ATTR_NONCE => {}
-            _ => return Err(Error::Other(format!("Unsupported AttrType {}", attr))),
+            _ => return Err(Error::Other(format!("Unsupported AttrType {attr}"))),
         };
 
         let a = m.get(attr)?;

--- a/stun/src/textattrs/textattrs_test.rs
+++ b/stun/src/textattrs/textattrs_test.rs
@@ -25,10 +25,7 @@ fn test_software_get_from() -> Result<()> {
     assert!(ok, "sowfware attribute should be found");
 
     let s = s_attr.to_string();
-    assert!(
-        s.starts_with("SOFTWARE:"),
-        "bad string representation {s}"
-    );
+    assert!(s.starts_with("SOFTWARE:"), "bad string representation {s}");
 
     Ok(())
 }

--- a/stun/src/textattrs/textattrs_test.rs
+++ b/stun/src/textattrs/textattrs_test.rs
@@ -19,7 +19,7 @@ fn test_software_get_from() -> Result<()> {
     let mut reader = BufReader::new(m.raw.as_slice());
     m2.read_from(&mut reader)?;
     let software = TextAttribute::get_from_as(&m, ATTR_SOFTWARE)?;
-    assert_eq!(software.to_string(), v, "Expected {}, got {}.", v, software);
+    assert_eq!(software.to_string(), v, "Expected {v}, got {software}.");
 
     let (s_attr, ok) = m.attributes.get(ATTR_SOFTWARE);
     assert!(ok, "sowfware attribute should be found");
@@ -27,8 +27,7 @@ fn test_software_get_from() -> Result<()> {
     let s = s_attr.to_string();
     assert!(
         s.starts_with("SOFTWARE:"),
-        "bad string representation {}",
-        s
+        "bad string representation {s}"
     );
 
     Ok(())
@@ -45,8 +44,7 @@ fn test_software_add_to_invalid() -> Result<()> {
     if let Err(err) = result {
         assert!(
             is_attr_size_overflow(&err),
-            "add_to should return AttrOverflowErr, got: {}",
-            err
+            "add_to should return AttrOverflowErr, got: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -103,8 +101,7 @@ fn test_username() -> Result<()> {
         if let Err(err) = result {
             assert!(
                 is_attr_size_overflow(&err),
-                "add_to should return *AttrOverflowErr, got: {}",
-                err
+                "add_to should return *AttrOverflowErr, got: {err}"
             );
         } else {
             panic!("expected error, but got ok");
@@ -120,9 +117,7 @@ fn test_username() -> Result<()> {
             assert_eq!(
                 got.to_string(),
                 username,
-                "expedted: {}, got: {}",
-                username,
-                got
+                "expedted: {username}, got: {got}"
             );
             //"Not found"
             {
@@ -182,13 +177,13 @@ fn test_realm_get_from() -> Result<()> {
     m2.read_from(&mut reader)?;
 
     let r = TextAttribute::get_from_as(&m, ATTR_REALM)?;
-    assert_eq!(r.to_string(), v, "Expected {}, got {}.", v, r);
+    assert_eq!(r.to_string(), v, "Expected {v}, got {r}.");
 
     let (r_attr, ok) = m.attributes.get(ATTR_REALM);
     assert!(ok, "realm attribute should be found");
 
     let s = r_attr.to_string();
-    assert!(s.starts_with("REALM:"), "bad string representation {}", s);
+    assert!(s.starts_with("REALM:"), "bad string representation {s}");
 
     Ok(())
 }
@@ -204,8 +199,7 @@ fn test_realm_add_to_invalid() -> Result<()> {
     if let Err(err) = result {
         assert!(
             is_attr_size_overflow(&err),
-            "add_to should return AttrOverflowErr, got: {}",
-            err
+            "add_to should return AttrOverflowErr, got: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -256,13 +250,13 @@ fn test_nonce_get_from() -> Result<()> {
     m2.read_from(&mut reader)?;
 
     let r = TextAttribute::get_from_as(&m, ATTR_NONCE)?;
-    assert_eq!(r.to_string(), v, "Expected {}, got {}.", v, r);
+    assert_eq!(r.to_string(), v, "Expected {v}, got {r}.");
 
     let (r_attr, ok) = m.attributes.get(ATTR_NONCE);
     assert!(ok, "realm attribute should be found");
 
     let s = r_attr.to_string();
-    assert!(s.starts_with("NONCE:"), "bad string representation {}", s);
+    assert!(s.starts_with("NONCE:"), "bad string representation {s}");
 
     Ok(())
 }
@@ -278,8 +272,7 @@ fn test_nonce_add_to_invalid() -> Result<()> {
     if let Err(err) = result {
         assert!(
             is_attr_size_overflow(&err),
-            "add_to should return AttrOverflowErr, got: {}",
-            err
+            "add_to should return AttrOverflowErr, got: {err}"
         );
     } else {
         panic!("expected error, but got ok");
@@ -311,7 +304,7 @@ fn test_nonce_add_to() -> Result<()> {
     n.add_to(&mut m)?;
 
     let v = m.get(ATTR_NONCE)?;
-    assert_eq!(v.as_slice(), b"example.org", "bad nonce {:?}", v);
+    assert_eq!(v.as_slice(), b"example.org", "bad nonce {v:?}");
 
     Ok(())
 }

--- a/stun/src/uattrs/uattrs_test.rs
+++ b/stun/src/uattrs/uattrs_test.rs
@@ -7,8 +7,7 @@ fn test_unknown_attributes() -> Result<()> {
     assert_eq!(
         a.to_string(),
         "DONT-FRAGMENT, CHANNEL-NUMBER",
-        "bad String:{}",
-        a
+        "bad String:{a}"
     );
     assert_eq!(
         UnknownAttributes(vec![]).to_string(),

--- a/stun/src/uri/uri_test.rs
+++ b/stun/src/uri/uri_test.rs
@@ -47,8 +47,8 @@ fn test_parse_uri() -> Result<()> {
 
     for (name, input, output, expected_str) in tests {
         let out = Uri::parse_uri(input)?;
-        assert_eq!(out, output, "{}: {} != {}", name, out, output);
-        assert_eq!(out.to_string(), expected_str, "{}", name);
+        assert_eq!(out, output, "{name}: {out} != {output}");
+        assert_eq!(out.to_string(), expected_str, "{name}");
     }
 
     //"MustFail"
@@ -60,7 +60,7 @@ fn test_parse_uri() -> Result<()> {
         ];
         for (name, input) in tests {
             let result = Uri::parse_uri(input);
-            assert!(result.is_err(), "{} should fail, but did not", name);
+            assert!(result.is_err(), "{name} should fail, but did not");
         }
     }
 

--- a/stun/src/xoraddr.rs
+++ b/stun/src/xoraddr.rs
@@ -142,7 +142,7 @@ impl XorMappedAddress {
 
         let family = u16::from_be_bytes([v[0], v[1]]);
         if family != FAMILY_IPV6 && family != FAMILY_IPV4 {
-            return Err(Error::Other(format!("bad value {}", family)));
+            return Err(Error::Other(format!("bad value {family}")));
         }
 
         check_overflow(

--- a/stun/src/xoraddr/xoraddr_test.rs
+++ b/stun/src/xoraddr/xoraddr_test.rs
@@ -91,8 +91,7 @@ fn test_xormapped_address_get_from() -> Result<()> {
         if let Err(err) = result {
             assert!(
                 is_attr_size_overflow(&err),
-                "AddTo should return AttrOverflowErr, got: {}",
-                err
+                "AddTo should return AttrOverflowErr, got: {err}"
             );
         } else {
             panic!("expected error, got ok");
@@ -240,9 +239,7 @@ fn test_xormapped_address_string() -> Result<()> {
         assert_eq!(
             addr.to_string(),
             ip,
-            " XORMappesAddres.String() {} (got) != {} (expected)",
-            addr,
-            ip,
+            " XORMappesAddres.String() {addr} (got) != {ip} (expected)",
         );
     }
 

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turn"
 version = "0.6.1"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of TURN"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/turn"

--- a/turn/examples/turn_client_udp.rs
+++ b/turn/examples/turn_client_udp.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Error> {
     // TURN client won't create a local listening socket by itself.
     let conn = UdpSocket::bind("0.0.0.0:0").await?;
 
-    let turn_server_addr = format!("{}:{}", host, port);
+    let turn_server_addr = format!("{host}:{port}");
 
     let cfg = ClientConfig {
         stun_serv_addr: turn_server_addr.clone(),
@@ -150,7 +150,7 @@ async fn do_ping_test(
                 Err(_) => break,
             };
 
-            println!("pingerConn read-loop: {} from {}", msg, from);
+            println!("pingerConn read-loop: {msg} from {from}");
             /*if sentAt, pingerErr := time.Parse(time.RFC3339Nano, msg); pingerErr == nil {
                 rtt := time.Since(sentAt)
                 log.Printf("%d bytes from from %s time=%d ms\n", n, from.String(), int(rtt.Seconds()*1000))

--- a/turn/examples/turn_server_udp.rs
+++ b/turn/examples/turn_server_udp.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Error> {
     // Create a UDP listener to pass into pion/turn
     // turn itself doesn't allocate any UDP sockets, but lets the user pass them in
     // this allows us to add logging, storage or modify inbound/outbound traffic
-    let conn = Arc::new(UdpSocket::bind(format!("0.0.0.0:{}", port)).await?);
+    let conn = Arc::new(UdpSocket::bind(format!("0.0.0.0:{port}")).await?);
     println!("listening {}...", conn.local_addr()?);
 
     let server = Server::new(ServerConfig {

--- a/turn/src/allocation/allocation_manager/allocation_manager_test.rs
+++ b/turn/src/allocation/allocation_manager/allocation_manager_test.rs
@@ -97,7 +97,7 @@ async fn test_packet_handler() -> Result<()> {
         a.relay_socket.local_addr()?.port()
     };
 
-    let relay_addr_with_host_str = format!("127.0.0.1:{}", port);
+    let relay_addr_with_host_str = format!("127.0.0.1:{port}");
     let relay_addr_with_host = SocketAddr::from_str(&relay_addr_with_host_str)?;
 
     // test for permission and data message
@@ -227,8 +227,7 @@ async fn test_delete_allocation() -> Result<()> {
 
     assert!(
         m.get_allocation(&five_tuple).await.is_none(),
-        "Get allocation with {} should be nil after delete",
-        five_tuple
+        "Get allocation with {five_tuple} should be nil after delete"
     );
 
     Ok(())
@@ -422,8 +421,8 @@ async fn create_client(username: String, server_port: u16) -> Result<Client> {
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
 
     Client::new(ClientConfig {
-        stun_serv_addr: format!("127.0.0.1:{}", server_port),
-        turn_serv_addr: format!("127.0.0.1:{}", server_port),
+        stun_serv_addr: format!("127.0.0.1:{server_port}"),
+        turn_serv_addr: format!("127.0.0.1:{server_port}"),
         username,
         password: "pass".to_owned(),
         realm: String::new(),
@@ -458,13 +457,13 @@ async fn test_get_allocations_info() -> Result<()> {
     assert_eq!(server.get_allocations_info(None).await?.len(), 3);
 
     let addr1 = client1
-        .send_binding_request_to(format!("127.0.0.1:{}", server_port).as_str())
+        .send_binding_request_to(format!("127.0.0.1:{server_port}").as_str())
         .await?;
     let addr2 = client2
-        .send_binding_request_to(format!("127.0.0.1:{}", server_port).as_str())
+        .send_binding_request_to(format!("127.0.0.1:{server_port}").as_str())
         .await?;
     let addr3 = client3
-        .send_binding_request_to(format!("127.0.0.1:{}", server_port).as_str())
+        .send_binding_request_to(format!("127.0.0.1:{server_port}").as_str())
         .await?;
 
     user1.send_to(b"1", addr1).await?;
@@ -500,7 +499,7 @@ async fn test_get_allocations_info_bytes_count() -> Result<()> {
 
     let conn = client.allocate().await?;
     let addr = client
-        .send_binding_request_to(format!("127.0.0.1:{}", server_port).as_str())
+        .send_binding_request_to(format!("127.0.0.1:{server_port}").as_str())
         .await?;
 
     assert!(!server.get_allocations_info(None).await?.is_empty());

--- a/turn/src/allocation/five_tuple/five_tuple_test.rs
+++ b/turn/src/allocation/five_tuple/five_tuple_test.rs
@@ -8,13 +8,11 @@ fn test_five_tuple_protocol() -> Result<()> {
 
     assert_eq!(
         udp_expect, PROTO_UDP,
-        "Invalid UDP Protocol value, expect {} but {}",
-        udp_expect, PROTO_UDP
+        "Invalid UDP Protocol value, expect {udp_expect} but {PROTO_UDP}"
     );
     assert_eq!(
         tcp_expect, PROTO_TCP,
-        "Invalid TCP Protocol value, expect {} but {}",
-        tcp_expect, PROTO_TCP
+        "Invalid TCP Protocol value, expect {tcp_expect} but {PROTO_TCP}"
     );
 
     assert_eq!(udp_expect.to_string(), "UDP");
@@ -94,8 +92,7 @@ fn test_five_tuple_equal() -> Result<()> {
         let fact = a == b;
         assert_eq!(
             expect, fact,
-            "{}: {}, {} equal check should be {}, but {}",
-            name, a, b, expect, fact
+            "{name}: {a}, {b} equal check should be {expect}, but {fact}"
         );
     }
 

--- a/turn/src/auth/auth_test.rs
+++ b/turn/src/auth/auth_test.rs
@@ -9,8 +9,7 @@ fn test_lt_cred() -> Result<()> {
     let actual_password = long_term_credentials(username, shared_secret);
     assert_eq!(
         expected_password, actual_password,
-        "Expected {}, got {}",
-        expected_password, actual_password
+        "Expected {expected_password}, got {actual_password}"
     );
 
     Ok(())
@@ -28,8 +27,7 @@ fn test_generate_auth_key() -> Result<()> {
     let actual_key = generate_auth_key(username, realm, password);
     assert_eq!(
         expected_key, actual_key,
-        "Expected {:?}, got {:?}",
-        expected_key, actual_key
+        "Expected {expected_key:?}, got {actual_key:?}"
     );
 
     Ok(())
@@ -79,8 +77,8 @@ async fn test_new_long_term_auth_handler() -> Result<()> {
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
 
     let client = Client::new(ClientConfig {
-        stun_serv_addr: format!("0.0.0.0:{}", server_port),
-        turn_serv_addr: format!("0.0.0.0:{}", server_port),
+        stun_serv_addr: format!("0.0.0.0:{server_port}"),
+        turn_serv_addr: format!("0.0.0.0:{server_port}"),
         username,
         password,
         realm: "webrtc.rs".to_owned(),

--- a/turn/src/auth/mod.rs
+++ b/turn/src/auth/mod.rs
@@ -35,7 +35,7 @@ fn long_term_credentials(username: &str, shared_secret: &str) -> String {
 
 // generate_auth_key is a convenience function to easily generate keys in the format used by AuthHandler
 pub fn generate_auth_key(username: &str, realm: &str, password: &str) -> Vec<u8> {
-    let s = format!("{}:{}:{}", username, realm, password);
+    let s = format!("{username}:{realm}:{password}");
 
     let mut h = Md5::new();
     h.update(s.as_bytes());
@@ -58,8 +58,7 @@ impl AuthHandler for LongTermAuthHandler {
         let t = Duration::from_secs(username.parse::<u64>()?);
         if t < SystemTime::now().duration_since(UNIX_EPOCH)? {
             return Err(Error::Other(format!(
-                "Expired time-windowed username {}",
-                username
+                "Expired time-windowed username {username}"
             )));
         }
 

--- a/turn/src/client/client_test.rs
+++ b/turn/src/client/client_test.rs
@@ -156,8 +156,8 @@ async fn test_client_nonce_expiration() -> Result<()> {
     let conn = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
 
     let client = Client::new(ClientConfig {
-        stun_serv_addr: format!("127.0.0.1:{}", server_port),
-        turn_serv_addr: format!("127.0.0.1:{}", server_port),
+        stun_serv_addr: format!("127.0.0.1:{server_port}"),
+        turn_serv_addr: format!("127.0.0.1:{server_port}"),
         username: "foo".to_owned(),
         password: "pass".to_owned(),
         realm: String::new(),

--- a/turn/src/client/relay_conn.rs
+++ b/turn/src/client/relay_conn.rs
@@ -185,7 +185,7 @@ impl<T: RelayConnObserver + Send + Sync> Conn for RelayConn<T> {
         let _ = relay_conn
             .close()
             .await
-            .map_err(|err| util::Error::Other(format!("{}", err)));
+            .map_err(|err| util::Error::Other(format!("{err}")));
         Ok(())
     }
 }

--- a/turn/src/proto/addr/addr_test.rs
+++ b/turn/src/proto/addr/addr_test.rs
@@ -74,7 +74,7 @@ fn test_five_tuple_equal() -> Result<()> {
 
     for (name, a, b, r) in tests {
         let v = a == b;
-        assert_eq!(v, r, "({}) {} [{}!={}] {}", name, a, v, r, b);
+        assert_eq!(v, r, "({name}) {a} [{v}!={r}] {b}");
     }
 
     Ok(())

--- a/turn/src/proto/chandata/chandata_test.rs
+++ b/turn/src/proto/chandata/chandata_test.rs
@@ -119,10 +119,7 @@ fn test_channel_data_decode() -> Result<()> {
             ..Default::default()
         };
         if let Err(err) = m.decode() {
-            assert_eq!(
-                want_err, err,
-                "unexpected: ({name}) {want_err} != {err}"
-            );
+            assert_eq!(want_err, err, "unexpected: ({name}) {want_err} != {err}");
         } else {
             panic!("expected error, but got ok");
         }

--- a/turn/src/proto/chandata/chandata_test.rs
+++ b/turn/src/proto/chandata/chandata_test.rs
@@ -86,7 +86,7 @@ fn test_channel_data_equal() -> Result<()> {
 
     for (name, a, b, r) in tests {
         let v = a == b;
-        assert_eq!(v, r, "unexpected: ({}) {} != {}", name, r, r);
+        assert_eq!(v, r, "unexpected: ({name}) {r} != {r}");
     }
 
     Ok(())
@@ -121,8 +121,7 @@ fn test_channel_data_decode() -> Result<()> {
         if let Err(err) = m.decode() {
             assert_eq!(
                 want_err, err,
-                "unexpected: ({}) {} != {}",
-                name, want_err, err
+                "unexpected: ({name}) {want_err} != {err}"
             );
         } else {
             panic!("expected error, but got ok");
@@ -158,7 +157,7 @@ fn test_is_channel_data() -> Result<()> {
 
     for (name, buf, r) in tests {
         let v = ChannelData::is_channel_data(&buf);
-        assert_eq!(v, r, "unexpected: ({}) {} != {}", name, r, v);
+        assert_eq!(v, r, "unexpected: ({name}) {r} != {v}");
     }
 
     Ok(())

--- a/turn/src/proto/channum/channnum_test.rs
+++ b/turn/src/proto/channum/channnum_test.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_channel_number_string() -> Result<(), stun::Error> {
     let n = ChannelNumber(112);
-    assert_eq!(n.to_string(), "112", "bad string {}, expected 112", n);
+    assert_eq!(n.to_string(), "112", "bad string {n}, expected 112");
     Ok(())
 }
 
@@ -48,7 +48,7 @@ fn test_channel_number_add_to() -> Result<(), stun::Error> {
 
         let mut num_decoded = ChannelNumber::default();
         num_decoded.get_from(&decoded)?;
-        assert_eq!(num_decoded, n, "Decoded {}, expected {}", num_decoded, n);
+        assert_eq!(num_decoded, n, "Decoded {num_decoded}, expected {n}");
 
         //"HandleErr"
         {
@@ -58,8 +58,7 @@ fn test_channel_number_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             } else {
                 panic!("expected error, but got ok");

--- a/turn/src/proto/data/data_test.rs
+++ b/turn/src/proto/data/data_test.rs
@@ -24,8 +24,7 @@ fn test_data_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             }
         }

--- a/turn/src/proto/evenport/evenport_test.rs
+++ b/turn/src/proto/evenport/evenport_test.rs
@@ -6,16 +6,14 @@ fn test_even_port_string() -> Result<(), stun::Error> {
     assert_eq!(
         p.to_string(),
         "reserve: false",
-        "bad value {} for reselve: false",
-        p
+        "bad value {p} for reselve: false"
     );
 
     p.reserve_port = true;
     assert_eq!(
         p.to_string(),
         "reserve: true",
-        "bad value {} for reselve: true",
-        p
+        "bad value {p} for reselve: true"
     );
 
     Ok(())
@@ -51,7 +49,7 @@ fn test_even_port_add_to() -> Result<(), stun::Error> {
         decoded.write(&m.raw)?;
         let mut port = EvenPort::default();
         port.get_from(&decoded)?;
-        assert_eq!(port, p, "Decoded {}, expected {}", port, p);
+        assert_eq!(port, p, "Decoded {port}, expected {p}");
 
         //"HandleErr"
         {
@@ -61,8 +59,7 @@ fn test_even_port_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             }
             m.add(ATTR_EVEN_PORT, &[1, 2, 3]);

--- a/turn/src/proto/lifetime/lifetime_test.rs
+++ b/turn/src/proto/lifetime/lifetime_test.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_lifetime_string() -> Result<(), stun::Error> {
     let l = Lifetime(Duration::from_secs(10));
-    assert_eq!(l.to_string(), "10s", "bad string {}, expected 10s", l);
+    assert_eq!(l.to_string(), "10s", "bad string {l}, expected 10s");
 
     Ok(())
 }
@@ -22,7 +22,7 @@ fn test_lifetime_add_to() -> Result<(), stun::Error> {
 
         let mut life = Lifetime::default();
         life.get_from(&decoded)?;
-        assert_eq!(life, l, "Decoded {}, expected {}", life, l);
+        assert_eq!(life, l, "Decoded {life}, expected {l}");
 
         //"HandleErr"
         {
@@ -32,8 +32,7 @@ fn test_lifetime_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             } else {
                 panic!("expected error, but got ok");

--- a/turn/src/proto/mod.rs
+++ b/turn/src/proto/mod.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Protocol {
             _ => others.as_str(),
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/turn/src/proto/reqfamily.rs
+++ b/turn/src/proto/reqfamily.rs
@@ -23,7 +23,7 @@ impl fmt::Display for RequestedAddressFamily {
             REQUESTED_FAMILY_IPV6 => "IPv6",
             _ => "unknown",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/turn/src/proto/reqfamily/reqfamily_test.rs
+++ b/turn/src/proto/reqfamily/reqfamily_test.rs
@@ -40,7 +40,7 @@ fn test_requested_address_family_add_to() -> Result<(), stun::Error> {
         decoded.write(&m.raw)?;
         let mut req = RequestedAddressFamily::default();
         req.get_from(&decoded)?;
-        assert_eq!(req, r, "Decoded {}, expected {}", req, r);
+        assert_eq!(req, r, "Decoded {req}, expected {r}");
 
         //"HandleErr"
         {
@@ -50,8 +50,7 @@ fn test_requested_address_family_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             } else {
                 panic!("expected error, but got ok");

--- a/turn/src/proto/reqtrans/reqtrans_test.rs
+++ b/turn/src/proto/reqtrans/reqtrans_test.rs
@@ -43,7 +43,7 @@ fn test_requested_transport_add_to() -> Result<(), stun::Error> {
             protocol: PROTO_UDP,
         };
         req.get_from(&decoded)?;
-        assert_eq!(req, r, "Decoded {}, expected {}", req, r);
+        assert_eq!(req, r, "Decoded {req}, expected {r}");
 
         //"HandleErr"
         {
@@ -53,8 +53,7 @@ fn test_requested_transport_add_to() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             } else {
                 panic!("expected error, got ok");

--- a/turn/src/proto/rsrvtoken/rsrvtoken_test.rs
+++ b/turn/src/proto/rsrvtoken/rsrvtoken_test.rs
@@ -29,7 +29,7 @@ fn test_reservation_token() -> Result<(), stun::Error> {
         decoded.write(&m.raw)?;
         let mut tok = ReservationToken::default();
         tok.get_from(&decoded)?;
-        assert_eq!(tok, tk, "Decoded {:?}, expected {:?}", tok, tk);
+        assert_eq!(tok, tk, "Decoded {tok:?}, expected {tk:?}");
 
         //"HandleErr"
         {
@@ -39,8 +39,7 @@ fn test_reservation_token() -> Result<(), stun::Error> {
                 assert_eq!(
                     stun::Error::ErrAttributeNotFound,
                     err,
-                    "{} should be not found",
-                    err
+                    "{err} should be not found"
                 );
             } else {
                 panic!("expected error, but got ok");

--- a/turn/src/server/request/request_test.rs
+++ b/turn/src/server/request/request_test.rs
@@ -27,8 +27,7 @@ async fn test_allocation_lifetime_parsing() -> Result<()> {
     let lifetime_duration = allocation_lifetime(&m);
     assert_eq!(
         lifetime_duration, lifetime.0,
-        "Expect lifetime_duration is {}, but {:?}",
-        lifetime, lifetime_duration
+        "Expect lifetime_duration is {lifetime}, but {lifetime_duration:?}"
     );
 
     Ok(())
@@ -44,8 +43,7 @@ async fn test_allocation_lifetime_overflow() -> Result<()> {
     let lifetime_duration = allocation_lifetime(&m2);
     assert_eq!(
         lifetime_duration, DEFAULT_LIFETIME,
-        "Expect lifetime_duration is {:?}, but {:?}",
-        DEFAULT_LIFETIME, lifetime_duration
+        "Expect lifetime_duration is {DEFAULT_LIFETIME:?}, but {lifetime_duration:?}"
     );
 
     Ok(())

--- a/turn/src/server/server_test.rs
+++ b/turn/src/server/server_test.rs
@@ -84,7 +84,7 @@ async fn test_server_simple() -> Result<()> {
     client.listen().await?;
 
     client
-        .send_binding_request_to(format!("127.0.0.1:{}", server_port).as_str())
+        .send_binding_request_to(format!("127.0.0.1:{server_port}").as_str())
         .await?;
 
     client.close().await?;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc-util"
 version = "0.7.0"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "Utilities for WebRTC.rs stack"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc-util"

--- a/util/examples/display-interfaces.rs
+++ b/util/examples/display-interfaces.rs
@@ -4,7 +4,7 @@ use webrtc_util::ifaces::ifaces;
 fn main() -> Result<(), Box<dyn Error>> {
     let interfaces = ifaces()?;
     for (index, interface) in interfaces.iter().enumerate() {
-        println!("{} {:?}", index, interface);
+        println!("{index} {interface:?}");
     }
     Ok(())
 }

--- a/util/src/buffer/buffer_test.rs
+++ b/util/src/buffer/buffer_test.rs
@@ -321,12 +321,12 @@ async fn test_buffer_limit_sizes() {
         // Next write is expected to be errored.
         let result = buffer.write(&pkt).await;
         assert!(result.is_err(), "{}", name);
-        assert_eq!(result.unwrap_err(), Error::ErrBufferFull, "{}", name);
+        assert_eq!(result.unwrap_err(), Error::ErrBufferFull, "{name}");
 
         let mut packet = vec![0; size];
         for _ in 0..n_packets {
             let n = assert_ok!(buffer.read(&mut packet, Some(Duration::new(5, 0))).await);
-            assert_eq!(n, PACKET_SIZE, "{}", name);
+            assert_eq!(n, PACKET_SIZE, "{name}");
         }
     }
 }

--- a/util/src/conn/conn_bridge_test.rs
+++ b/util/src/conn/conn_bridge_test.rs
@@ -234,9 +234,9 @@ async fn test_bridge_drop_next_n_packets() -> Result<()> {
 
         let mut msgs = vec![];
         for i in 0..5u8 {
-            let msg = format!("msg{}", i);
+            let msg = format!("msg{i}");
             let n = src_conn.send(msg.as_bytes()).await?;
-            assert_eq!(n, msg.len(), "[{}] unexpected length", id);
+            assert_eq!(n, msg.len(), "[{id}] unexpected length");
             msgs.push(msg);
             br.process().await;
         }
@@ -245,7 +245,7 @@ async fn test_bridge_drop_next_n_packets() -> Result<()> {
             if let Some(buf) = rx.recv().await {
                 assert_eq!(msgs[i + 3].as_bytes(), &buf);
             } else {
-                panic!("{} unexpected number of packets", id);
+                panic!("{id} unexpected number of packets");
             }
         }
     }

--- a/util/src/conn/conn_test.rs
+++ b/util/src/conn/conn_test.rs
@@ -7,16 +7,14 @@ async fn test_conn_lookup_host() -> Result<()> {
     if let Ok(ipv4_addr) = lookup_host(true, stun_serv_addr).await {
         assert!(
             ipv4_addr.is_ipv4(),
-            "expected ipv4 but got ipv6: {}",
-            ipv4_addr
+            "expected ipv4 but got ipv6: {ipv4_addr}"
         );
     }
 
     if let Ok(ipv6_addr) = lookup_host(false, stun_serv_addr).await {
         assert!(
             ipv6_addr.is_ipv6(),
-            "expected ipv6 but got ipv4: {}",
-            ipv6_addr
+            "expected ipv6 but got ipv4: {ipv6_addr}"
         );
     }
 

--- a/util/src/conn/conn_udp_listener_test.rs
+++ b/util/src/conn/conn_udp_listener_test.rs
@@ -42,8 +42,7 @@ async fn pipe() -> Result<(
     let result = String::from_utf8(buf[..n].to_vec())?;
     if handshake != result {
         Err(Error::Other(format!(
-            "errHandshakeFailed: {} != {}",
-            handshake, result
+            "errHandshakeFailed: {handshake} != {result}"
         )))
     } else {
         Ok((listener, l_conn, d_conn))
@@ -145,8 +144,8 @@ async fn test_listener_accept_filter() -> Result<()> {
             }
         }
 
-        assert_eq!(accepted, expected, "{}: unexpected result", name);
-        assert_eq!(!timeout, expected, "{}: unexpected result", name);
+        assert_eq!(accepted, expected, "{name}: unexpected result");
+        assert_eq!(!timeout, expected, "{name}: unexpected result");
 
         conn.close().await?;
         listener.close().await?;

--- a/util/src/fixed_big_int/mod.rs
+++ b/util/src/fixed_big_int/mod.rs
@@ -17,7 +17,7 @@ impl fmt::Display for FixedBigInt {
             out += format!("{:016X}", self.bits[i]).as_str();
         }
 
-        write!(f, "{}", out)
+        write!(f, "{out}")
     }
 }
 

--- a/util/src/marshal/mod.rs
+++ b/util/src/marshal/mod.rs
@@ -18,8 +18,7 @@ pub trait Marshal: MarshalSize {
         let n = self.marshal_to(&mut buf)?;
         if n != l {
             Err(Error::Other(format!(
-                "marshal_to output size {}, but expect {}",
-                n, l
+                "marshal_to output size {n}, but expect {l}"
             )))
         } else {
             Ok(buf.freeze())

--- a/util/src/replay_detector/replay_detector_test.rs
+++ b/util/src/replay_detector/replay_detector_test.rs
@@ -272,7 +272,7 @@ fn test_replay_detector() {
                 }
             }
 
-            assert_eq!(&out, exp, "{} failed", name);
+            assert_eq!(&out, exp, "{name} failed");
         }
     }
 }

--- a/util/src/vnet/nat.rs
+++ b/util/src/vnet/nat.rs
@@ -235,7 +235,7 @@ impl NetworkAddressTranslator {
                             proto: "udp".to_owned(),
                             local: from.source_addr().to_string(),
                             bound,
-                            mapped: format!("{}:{}", mapped_ips_first, mapped_port),
+                            mapped: format!("{mapped_ips_first}:{mapped_port}"),
                             filters: Arc::new(Mutex::new(HashSet::new())),
                             expires: Arc::new(Mutex::new(
                                 SystemTime::now().add(self.nat_type.mapping_life_time),
@@ -306,7 +306,7 @@ impl NetworkAddressTranslator {
                 let dst_addr = from.destination_addr();
                 if let Some(dst_ip) = self.get_paired_local_ip(&dst_addr.ip()) {
                     let dst_port = from.destination_addr().port();
-                    to.set_destination_addr(&format!("{}:{}", dst_ip, dst_port))?;
+                    to.set_destination_addr(&format!("{dst_ip}:{dst_port}"))?;
                 } else {
                     return Err(Error::Other(format!(
                         "drop {} as {:?}",

--- a/util/src/vnet/net/net_test.rs
+++ b/util/src/vnet/net/net_test.rs
@@ -106,10 +106,9 @@ async fn test_net_native_loopback() -> Result<()> {
     assert_eq!(
         &buf[..n],
         msg.as_bytes(),
-        "should match msg content {}",
-        msg
+        "should match msg content {msg}"
     );
-    assert_eq!(laddr, raddr, "should match addr {}", laddr);
+    assert_eq!(laddr, raddr, "should match addr {laddr}");
 
     Ok(())
 }
@@ -229,13 +228,13 @@ async fn test_net_virtual_has_ipaddr() -> Result<()> {
     if let Net::VNet(vnet) = &nw {
         let net = vnet.lock().await;
         let ip = Ipv4Addr::from_str("127.0.0.1")?.into();
-        assert!(net.has_ipaddr(ip), "the IP addr {} should exist", ip);
+        assert!(net.has_ipaddr(ip), "the IP addr {ip} should exist");
 
         let ip = Ipv4Addr::from_str("10.1.2.3")?.into();
-        assert!(net.has_ipaddr(ip), "the IP addr {} should exist", ip);
+        assert!(net.has_ipaddr(ip), "the IP addr {ip} should exist");
 
         let ip = Ipv4Addr::from_str("192.168.1.1")?.into();
-        assert!(!net.has_ipaddr(ip), "the IP addr {} should exist", ip);
+        assert!(!net.has_ipaddr(ip), "the IP addr {ip} should exist");
     }
     Ok(())
 }
@@ -285,7 +284,7 @@ async fn test_net_virtual_assign_port() -> Result<()> {
     {
         let nic = nw.get_nic()?;
         let mut nic = nic.lock().await;
-        let ipnet = IpNet::from_str(&format!("{}/24", addr))?;
+        let ipnet = IpNet::from_str(&format!("{addr}/24"))?;
         nic.add_addrs_to_interface("eth0", &[ipnet]).await?;
     }
 
@@ -337,7 +336,7 @@ async fn test_net_virtual_determine_source_ip() -> Result<()> {
     {
         let nic = nw.get_nic()?;
         let mut nic = nic.lock().await;
-        let ipnet = IpNet::from_str(&format!("{}/24", DEMO_IP))?;
+        let ipnet = IpNet::from_str(&format!("{DEMO_IP}/24"))?;
         nic.add_addrs_to_interface("eth0", &[ipnet]).await?;
     }
 
@@ -426,10 +425,9 @@ async fn test_net_virtual_loopback1() -> Result<()> {
     assert_eq!(
         &buf[..n],
         msg.as_bytes(),
-        "should match msg content {}",
-        msg
+        "should match msg content {msg}"
     );
-    assert_eq!(laddr, raddr, "should match addr {}", laddr);
+    assert_eq!(laddr, raddr, "should match addr {laddr}");
 
     Ok(())
 }
@@ -547,8 +545,7 @@ async fn test_net_virtual_resolver() -> Result<()> {
         assert_eq!(
             raddr.to_string(),
             "30.31.32.33:1234",
-            "{} should match 30.31.32.33:1234",
-            raddr
+            "{raddr} should match 30.31.32.33:1234"
         );
 
         drop(done_tx);
@@ -570,8 +567,7 @@ async fn test_net_virtual_loopback2() -> Result<()> {
     assert_eq!(
         laddr.to_string().as_str(),
         "127.0.0.1:50916",
-        "{} should match 127.0.0.1:50916",
-        laddr
+        "{laddr} should match 127.0.0.1:50916"
     );
 
     let mut c = ChunkUdp::new(
@@ -598,7 +594,7 @@ async fn test_net_virtual_loopback2() -> Result<()> {
                         }
                     };
 
-                    assert_eq!(n, 6, "{} should match 6", n);
+                    assert_eq!(n, 6, "{n} should match 6");
                     assert_eq!(addr.to_string(), "127.0.0.1:4000", "addr should match");
                     assert_eq!(&buf[..n], b"Hello!", "buf should match");
 

--- a/util/src/vnet/net/net_test.rs
+++ b/util/src/vnet/net/net_test.rs
@@ -103,11 +103,7 @@ async fn test_net_native_loopback() -> Result<()> {
     let mut buf = vec![0u8; 1000];
     let (n, raddr) = conn.recv_from(&mut buf).await?;
     assert_eq!(n, msg.len(), "should match msg size {}", msg.len());
-    assert_eq!(
-        &buf[..n],
-        msg.as_bytes(),
-        "should match msg content {msg}"
-    );
+    assert_eq!(&buf[..n], msg.as_bytes(), "should match msg content {msg}");
     assert_eq!(laddr, raddr, "should match addr {laddr}");
 
     Ok(())
@@ -422,11 +418,7 @@ async fn test_net_virtual_loopback1() -> Result<()> {
     let mut buf = vec![0u8; 1000];
     let (n, raddr) = conn.recv_from(&mut buf).await?;
     assert_eq!(n, msg.len(), "should match msg size {}", msg.len());
-    assert_eq!(
-        &buf[..n],
-        msg.as_bytes(),
-        "should match msg content {msg}"
-    );
+    assert_eq!(&buf[..n], msg.as_bytes(), "should match msg content {msg}");
     assert_eq!(laddr, raddr, "should match addr {laddr}");
 
     Ok(())

--- a/util/src/vnet/router.rs
+++ b/util/src/vnet/router.rs
@@ -32,7 +32,7 @@ lazy_static! {
 // Generate a unique router name
 fn assign_router_name() -> String {
     let n = ROUTER_ID_CTR.fetch_add(1, Ordering::SeqCst);
-    format!("router{}", n)
+    format!("router{n}")
 }
 
 // RouterConfig ...

--- a/util/src/vnet/router/router_test.rs
+++ b/util/src/vnet/router/router_test.rs
@@ -442,12 +442,10 @@ async fn delay_sub_test(title: String, min_delay: Duration, max_jitter: Duration
             log::info!("min delay : {:?}", min_delay);
             log::info!("max jitter: {:?}", max_jitter);
             log::info!("actual delay: {:?}", d);
-            assert!(*d >= min_delay, "{} should delay {:?} >= 20ms", title, d);
+            assert!(*d >= min_delay, "{title} should delay {d:?} >= 20ms");
             assert!(
                 *d <= (min_delay + max_jitter + MARGIN),
-                "{} should delay {:?} <= minDelay + maxJitter",
-                title,
-                d,
+                "{title} should delay {d:?} <= minDelay + maxJitter",
             );
             // Note: actual delay should be within 30ms but giving a 8ms
             // MARGIN for possible extra delay

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc"
 version = "0.6.1"
 authors = ["Rain Liu <yliu@webrtc.rs>"]
-edition = "2018"
+edition = "2021"
 description = "A pure Rust implementation of WebRTC API"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/webrtc"

--- a/webrtc/src/api/media_engine/media_engine_test.rs
+++ b/webrtc/src/api/media_engine/media_engine_test.rs
@@ -708,7 +708,8 @@ a=rtpmap:111 opus/48000/2
 
     let mut m = MediaEngine::default();
     m.register_default_codecs()?;
-    for extension in ["urn:3gpp:video-orientation"] {
+    {
+        let extension = "urn:3gpp:video-orientation";
         m.register_header_extension(
             RTCRtpHeaderExtensionCapability {
                 uri: extension.to_owned(),

--- a/webrtc/src/data_channel/data_channel_state.rs
+++ b/webrtc/src/data_channel/data_channel_state.rs
@@ -73,7 +73,7 @@ impl fmt::Display for RTCDataChannelState {
             RTCDataChannelState::Closed => DATA_CHANNEL_STATE_CLOSED_STR,
             RTCDataChannelState::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -95,8 +95,7 @@ mod test {
             assert_eq!(
                 RTCDataChannelState::from(state_string),
                 expected_state,
-                "testCase: {}",
-                expected_state,
+                "testCase: {expected_state}",
             );
         }
     }

--- a/webrtc/src/data_channel/data_channel_test.rs
+++ b/webrtc/src/data_channel/data_channel_test.rs
@@ -1473,8 +1473,7 @@ async fn test_data_channel_ortc_e2e() -> Result<()> {
         assert_eq!(
             Error::ErrClosedPipe,
             err,
-            "expected ErrClosedPipe, but got {}",
-            err
+            "expected ErrClosedPipe, but got {err}"
         );
     } else {
         panic!();
@@ -1485,8 +1484,7 @@ async fn test_data_channel_ortc_e2e() -> Result<()> {
         assert_eq!(
             Error::ErrClosedPipe,
             err,
-            "expected ErrClosedPipe, but got {}",
-            err
+            "expected ErrClosedPipe, but got {err}"
         );
     } else {
         panic!();
@@ -1497,8 +1495,7 @@ async fn test_data_channel_ortc_e2e() -> Result<()> {
         assert_eq!(
             Error::ErrClosedPipe,
             err,
-            "expected ErrClosedPipe, but got {}",
-            err
+            "expected ErrClosedPipe, but got {err}"
         );
     } else {
         panic!();

--- a/webrtc/src/dtls_transport/dtls_role.rs
+++ b/webrtc/src/dtls_transport/dtls_role.rs
@@ -167,8 +167,7 @@ a=setup:";
             assert_eq!(
                 DTLSRole::from(&session_description),
                 expected_role,
-                "{} failed",
-                name
+                "{name} failed"
             );
         }
 

--- a/webrtc/src/dtls_transport/dtls_transport_state.rs
+++ b/webrtc/src/dtls_transport/dtls_transport_state.rs
@@ -76,7 +76,7 @@ impl fmt::Display for RTCDtlsTransportState {
             RTCDtlsTransportState::Failed => DTLS_TRANSPORT_STATE_FAILED_STR,
             RTCDtlsTransportState::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -99,8 +99,7 @@ mod test {
             assert_eq!(
                 RTCDtlsTransportState::from(state_string),
                 expected_state,
-                "testCase: {}",
-                expected_state,
+                "testCase: {expected_state}",
             );
         }
     }

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -547,7 +547,7 @@ impl RTCDtlsTransport {
             let mut h = Sha256::new();
             h.update(remote_cert);
             let hashed = h.finalize();
-            let values: Vec<String> = hashed.iter().map(|x| format! {"{:02x}", x}).collect();
+            let values: Vec<String> = hashed.iter().map(|x| format! {"{x:02x}"}).collect();
             let remote_value = values.join(":").to_lowercase();
 
             if remote_value == fp.value.to_lowercase() {

--- a/webrtc/src/ice_transport/ice_candidate.rs
+++ b/webrtc/src/ice_transport/ice_candidate.rs
@@ -205,12 +205,12 @@ mod test {
 
         for (candidate_init, expected_string) in tests {
             let result = serde_json::to_string(&candidate_init);
-            assert!(result.is_ok(), "testCase: marshal err: {:?}", result);
+            assert!(result.is_ok(), "testCase: marshal err: {result:?}");
             let candidate_data = result.unwrap();
             assert_eq!(candidate_data, expected_string, "string is not expected");
 
             let result = serde_json::from_str::<RTCIceCandidateInit>(&candidate_data);
-            assert!(result.is_ok(), "testCase: unmarshal err: {:?}", result);
+            assert!(result.is_ok(), "testCase: unmarshal err: {result:?}");
             if let Ok(actual_candidate_init) = result {
                 assert_eq!(actual_candidate_init, candidate_init);
             }

--- a/webrtc/src/ice_transport/ice_candidate_pair.rs
+++ b/webrtc/src/ice_transport/ice_candidate_pair.rs
@@ -18,7 +18,7 @@ impl fmt::Display for RTCIceCandidatePair {
 
 impl RTCIceCandidatePair {
     fn stats_id(local_id: &str, remote_id: &str) -> String {
-        format!("{}-{}", local_id, remote_id)
+        format!("{local_id}-{remote_id}")
     }
 
     /// returns an initialized ICECandidatePair

--- a/webrtc/src/ice_transport/ice_candidate_type.rs
+++ b/webrtc/src/ice_transport/ice_candidate_type.rs
@@ -77,10 +77,10 @@ impl From<CandidateType> for RTCIceCandidateType {
 impl fmt::Display for RTCIceCandidateType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceCandidateType::Host => write!(f, "{}", ICE_CANDIDATE_TYPE_HOST_STR),
-            RTCIceCandidateType::Srflx => write!(f, "{}", ICE_CANDIDATE_TYPE_SRFLX_STR),
-            RTCIceCandidateType::Prflx => write!(f, "{}", ICE_CANDIDATE_TYPE_PRFLX_STR),
-            RTCIceCandidateType::Relay => write!(f, "{}", ICE_CANDIDATE_TYPE_RELAY_STR),
+            RTCIceCandidateType::Host => write!(f, "{ICE_CANDIDATE_TYPE_HOST_STR}"),
+            RTCIceCandidateType::Srflx => write!(f, "{ICE_CANDIDATE_TYPE_SRFLX_STR}"),
+            RTCIceCandidateType::Prflx => write!(f, "{ICE_CANDIDATE_TYPE_PRFLX_STR}"),
+            RTCIceCandidateType::Relay => write!(f, "{ICE_CANDIDATE_TYPE_RELAY_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/ice_transport/ice_connection_state.rs
+++ b/webrtc/src/ice_transport/ice_connection_state.rs
@@ -97,7 +97,7 @@ impl fmt::Display for RTCIceConnectionState {
             RTCIceConnectionState::Closed => ICE_CONNECTION_STATE_CLOSED_STR,
             RTCIceConnectionState::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -122,8 +122,7 @@ mod test {
             assert_eq!(
                 RTCIceConnectionState::from(state_string),
                 expected_state,
-                "testCase: {}",
-                expected_state,
+                "testCase: {expected_state}",
             );
         }
     }

--- a/webrtc/src/ice_transport/ice_credential_type.rs
+++ b/webrtc/src/ice_transport/ice_credential_type.rs
@@ -38,8 +38,8 @@ impl From<&str> for RTCIceCredentialType {
 impl fmt::Display for RTCIceCredentialType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceCredentialType::Password => write!(f, "{}", ICE_CREDENTIAL_TYPE_PASSWORD_STR),
-            RTCIceCredentialType::Oauth => write!(f, "{}", ICE_CREDENTIAL_TYPE_OAUTH_STR),
+            RTCIceCredentialType::Password => write!(f, "{ICE_CREDENTIAL_TYPE_PASSWORD_STR}"),
+            RTCIceCredentialType::Oauth => write!(f, "{ICE_CREDENTIAL_TYPE_OAUTH_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/ice_transport/ice_gatherer_state.rs
+++ b/webrtc/src/ice_transport/ice_gatherer_state.rs
@@ -59,13 +59,13 @@ impl From<u8> for RTCIceGathererState {
 impl fmt::Display for RTCIceGathererState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceGathererState::New => write!(f, "{}", ICE_GATHERED_STATE_NEW_STR),
-            RTCIceGathererState::Gathering => write!(f, "{}", ICE_GATHERED_STATE_GATHERING_STR),
+            RTCIceGathererState::New => write!(f, "{ICE_GATHERED_STATE_NEW_STR}"),
+            RTCIceGathererState::Gathering => write!(f, "{ICE_GATHERED_STATE_GATHERING_STR}"),
             RTCIceGathererState::Complete => {
-                write!(f, "{}", ICE_GATHERED_STATE_COMPLETE_STR)
+                write!(f, "{ICE_GATHERED_STATE_COMPLETE_STR}")
             }
             RTCIceGathererState::Closed => {
-                write!(f, "{}", ICE_GATHERED_STATE_CLOSED_STR)
+                write!(f, "{ICE_GATHERED_STATE_CLOSED_STR}")
             }
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }

--- a/webrtc/src/ice_transport/ice_gathering_state.rs
+++ b/webrtc/src/ice_transport/ice_gathering_state.rs
@@ -44,10 +44,10 @@ impl From<&str> for RTCIceGatheringState {
 impl fmt::Display for RTCIceGatheringState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceGatheringState::New => write!(f, "{}", ICE_GATHERING_STATE_NEW_STR),
-            RTCIceGatheringState::Gathering => write!(f, "{}", ICE_GATHERING_STATE_GATHERING_STR),
+            RTCIceGatheringState::New => write!(f, "{ICE_GATHERING_STATE_NEW_STR}"),
+            RTCIceGatheringState::Gathering => write!(f, "{ICE_GATHERING_STATE_GATHERING_STR}"),
             RTCIceGatheringState::Complete => {
-                write!(f, "{}", ICE_GATHERING_STATE_COMPLETE_STR)
+                write!(f, "{ICE_GATHERING_STATE_COMPLETE_STR}")
             }
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }

--- a/webrtc/src/ice_transport/ice_protocol.rs
+++ b/webrtc/src/ice_transport/ice_protocol.rs
@@ -41,8 +41,8 @@ impl From<&str> for RTCIceProtocol {
 impl fmt::Display for RTCIceProtocol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceProtocol::Udp => write!(f, "{}", ICE_PROTOCOL_UDP_STR),
-            RTCIceProtocol::Tcp => write!(f, "{}", ICE_PROTOCOL_TCP_STR),
+            RTCIceProtocol::Udp => write!(f, "{ICE_PROTOCOL_UDP_STR}"),
+            RTCIceProtocol::Tcp => write!(f, "{ICE_PROTOCOL_TCP_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/ice_transport/ice_role.rs
+++ b/webrtc/src/ice_transport/ice_role.rs
@@ -39,8 +39,8 @@ impl From<&str> for RTCIceRole {
 impl fmt::Display for RTCIceRole {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceRole::Controlling => write!(f, "{}", ICE_ROLE_CONTROLLING_STR),
-            RTCIceRole::Controlled => write!(f, "{}", ICE_ROLE_CONTROLLED_STR),
+            RTCIceRole::Controlling => write!(f, "{ICE_ROLE_CONTROLLING_STR}"),
+            RTCIceRole::Controlled => write!(f, "{ICE_ROLE_CONTROLLED_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/ice_transport/ice_server.rs
+++ b/webrtc/src/ice_transport/ice_server.rs
@@ -141,7 +141,7 @@ mod test {
 
         for (ice_server, expected_err) in tests {
             if let Err(err) = ice_server.urls() {
-                assert_eq!(err, expected_err, "{:?} with err {:?}", ice_server, err);
+                assert_eq!(err, expected_err, "{ice_server:?} with err {err:?}");
             } else {
                 panic!("expected error, but got ok");
             }
@@ -162,7 +162,7 @@ mod test {
 
         for (ice_server, expected_err) in tests {
             if let Err(err) = ice_server.urls() {
-                assert_eq!(err, expected_err, "{:?} with err {:?}", ice_server, err);
+                assert_eq!(err, expected_err, "{ice_server:?} with err {err:?}");
             } else {
                 panic!("expected error, but got ok");
             }

--- a/webrtc/src/ice_transport/ice_transport_state.rs
+++ b/webrtc/src/ice_transport/ice_transport_state.rs
@@ -90,20 +90,20 @@ impl From<u8> for RTCIceTransportState {
 impl fmt::Display for RTCIceTransportState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCIceTransportState::New => write!(f, "{}", ICE_TRANSPORT_STATE_NEW_STR),
-            RTCIceTransportState::Checking => write!(f, "{}", ICE_TRANSPORT_STATE_CHECKING_STR),
+            RTCIceTransportState::New => write!(f, "{ICE_TRANSPORT_STATE_NEW_STR}"),
+            RTCIceTransportState::Checking => write!(f, "{ICE_TRANSPORT_STATE_CHECKING_STR}"),
             RTCIceTransportState::Connected => {
-                write!(f, "{}", ICE_TRANSPORT_STATE_CONNECTED_STR)
+                write!(f, "{ICE_TRANSPORT_STATE_CONNECTED_STR}")
             }
-            RTCIceTransportState::Completed => write!(f, "{}", ICE_TRANSPORT_STATE_COMPLETED_STR),
+            RTCIceTransportState::Completed => write!(f, "{ICE_TRANSPORT_STATE_COMPLETED_STR}"),
             RTCIceTransportState::Failed => {
-                write!(f, "{}", ICE_TRANSPORT_STATE_FAILED_STR)
+                write!(f, "{ICE_TRANSPORT_STATE_FAILED_STR}")
             }
             RTCIceTransportState::Disconnected => {
-                write!(f, "{}", ICE_TRANSPORT_STATE_DISCONNECTED_STR)
+                write!(f, "{ICE_TRANSPORT_STATE_DISCONNECTED_STR}")
             }
             RTCIceTransportState::Closed => {
-                write!(f, "{}", ICE_TRANSPORT_STATE_CLOSED_STR)
+                write!(f, "{ICE_TRANSPORT_STATE_CLOSED_STR}")
             }
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }

--- a/webrtc/src/peer_connection/certificate.rs
+++ b/webrtc/src/peer_connection/certificate.rs
@@ -121,7 +121,7 @@ impl RTCCertificate {
             return Err(Error::InvalidPEM("empty PEM".into()));
         };
         let expires_pem =
-            pem::parse(first_block).map_err(|e| Error::new(format!("can't parse PEM: {}", e)))?;
+            pem::parse(first_block).map_err(|e| Error::new(format!("can't parse PEM: {e}")))?;
         if expires_pem.tag != "EXPIRES" {
             return Err(Error::InvalidPEM(format!(
                 "invalid tag (expected: 'EXPIRES', got '{}')",
@@ -192,7 +192,7 @@ impl RTCCertificate {
             let mut h = Sha256::new();
             h.update(c.as_ref());
             let hashed = h.finalize();
-            let values: Vec<String> = hashed.iter().map(|x| format! {"{:02x}", x}).collect();
+            let values: Vec<String> = hashed.iter().map(|x| format! {"{x:02x}"}).collect();
 
             fingerprints.push(RTCDtlsFingerprint {
                 algorithm: "sha-256".to_owned(),

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -1901,7 +1901,7 @@ impl RTCPeerConnection {
         let mut close_errs = vec![];
 
         if let Err(err) = self.interceptor.close().await {
-            close_errs.push(Error::new(format!("interceptor: {}", err)));
+            close_errs.push(Error::new(format!("interceptor: {err}")));
         }
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #4)
@@ -1909,7 +1909,7 @@ impl RTCPeerConnection {
             let mut rtp_transceivers = self.internal.rtp_transceivers.lock().await;
             for t in &*rtp_transceivers {
                 if let Err(err) = t.stop().await {
-                    close_errs.push(Error::new(format!("rtp_transceivers: {}", err)));
+                    close_errs.push(Error::new(format!("rtp_transceivers: {err}")));
                 }
             }
             rtp_transceivers.clear();
@@ -1920,7 +1920,7 @@ impl RTCPeerConnection {
             let mut data_channels = self.internal.sctp_transport.data_channels.lock().await;
             for d in &*data_channels {
                 if let Err(err) = d.close().await {
-                    close_errs.push(Error::new(format!("data_channels: {}", err)));
+                    close_errs.push(Error::new(format!("data_channels: {err}")));
                 }
             }
             data_channels.clear();
@@ -1928,17 +1928,17 @@ impl RTCPeerConnection {
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #6)
         if let Err(err) = self.internal.sctp_transport.stop().await {
-            close_errs.push(Error::new(format!("sctp_transport: {}", err)));
+            close_errs.push(Error::new(format!("sctp_transport: {err}")));
         }
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #7)
         if let Err(err) = self.internal.dtls_transport.stop().await {
-            close_errs.push(Error::new(format!("dtls_transport: {}", err)));
+            close_errs.push(Error::new(format!("dtls_transport: {err}")));
         }
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #8, #9, #10)
         if let Err(err) = self.internal.ice_transport.stop().await {
-            close_errs.push(Error::new(format!("dtls_transport: {}", err)));
+            close_errs.push(Error::new(format!("dtls_transport: {err}")));
         }
 
         // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #11)
@@ -1952,7 +1952,7 @@ impl RTCPeerConnection {
         .await;
 
         if let Err(err) = self.internal.ops.close().await {
-            close_errs.push(Error::new(format!("ops: {}", err)));
+            close_errs.push(Error::new(format!("ops: {err}")));
         }
 
         flatten_errs(close_errs)

--- a/webrtc/src/peer_connection/peer_connection_state.rs
+++ b/webrtc/src/peer_connection/peer_connection_state.rs
@@ -87,7 +87,7 @@ impl fmt::Display for RTCPeerConnectionState {
             RTCPeerConnectionState::Closed => PEER_CONNECTION_STATE_CLOSED_STR,
             RTCPeerConnectionState::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -137,8 +137,7 @@ mod test {
             assert_eq!(
                 RTCPeerConnectionState::from(state_string),
                 expected_state,
-                "testCase: {}",
-                expected_state,
+                "testCase: {expected_state}",
             );
         }
     }

--- a/webrtc/src/peer_connection/policy/bundle_policy.rs
+++ b/webrtc/src/peer_connection/policy/bundle_policy.rs
@@ -56,9 +56,9 @@ impl From<&str> for RTCBundlePolicy {
 impl fmt::Display for RTCBundlePolicy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCBundlePolicy::Balanced => write!(f, "{}", BUNDLE_POLICY_BALANCED_STR),
-            RTCBundlePolicy::MaxCompat => write!(f, "{}", BUNDLE_POLICY_MAX_COMPAT_STR),
-            RTCBundlePolicy::MaxBundle => write!(f, "{}", BUNDLE_POLICY_MAX_BUNDLE_STR),
+            RTCBundlePolicy::Balanced => write!(f, "{BUNDLE_POLICY_BALANCED_STR}"),
+            RTCBundlePolicy::MaxCompat => write!(f, "{BUNDLE_POLICY_MAX_COMPAT_STR}"),
+            RTCBundlePolicy::MaxBundle => write!(f, "{BUNDLE_POLICY_MAX_BUNDLE_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/peer_connection/policy/ice_transport_policy.rs
+++ b/webrtc/src/peer_connection/policy/ice_transport_policy.rs
@@ -47,7 +47,7 @@ impl fmt::Display for RTCIceTransportPolicy {
             RTCIceTransportPolicy::All => ICE_TRANSPORT_POLICY_ALL_STR,
             RTCIceTransportPolicy::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
+++ b/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
@@ -47,7 +47,7 @@ impl fmt::Display for RTCRtcpMuxPolicy {
             RTCRtcpMuxPolicy::Require => RTCP_MUX_POLICY_REQUIRE_STR,
             RTCRtcpMuxPolicy::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/webrtc/src/peer_connection/policy/sdp_semantics.rs
+++ b/webrtc/src/peer_connection/policy/sdp_semantics.rs
@@ -57,7 +57,7 @@ impl fmt::Display for RTCSdpSemantics {
             RTCSdpSemantics::PlanB => SDP_SEMANTICS_PLAN_B,
             RTCSdpSemantics::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -566,7 +566,7 @@ pub(crate) async fn add_transceiver_sdp(
             // description, "a=msid" line(s) MUST be generated according to the
             // same rules as for an initial offer.
             for stream_id in sender.associated_media_stream_ids() {
-                media = media.with_property_attribute(format!("msid:{} {}", stream_id, track_id));
+                media = media.with_property_attribute(format!("msid:{stream_id} {track_id}"));
             }
 
             break;

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -844,10 +844,10 @@ pub(crate) fn have_application_media_section(desc: &SessionDescription) -> bool 
     false
 }
 
-pub(crate) fn get_by_mid<'a, 'b>(
-    search_mid: &'a str,
-    desc: &'b session_description::RTCSessionDescription,
-) -> Option<&'b MediaDescription> {
+pub(crate) fn get_by_mid<'a>(
+    search_mid: &str,
+    desc: &'a session_description::RTCSessionDescription,
+) -> Option<&'a MediaDescription> {
     if let Some(parsed) = &desc.parsed {
         for m in &parsed.media_descriptions {
             if let Some(mid) = m.attribute(ATTR_KEY_MID).flatten() {

--- a/webrtc/src/peer_connection/sdp/sdp_type.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_type.rs
@@ -60,10 +60,10 @@ impl From<&str> for RTCSdpType {
 impl fmt::Display for RTCSdpType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCSdpType::Offer => write!(f, "{}", SDP_TYPE_OFFER_STR),
-            RTCSdpType::Pranswer => write!(f, "{}", SDP_TYPE_PRANSWER_STR),
-            RTCSdpType::Answer => write!(f, "{}", SDP_TYPE_ANSWER_STR),
-            RTCSdpType::Rollback => write!(f, "{}", SDP_TYPE_ROLLBACK_STR),
+            RTCSdpType::Offer => write!(f, "{SDP_TYPE_OFFER_STR}"),
+            RTCSdpType::Pranswer => write!(f, "{SDP_TYPE_PRANSWER_STR}"),
+            RTCSdpType::Answer => write!(f, "{SDP_TYPE_ANSWER_STR}"),
+            RTCSdpType::Rollback => write!(f, "{SDP_TYPE_ROLLBACK_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }

--- a/webrtc/src/peer_connection/sdp/session_description.rs
+++ b/webrtc/src/peer_connection/sdp/session_description.rs
@@ -128,12 +128,12 @@ mod test {
 
         for (desc, expected_string) in tests {
             let result = serde_json::to_string(&desc);
-            assert!(result.is_ok(), "testCase: marshal err: {:?}", result);
+            assert!(result.is_ok(), "testCase: marshal err: {result:?}");
             let desc_data = result.unwrap();
             assert_eq!(desc_data, expected_string, "string is not expected");
 
             let result = serde_json::from_str::<RTCSessionDescription>(&desc_data);
-            assert!(result.is_ok(), "testCase: unmarshal err: {:?}", result);
+            assert!(result.is_ok(), "testCase: unmarshal err: {result:?}");
             if let Ok(sd) = result {
                 assert!(sd.sdp == desc.sdp && sd.sdp_type == desc.sdp_type);
             }

--- a/webrtc/src/peer_connection/signaling_state.rs
+++ b/webrtc/src/peer_connection/signaling_state.rs
@@ -362,9 +362,7 @@ mod test {
                     assert_eq!(got.to_string(), err.to_string(), "{desc} error mismatch");
                 }
                 _ => {
-                    panic!(
-                        "{desc}: expected {expected_err:?}, but got {result:?}"
-                    );
+                    panic!("{desc}: expected {expected_err:?}, but got {result:?}");
                 }
             };
         }

--- a/webrtc/src/peer_connection/signaling_state.rs
+++ b/webrtc/src/peer_connection/signaling_state.rs
@@ -87,20 +87,20 @@ impl From<&str> for RTCSignalingState {
 impl fmt::Display for RTCSignalingState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RTCSignalingState::Stable => write!(f, "{}", SIGNALING_STATE_STABLE_STR),
+            RTCSignalingState::Stable => write!(f, "{SIGNALING_STATE_STABLE_STR}"),
             RTCSignalingState::HaveLocalOffer => {
-                write!(f, "{}", SIGNALING_STATE_HAVE_LOCAL_OFFER_STR)
+                write!(f, "{SIGNALING_STATE_HAVE_LOCAL_OFFER_STR}")
             }
             RTCSignalingState::HaveRemoteOffer => {
-                write!(f, "{}", SIGNALING_STATE_HAVE_REMOTE_OFFER_STR)
+                write!(f, "{SIGNALING_STATE_HAVE_REMOTE_OFFER_STR}")
             }
             RTCSignalingState::HaveLocalPranswer => {
-                write!(f, "{}", SIGNALING_STATE_HAVE_LOCAL_PRANSWER_STR)
+                write!(f, "{SIGNALING_STATE_HAVE_LOCAL_PRANSWER_STR}")
             }
             RTCSignalingState::HaveRemotePranswer => {
-                write!(f, "{}", SIGNALING_STATE_HAVE_REMOTE_PRANSWER_STR)
+                write!(f, "{SIGNALING_STATE_HAVE_REMOTE_PRANSWER_STR}")
             }
-            RTCSignalingState::Closed => write!(f, "{}", SIGNALING_STATE_CLOSED_STR),
+            RTCSignalingState::Closed => write!(f, "{SIGNALING_STATE_CLOSED_STR}"),
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }
     }
@@ -356,15 +356,14 @@ mod test {
             let result = check_next_signaling_state(cur, next, op, sdp_type);
             match (&result, &expected_err) {
                 (Ok(got), None) => {
-                    assert_eq!(*got, next, "{} state mismatch", desc);
+                    assert_eq!(*got, next, "{desc} state mismatch");
                 }
                 (Err(got), Some(err)) => {
-                    assert_eq!(got.to_string(), err.to_string(), "{} error mismatch", desc);
+                    assert_eq!(got.to_string(), err.to_string(), "{desc} error mismatch");
                 }
                 _ => {
                     panic!(
-                        "{}: expected {:?}, but got {:?}",
-                        desc, expected_err, result
+                        "{desc}: expected {expected_err:?}, but got {result:?}"
                     );
                 }
             };

--- a/webrtc/src/rtp_transceiver/fmtp/generic/generic_test.rs
+++ b/webrtc/src/rtp_transceiver/fmtp/generic/generic_test.rs
@@ -57,7 +57,7 @@ fn test_generic_fmtp_parse() {
 
     for (name, input, expected) in tests {
         let f = parse("generic", input);
-        assert_eq!(&f, &expected, "{} failed", name);
+        assert_eq!(&f, &expected, "{name} failed");
 
         assert_eq!(f.mime_type(), "generic");
     }

--- a/webrtc/src/rtp_transceiver/fmtp/h264/h264_test.rs
+++ b/webrtc/src/rtp_transceiver/fmtp/h264/h264_test.rs
@@ -53,7 +53,7 @@ fn test_h264_fmtp_parse() {
 
     for (name, input, expected) in tests {
         let f = parse("video/h264", input);
-        assert_eq!(&f, &expected, "{} failed", name);
+        assert_eq!(&f, &expected, "{name} failed");
 
         assert_eq!(f.mime_type(), "video/h264");
     }

--- a/webrtc/src/rtp_transceiver/rtp_codec.rs
+++ b/webrtc/src/rtp_transceiver/rtp_codec.rs
@@ -50,7 +50,7 @@ impl fmt::Display for RTPCodecType {
             RTPCodecType::Video => "video",
             RTPCodecType::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -80,7 +80,7 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
                 assert_eq!(track.codec().await.capability.mime_type, MIME_TYPE_H264);
                 let _ = seen_packet_b_tx2.send(()).await;
             } else {
-                panic!("Unexpected RTP Data {:02x}", last);
+                panic!("Unexpected RTP Data {last:02x}");
             }
         })
     }));

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
@@ -55,16 +55,16 @@ impl fmt::Display for RTCRtpTransceiverDirection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RTCRtpTransceiverDirection::Sendrecv => {
-                write!(f, "{}", RTP_TRANSCEIVER_DIRECTION_SENDRECV_STR)
+                write!(f, "{RTP_TRANSCEIVER_DIRECTION_SENDRECV_STR}")
             }
             RTCRtpTransceiverDirection::Sendonly => {
-                write!(f, "{}", RTP_TRANSCEIVER_DIRECTION_SENDONLY_STR)
+                write!(f, "{RTP_TRANSCEIVER_DIRECTION_SENDONLY_STR}")
             }
             RTCRtpTransceiverDirection::Recvonly => {
-                write!(f, "{}", RTP_TRANSCEIVER_DIRECTION_RECVONLY_STR)
+                write!(f, "{RTP_TRANSCEIVER_DIRECTION_RECVONLY_STR}")
             }
             RTCRtpTransceiverDirection::Inactive => {
-                write!(f, "{}", RTP_TRANSCEIVER_DIRECTION_INACTIVE_STR)
+                write!(f, "{RTP_TRANSCEIVER_DIRECTION_INACTIVE_STR}")
             }
             _ => write!(f, "{}", crate::UNSPECIFIED_STR),
         }

--- a/webrtc/src/sctp_transport/sctp_transport_state.rs
+++ b/webrtc/src/sctp_transport/sctp_transport_state.rs
@@ -62,7 +62,7 @@ impl fmt::Display for RTCSctpTransportState {
             RTCSctpTransportState::Closed => SCTP_TRANSPORT_STATE_CLOSED_STR,
             RTCSctpTransportState::Unspecified => crate::UNSPECIFIED_STR,
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -83,8 +83,7 @@ mod test {
             assert_eq!(
                 RTCSctpTransportState::from(state_string),
                 expected_state,
-                "testCase: {}",
-                expected_state,
+                "testCase: {expected_state}",
             );
         }
     }

--- a/webrtc/src/sctp_transport/sctp_transport_test.rs
+++ b/webrtc/src/sctp_transport/sctp_transport_test.rs
@@ -34,7 +34,7 @@ async fn test_generate_data_channel_id() -> Result<()> {
     for (role, s, expected) in tests {
         match s.generate_and_set_data_channel_id(role).await {
             Ok(actual) => assert_eq!(actual, expected),
-            Err(err) => panic!("failed to generate id: {}", err),
+            Err(err) => panic!("failed to generate id: {err}"),
         };
     }
 


### PR DESCRIPTION
updated the crates to the 2021 edition due to the new formatting lints in `panic!` and `assert!` macros.  
If preferred I can try to isolate the fixes to only assert #405 passes.