### PR TITLE
fixed send mutex guard between threads bug

### DIFF
--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -27,6 +27,8 @@ impl<T> Mutex<T> {
 /// dropped (falls out of scope), the lock will be unlocked.
 pub struct MutexGuard<'a, T>(sync::MutexGuard<'a, T>);
 
+unsafe impl<'a, T> Send for MutexGuard<'a, T> {}
+
 impl<'a, T> ops::Deref for MutexGuard<'a, T> {
     type Target = T;
 


### PR DESCRIPTION
This pull request solves this issue https://github.com/webrtc-rs/webrtc/issues/422. Implementation example of `Send` for `MutexGuard` I took from here https://github.com/rust-lang/rust/blob/98815742cf2e914ee0d7142a02322cf939c47834/library/std/src/sync/mutex.rs#L204 .