### PR TITLE
Update x25519-dalek

### DIFF
--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -35,7 +35,7 @@ aes-gcm = "0.10.1"
 ccm = "0.3.0"
 tokio = { version = "1.19", features = ["full"] }
 async-trait = "0.1.56"
-x25519-dalek = "2.0.0-pre.1"
+x25519-dalek = { version = "2.0.0-rc.2", features = ["static_secrets"] }
 signature = "1.2.2"
 x509-parser = "0.13.2"
 der-parser = "8.1"

--- a/dtls/src/curve/named_curve.rs
+++ b/dtls/src/curve/named_curve.rs
@@ -54,7 +54,7 @@ fn elliptic_curve_keypair(curve: NamedCurve) -> Result<NamedCurveKeypair> {
             )
         }
         NamedCurve::X25519 => {
-            let secret_key = x25519_dalek::StaticSecret::new(OsRng);
+            let secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
             let public_key = x25519_dalek::PublicKey::from(&secret_key);
             (
                 public_key.as_bytes().to_vec(),


### PR DESCRIPTION
Without this webrtc fails to compile because x25519 2.0.0-rc.2 introduced a breaking change by moving `StaticSecret` behind a feature flag, and cargo selects the latest version of the dependency.

```
error[E0433]: failed to resolve: could not find `StaticSecret` in `x25519_dalek`
  --> dtls/src/curve/named_curve.rs:57:44
   |
57 |             let secret_key = x25519_dalek::StaticSecret::new(OsRng);
   |                                            ^^^^^^^^^^^^
   |                                            |
   |                                            could not find `StaticSecret` in `x25519_dalek`
   |                                            help: a struct with a similar name exists: `SharedSecret`
```

This updates the dependency to point to the latest version (so the feature flag will always exist), and enables it. It also fixes a deprecation warning where `StaticSecret::new` was renamed to `StaticSecret::random_from_rng`