### PR TITLE
Add alloc_close_notify config param.

### DIFF
--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -237,6 +237,7 @@ pub(crate) async fn add_vnet_stun(wan_net: Arc<net::Net>) -> Result<turn::server
         realm: "webrtc.rs".to_owned(),
         auth_handler: Arc::new(TestAuthHandler::new()),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/ice/src/candidate/candidate_relay_test.rs
+++ b/ice/src/candidate/candidate_relay_test.rs
@@ -61,6 +61,7 @@ async fn test_relay_only_connection() -> Result<(), Error> {
             }),
         }],
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/ice/src/candidate/candidate_server_reflexive_test.rs
+++ b/ice/src/candidate/candidate_server_reflexive_test.rs
@@ -40,6 +40,7 @@ async fn test_server_reflexive_only_connection() -> Result<()> {
             }),
         }],
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/turn/CHANGELOG.md
+++ b/turn/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [#330 Fix the problem that the UDP port of the server relay is not released](https://github.com/webrtc-rs/webrtc/pull/330) by [@clia](https://github.com/clia).
+* Added `alloc_close_notify` config parameter to `ServerConfig` and `Allocation`, to receive notify on allocation close event, with metrics data.
 
 ## v0.6.1
 

--- a/turn/examples/turn_server_udp.rs
+++ b/turn/examples/turn_server_udp.rs
@@ -125,6 +125,7 @@ async fn main() -> Result<(), Error> {
         realm: realm.to_owned(),
         auth_handler: Arc::new(MyAuthHandler::new(cred_map)),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/turn/src/allocation/allocation_test.rs
+++ b/turn/src/allocation/allocation_test.rs
@@ -16,6 +16,7 @@ async fn test_has_permission() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr1 = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -53,6 +54,7 @@ async fn test_add_permission() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -76,6 +78,7 @@ async fn test_remove_permission() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -108,6 +111,7 @@ async fn test_add_channel_bind() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -141,6 +145,7 @@ async fn test_get_channel_by_number() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -176,6 +181,7 @@ async fn test_get_channel_by_addr() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -207,6 +213,7 @@ async fn test_remove_channel_bind() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::from_str("127.0.0.1:3478")?;
@@ -243,6 +250,7 @@ async fn test_allocation_refresh() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     a.start(DEFAULT_LIFETIME).await;
@@ -264,6 +272,7 @@ async fn test_allocation_close() -> Result<()> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     // add mock lifetimeTimer

--- a/turn/src/allocation/channel_bind/channel_bind_test.rs
+++ b/turn/src/allocation/channel_bind/channel_bind_test.rs
@@ -17,6 +17,7 @@ async fn create_channel_bind(lifetime: Duration) -> Result<Allocation> {
         relay_addr,
         FiveTuple::default(),
         TextAttribute::new(ATTR_USERNAME, "user".into()),
+        None,
     );
 
     let addr = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 0);

--- a/turn/src/auth/auth_test.rs
+++ b/turn/src/auth/auth_test.rs
@@ -68,6 +68,7 @@ async fn test_new_long_term_auth_handler() -> Result<()> {
         realm: "webrtc.rs".to_owned(),
         auth_handler: Arc::new(LongTermAuthHandler::new(SHARED_SECRET.to_string())),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/turn/src/client/client_test.rs
+++ b/turn/src/client/client_test.rs
@@ -150,6 +150,7 @@ async fn test_client_nonce_expiration() -> Result<()> {
         realm: "webrtc.rs".to_owned(),
         auth_handler: Arc::new(TestAuthHandler {}),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 

--- a/turn/src/server/config.rs
+++ b/turn/src/server/config.rs
@@ -1,3 +1,4 @@
+use crate::allocation::*;
 use crate::auth::*;
 use crate::error::*;
 use crate::relay::*;
@@ -5,6 +6,7 @@ use crate::relay::*;
 use util::Conn;
 
 use std::sync::Arc;
+use tokio::sync::mpsc;
 use tokio::time::Duration;
 
 // ConnConfig is used for UDP listeners
@@ -36,6 +38,9 @@ pub struct ServerConfig {
 
     // channel_bind_timeout sets the lifetime of channel binding. Defaults to 10 minutes.
     pub channel_bind_timeout: Duration,
+
+    // to receive notify on allocation close event, with metrics data.
+    pub alloc_close_notify: Option<mpsc::Sender<AllocationInfo>>,
 }
 
 impl ServerConfig {

--- a/turn/src/server/mod.rs
+++ b/turn/src/server/mod.rs
@@ -62,6 +62,7 @@ impl Server {
             let conn = p.conn;
             let allocation_manager = Arc::new(Manager::new(ManagerConfig {
                 relay_addr_generator: p.relay_addr_generator,
+                alloc_close_notify: config.alloc_close_notify.clone(),
             }));
 
             tokio::spawn(Server::read_loop(

--- a/turn/src/server/request/request_test.rs
+++ b/turn/src/server/request/request_test.rs
@@ -67,6 +67,7 @@ async fn test_allocation_lifetime_deletion_zero_lifetime() -> Result<()> {
             address: "0.0.0.0".to_owned(),
             net: Arc::new(Net::new(None)),
         }),
+        alloc_close_notify: None,
     }));
 
     let socket = SocketAddr::new(IpAddr::from_str("127.0.0.1")?, 5000);

--- a/turn/src/server/server_test.rs
+++ b/turn/src/server/server_test.rs
@@ -58,6 +58,7 @@ async fn test_server_simple() -> Result<()> {
         realm: "webrtc.rs".to_owned(),
         auth_handler: Arc::new(TestAuthHandler::new()),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 
@@ -192,6 +193,7 @@ async fn build_vnet() -> Result<VNet> {
         realm: "webrtc.rs".to_owned(),
         auth_handler: Arc::new(TestAuthHandler::new()),
         channel_bind_timeout: Duration::from_secs(0),
+        alloc_close_notify: None,
     })
     .await?;
 


### PR DESCRIPTION
When using the turn service, we want to count the number of traffic bytes forwarded by each allocation in the application. I think a good time is when the allocation is closed. So I designed a parameter to pass an mpsc sender in, and send the AllocationInfo out to the application when the allocation is closed.