### PR TITLE
Remove `derive_builder` dependency

### DIFF
--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Remove builder pattern from `data_channel::Config`.
+
 ## v0.6.0
 
 * Increased minimum support rust version to `1.60.0`.

--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Remove builder pattern from `data_channel::Config` [#411](https://github.com/webrtc-rs/webrtc/pull/411).
 
+## v0.7.0
+
 ## v0.6.0
 
 * Increased minimum support rust version to `1.60.0`.

--- a/data/CHANGELOG.md
+++ b/data/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Remove builder pattern from `data_channel::Config`.
+* Remove builder pattern from `data_channel::Config` [#411](https://github.com/webrtc-rs/webrtc/pull/411).
 
 ## v0.6.0
 

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -18,7 +18,6 @@ sctp = { version = "0.8.0", path = "../sctp", package = "webrtc-sctp" }
 
 tokio = { version = "1.19", features = ["full"] }
 bytes = "1"
-derive_builder = "0.11.2"
 log = "0.4.16"
 thiserror = "1.0"
 

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -13,7 +13,6 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use util::marshal::*;
 
 use bytes::{Buf, Bytes};
-use derive_builder::Builder;
 use std::borrow::Borrow;
 use std::fmt;
 use std::future::Future;
@@ -27,19 +26,13 @@ use std::task::{Context, Poll};
 const RECEIVE_MTU: usize = 8192;
 
 /// Config is used to configure the data channel.
-#[derive(Eq, PartialEq, Default, Clone, Debug, Builder)]
+#[derive(Eq, PartialEq, Default, Clone, Debug)]
 pub struct Config {
-    #[builder(default)]
     pub channel_type: ChannelType,
-    #[builder(default)]
     pub negotiated: bool,
-    #[builder(default)]
     pub priority: u16,
-    #[builder(default)]
     pub reliability_parameter: u32,
-    #[builder(default)]
     pub label: String,
-    #[builder(default)]
     pub protocol: String,
 }
 

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -21,7 +21,6 @@ bytes = "1"
 displaydoc = "0.2.3"
 thiserror = "1.0"
 rand = "0.8.5"
-derive_builder = "0.11.2"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }


### PR DESCRIPTION
This is quite a heavy dependency and it is only in use in one place which IMO doesn't need it. A struct with all public fields an easily be built in a single expression using `Config { negotiated: true, ..Default::default() }`.

Here is the output of `cargo tree` for us. In this case, it is also the only place where we pull in `darling` which by itself is quite heavy:

![image](https://user-images.githubusercontent.com/5486389/221492291-06b79321-ce44-44f6-80a6-0d95ebd3b8e6.png)


