### PR TITLE
Fix redundant / duplicate dependencies

### DIFF
--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -17,7 +17,7 @@ util = { version = "0.7.0", path = "../util", package = "webrtc-util", default-f
 
 byteorder = "1"
 rand_core = "0.6.3"
-elliptic-curve = { version = "0.13.5", features = ["default", "ecdh"] }
+#elliptic-curve = { version = "0.13.5", features = ["default", "ecdh"] }
 hkdf = "~0.12.1"
 p256 = { version = "0.11.1", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.11.2"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -17,7 +17,6 @@ util = { version = "0.7.0", path = "../util", package = "webrtc-util", default-f
 
 byteorder = "1"
 rand_core = "0.6.3"
-#elliptic-curve = { version = "0.13.5", features = ["default", "ecdh"] }
 hkdf = "~0.12.1"
 p256 = { version = "0.11.1", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.11.2"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -33,7 +33,6 @@ ccm = "0.3.0"
 tokio = { version = "1.19", features = ["full"] }
 async-trait = "0.1.56"
 x25519-dalek = { version = "2.0.0-rc.2", features = ["static_secrets"] }
-signature = "1.2.2"
 x509-parser = "0.13.2"
 der-parser = "8.1"
 rcgen = "0.10.0"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -17,11 +17,8 @@ util = { version = "0.7.0", path = "../util", package = "webrtc-util", default-f
 
 byteorder = "1"
 rand_core = "0.6.3"
-elliptic-curve = { version = "0.12.1", features = ["default", "ecdh"] }
-# required because elliptic-curve requires "0.12", but "0.12.0" does not compile.
+elliptic-curve = { version = "0.13.5", features = ["default", "ecdh"] }
 hkdf = "~0.12.1"
-# required because elliptic-curve requires "3", but "3.0.0" does not compile.
-curve25519-dalek = "3.2"
 p256 = { version = "0.11.1", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.11.2"
 rand = "0.8.5"


### PR DESCRIPTION
- curve25519-dalek is not used directly and is using old version causing dependency tree dups
- ~bump elliptic-curve to 0.13.5~ - this is not used so removed as redundant
- Remove redundant signature dependency