### PR TITLE
Allow setting local SDP for `RTCSignalingState::HaveLocalOffer`

### DIFF
--- a/webrtc/src/peer_connection/signaling_state.rs
+++ b/webrtc/src/peer_connection/signaling_state.rs
@@ -156,6 +156,11 @@ pub(crate) fn check_next_signaling_state(
                     }
                     _ => {}
                 }
+            } else if op == StateChangeOp::SetLocal
+                && sdp_type == RTCSdpType::Offer
+                && next == RTCSignalingState::HaveLocalOffer
+            {
+                return Ok(next);
             }
         }
         RTCSignalingState::HaveRemotePranswer => {


### PR DESCRIPTION
This PR makes setting local `SDP` spec compliant (as described in **RFC8829** [section 5.5](https://datatracker.ietf.org/doc/html/rfc8829#section-5.5)).