### PR TITLE
Unmarshal optimization

### DIFF
--- a/examples/examples/rtp-forwarder/rtp-forwarder.rs
+++ b/examples/examples/rtp-forwarder/rtp-forwarder.rs
@@ -18,7 +18,7 @@ use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndicat
 use webrtc::rtp_transceiver::rtp_codec::{
     RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType,
 };
-use webrtc::util::{Conn, Marshal, Unmarshal};
+use webrtc::util::{Conn, Marshal};
 
 #[derive(Clone)]
 struct UdpConn {
@@ -208,10 +208,8 @@ async fn main() -> Result<()> {
 
         tokio::spawn(async move {
             let mut b = vec![0u8; 1500];
-            while let Ok((n, _)) = track.read(&mut b).await {
-                // Unmarshal the packet and update the PayloadType
-                let mut buf = &b[..n];
-                let mut rtp_packet = webrtc::rtp::packet::Packet::unmarshal(&mut buf)?;
+            while let Ok((mut rtp_packet, _)) = track.read(&mut b).await {
+                // Update the PayloadType
                 rtp_packet.header.payload_type = c.payload_type;
 
                 // Marshal into original buffer with updated PayloadType

--- a/interceptor/src/lib.rs
+++ b/interceptor/src/lib.rs
@@ -104,14 +104,19 @@ impl RTPWriter for RTPWriterFn {
 #[async_trait]
 pub trait RTPReader {
     /// read a rtp packet
-    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)>;
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        attributes: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)>;
 }
 
 pub type RTPReaderBoxFn = Box<
     dyn (Fn(
             &mut [u8],
             &Attributes,
-        ) -> Pin<Box<dyn Future<Output = Result<(usize, Attributes)>> + Send + Sync>>)
+        )
+            -> Pin<Box<dyn Future<Output = Result<(rtp::packet::Packet, Attributes)>> + Send + Sync>>)
         + Send
         + Sync,
 >;
@@ -120,7 +125,11 @@ pub struct RTPReaderFn(pub RTPReaderBoxFn);
 #[async_trait]
 impl RTPReader for RTPReaderFn {
     /// read a rtp packet
-    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)> {
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        attributes: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
         self.0(buf, attributes).await
     }
 }
@@ -163,15 +172,28 @@ impl RTCPWriter for RTCPWriterFn {
 #[async_trait]
 pub trait RTCPReader {
     /// read a batch of rtcp packets
-    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)>;
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        attributes: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)>;
 }
 
 pub type RTCPReaderBoxFn = Box<
     dyn (Fn(
             &mut [u8],
             &Attributes,
-        ) -> Pin<Box<dyn Future<Output = Result<(usize, Attributes)>> + Send + Sync>>)
-        + Send
+        ) -> Pin<
+            Box<
+                dyn Future<
+                        Output = Result<(
+                            Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>,
+                            Attributes,
+                        )>,
+                    > + Send
+                    + Sync,
+            >,
+        >) + Send
         + Sync,
 >;
 
@@ -180,7 +202,11 @@ pub struct RTCPReaderFn(pub RTCPReaderBoxFn);
 #[async_trait]
 impl RTCPReader for RTCPReaderFn {
     /// read a batch of rtcp packets
-    async fn read(&self, buf: &mut [u8], attributes: &Attributes) -> Result<(usize, Attributes)> {
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        attributes: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         self.0(buf, attributes).await
     }
 }

--- a/interceptor/src/mock/mock_stream.rs
+++ b/interceptor/src/mock/mock_stream.rs
@@ -5,7 +5,7 @@ use crate::{Attributes, Interceptor, RTCPReader, RTCPWriter, RTPReader, RTPWrite
 use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
-use util::{Marshal, Unmarshal};
+use util::Marshal;
 
 type RTCPPackets = Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>;
 
@@ -88,26 +88,15 @@ impl MockStream {
             let mut buf = vec![0u8; 1500];
             let a = Attributes::new();
             loop {
-                let n = match rtcp_reader.read(&mut buf, &a).await {
+                let pkts = match rtcp_reader.read(&mut buf, &a).await {
                     Ok((n, _)) => n,
                     Err(err) => {
-                        if Error::ErrIoEOF != err {
-                            let _ = rtcp_in_modified_tx.send(Err(err)).await;
-                        }
+                        let _ = rtcp_in_modified_tx.send(Err(err)).await;
                         break;
                     }
                 };
 
-                let mut b = &buf[..n];
-                let pkt = match rtcp::packet::unmarshal(&mut b) {
-                    Ok(pkt) => pkt,
-                    Err(err) => {
-                        let _ = rtcp_in_modified_tx.send(Err(err.into())).await;
-                        break;
-                    }
-                };
-
-                let _ = rtcp_in_modified_tx.send(Ok(pkt)).await;
+                let _ = rtcp_in_modified_tx.send(Ok(pkts)).await;
             }
         });
 
@@ -121,21 +110,10 @@ impl MockStream {
             let mut buf = vec![0u8; 1500];
             let a = Attributes::new();
             loop {
-                let n = match rtp_reader.read(&mut buf, &a).await {
-                    Ok((n, _)) => n,
+                let pkt = match rtp_reader.read(&mut buf, &a).await {
+                    Ok((pkt, _)) => pkt,
                     Err(err) => {
-                        if Error::ErrIoEOF != err {
-                            let _ = rtp_in_modified_tx.send(Err(err)).await;
-                        }
-                        break;
-                    }
-                };
-
-                let mut b = &buf[..n];
-                let pkt = match rtp::packet::Packet::unmarshal(&mut b) {
-                    Ok(pkt) => pkt,
-                    Err(err) => {
-                        let _ = rtp_in_modified_tx.send(Err(err.into())).await;
+                        let _ = rtp_in_modified_tx.send(Err(err)).await;
                         break;
                     }
                 };
@@ -259,7 +237,11 @@ impl RTCPWriter for MockStream {
 
 #[async_trait]
 impl RTCPReader for MockStream {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let pkts = {
             let mut rtcp_in = self.rtcp_in_rx.lock().await;
             rtcp_in.recv().await.ok_or(Error::ErrIoEOF)?
@@ -272,7 +254,7 @@ impl RTCPReader for MockStream {
         }
 
         buf[..n].copy_from_slice(&marshaled);
-        Ok((n, a.clone()))
+        Ok((pkts, a.clone()))
     }
 }
 
@@ -286,7 +268,11 @@ impl RTPWriter for MockStream {
 
 #[async_trait]
 impl RTPReader for MockStream {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
         let pkt = {
             let mut rtp_in = self.rtp_in_rx.lock().await;
             rtp_in.recv().await.ok_or(Error::ErrIoEOF)?
@@ -299,7 +285,7 @@ impl RTPReader for MockStream {
         }
 
         buf[..n].copy_from_slice(&marshaled);
-        Ok((n, a.clone()))
+        Ok((pkt, a.clone()))
     }
 }
 

--- a/interceptor/src/nack/generator/generator_stream.rs
+++ b/interceptor/src/nack/generator/generator_stream.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::nack::UINT16SIZE_HALF;
 
 use util::sync::Mutex;
-use util::Unmarshal;
 
 struct GeneratorStreamInternal {
     packets: Vec<u64>,
@@ -152,14 +151,16 @@ impl GeneratorStream {
 #[async_trait]
 impl RTPReader for GeneratorStream {
     /// read a rtp packet
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        let (n, attr) = self.parent_rtp_reader.read(buf, a).await?;
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
+        let (pkt, attr) = self.parent_rtp_reader.read(buf, a).await?;
 
-        let mut b = &buf[..n];
-        let pkt = rtp::packet::Packet::unmarshal(&mut b)?;
         self.add(pkt.header.sequence_number);
 
-        Ok((n, attr))
+        Ok((pkt, attr))
     }
 }
 

--- a/interceptor/src/noop.rs
+++ b/interceptor/src/noop.rs
@@ -60,14 +60,22 @@ impl Interceptor for NoOp {
 
 #[async_trait]
 impl RTPReader for NoOp {
-    async fn read(&self, _buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        Ok((0, a.clone()))
+    async fn read(
+        &self,
+        _buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
+        Ok((rtp::packet::Packet::default(), a.clone()))
     }
 }
 
 #[async_trait]
 impl RTCPReader for NoOp {
-    async fn read(&self, _buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        Ok((0, a.clone()))
+    async fn read(
+        &self,
+        _buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
+        Ok((vec![], a.clone()))
     }
 }

--- a/interceptor/src/report/receiver/mod.rs
+++ b/interceptor/src/report/receiver/mod.rs
@@ -26,11 +26,12 @@ pub(crate) struct ReceiverReportRtcpReader {
 
 #[async_trait]
 impl RTCPReader for ReceiverReportRtcpReader {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        let (n, attr) = self.parent_rtcp_reader.read(buf, a).await?;
-
-        let mut b = &buf[..n];
-        let pkts = rtcp::packet::unmarshal(&mut b)?;
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
+        let (pkts, attr) = self.parent_rtcp_reader.read(buf, a).await?;
 
         let now = if let Some(f) = &self.internal.now {
             f()
@@ -53,7 +54,7 @@ impl RTCPReader for ReceiverReportRtcpReader {
             }
         }
 
-        Ok((n, attr))
+        Ok((pkts, attr))
     }
 }
 

--- a/interceptor/src/report/receiver/receiver_stream.rs
+++ b/interceptor/src/report/receiver/receiver_stream.rs
@@ -4,7 +4,6 @@ use crate::{Attributes, RTPReader};
 use async_trait::async_trait;
 use std::time::SystemTime;
 use util::sync::Mutex;
-use util::Unmarshal;
 
 struct ReceiverStreamInternal {
     ssrc: u32,
@@ -208,11 +207,13 @@ impl ReceiverStream {
 #[async_trait]
 impl RTPReader for ReceiverStream {
     /// read a rtp packet
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        let (n, attr) = self.parent_rtp_reader.read(buf, a).await?;
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
+        let (pkt, attr) = self.parent_rtp_reader.read(buf, a).await?;
 
-        let mut b = &buf[..n];
-        let pkt = rtp::packet::Packet::unmarshal(&mut b)?;
         let now = if let Some(f) = &self.now {
             f()
         } else {
@@ -220,6 +221,6 @@ impl RTPReader for ReceiverStream {
         };
         self.process_rtp(now, &pkt);
 
-        Ok((n, attr))
+        Ok((pkt, attr))
     }
 }

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -729,8 +729,6 @@ impl RTPReader for RTPReadRecorder {
         attributes: &Attributes,
     ) -> Result<(rtp::packet::Packet, Attributes)> {
         let (pkt, attributes) = self.rtp_reader.read(buf, attributes).await?;
-        // TODO: This parsing happens redundantly in several interceptors, would be good if we
-        // could not do this.
 
         let _ = self
             .tx

--- a/interceptor/src/stream_reader.rs
+++ b/interceptor/src/stream_reader.rs
@@ -6,14 +6,22 @@ use srtp::stream::Stream;
 
 #[async_trait]
 impl RTPReader for Stream {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        Ok((self.read(buf).await?, a.clone()))
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
+        Ok((self.read_rtp(buf).await?, a.clone()))
     }
 }
 
 #[async_trait]
 impl RTCPReader for Stream {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> Result<(usize, Attributes)> {
-        Ok((self.read(buf).await?, a.clone()))
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
+        Ok((self.read_rtcp(buf).await?, a.clone()))
     }
 }

--- a/media/src/io/sample_builder/mod.rs
+++ b/media/src/io/sample_builder/mod.rs
@@ -373,10 +373,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
         if self.prepared.empty() {
             return None;
         }
-        let result = std::mem::replace(
-            &mut self.prepared_samples[self.prepared.head as usize],
-            None,
-        );
+        let result = self.prepared_samples[self.prepared.head as usize].take();
         self.prepared.head = self.prepared.head.wrapping_add(1);
         result
     }

--- a/srtp/src/session/session_rtcp_test.rs
+++ b/srtp/src/session/session_rtcp_test.rs
@@ -158,9 +158,9 @@ async fn get_sender_ssrc(read_stream: &Arc<Stream>) -> Result<u32> {
     let mut read_buffer = BytesMut::with_capacity(PLI_PACKET_SIZE + auth_tag_size);
     read_buffer.resize(PLI_PACKET_SIZE + auth_tag_size, 0u8);
 
-    let (n, _) = read_stream.read_rtcp(&mut read_buffer).await?;
-    let mut reader = &read_buffer[0..n];
-    let pli = picture_loss_indication::PictureLossIndication::unmarshal(&mut reader)?;
+    let pkts = read_stream.read_rtcp(&mut read_buffer).await?;
+    let mut bytes = &pkts[0].marshal()?[..];
+    let pli = picture_loss_indication::PictureLossIndication::unmarshal(&mut bytes)?;
 
     Ok(pli.sender_ssrc)
 }

--- a/srtp/src/session/session_rtp_test.rs
+++ b/srtp/src/session/session_rtp_test.rs
@@ -210,17 +210,17 @@ async fn payload_srtp(
     let mut read_buffer = BytesMut::with_capacity(header_size + expected_payload.len());
     read_buffer.resize(header_size + expected_payload.len(), 0u8);
 
-    let (n, hdr) = read_stream.read_rtp(&mut read_buffer).await?;
+    let pkt = read_stream.read_rtp(&mut read_buffer).await?;
 
     assert_eq!(
         expected_payload,
-        &read_buffer[header_size..n],
+        &pkt.payload[..],
         "Sent buffer does not match the one received exp({:?}) actual({:?})",
         expected_payload,
-        &read_buffer[header_size..n]
+        &pkt.payload[..]
     );
 
-    Ok(hdr.sequence_number)
+    Ok(pkt.header.sequence_number)
 }
 
 #[tokio::test]

--- a/srtp/src/stream.rs
+++ b/srtp/src/stream.rs
@@ -53,29 +53,32 @@ impl Stream {
     }
 
     /// ReadRTP reads and decrypts full RTP packet and its header from the nextConn
-    pub async fn read_rtp(&self, buf: &mut [u8]) -> Result<(usize, rtp::header::Header)> {
+    pub async fn read_rtp(&self, buf: &mut [u8]) -> Result<rtp::packet::Packet> {
         if !self.is_rtp {
             return Err(Error::InvalidRtpStream);
         }
 
         let n = self.buffer.read(buf, None).await?;
         let mut b = &buf[..n];
-        let header = rtp::header::Header::unmarshal(&mut b)?;
 
-        Ok((n, header))
+        let pkt = rtp::packet::Packet::unmarshal(&mut b)?;
+        Ok(pkt)
     }
 
     /// read_rtcp reads and decrypts full RTP packet and its header from the nextConn
-    pub async fn read_rtcp(&self, buf: &mut [u8]) -> Result<(usize, rtcp::header::Header)> {
+    pub async fn read_rtcp(
+        &self,
+        buf: &mut [u8],
+    ) -> Result<Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>> {
         if self.is_rtp {
             return Err(Error::InvalidRtcpStream);
         }
 
         let n = self.buffer.read(buf, None).await?;
         let mut b = &buf[..n];
-        let header = rtcp::header::Header::unmarshal(&mut b)?;
+        let pkt = rtcp::packet::unmarshal(&mut b)?;
 
-        Ok((n, header))
+        Ok(pkt)
     }
 
     /// Close removes the ReadStream from the session and cleans up any associated state

--- a/srtp/src/stream.rs
+++ b/srtp/src/stream.rs
@@ -60,8 +60,8 @@ impl Stream {
 
         let n = self.buffer.read(buf, None).await?;
         let mut b = &buf[..n];
-
         let pkt = rtp::packet::Packet::unmarshal(&mut b)?;
+
         Ok(pkt)
     }
 

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -60,6 +60,10 @@
         - `onmute`;
         - `onunmute`.
 
+* Change `RTPReader::read` signature to `|&self, buf: &mut [u8], attributes: &Attributes| -> Result<(rtp::packet::Packet, Attributes)>` [#450](https://github.com/webrtc-rs/webrtc/pull/450).
+
+* Change `RTCPReader::read` signature to `|&self, buf: &mut [u8], attributes: &Attributes| -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)>` [#450](https://github.com/webrtc-rs/webrtc/pull/450).
+
 ## v0.6.0
 
 * Added more stats to `RemoteInboundRTPStats` and `RemoteOutboundRTPStats` [#282](https://github.com/webrtc-rs/webrtc/pull/282) by [@k0nserv](https://github.com/k0nserv).

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1,5 +1,5 @@
-use bytes::Bytes;
 use tokio::time::Instant;
+use util::Unmarshal;
 
 use super::*;
 use crate::rtp_transceiver::create_stream_info;
@@ -945,7 +945,7 @@ impl PeerConnectionInternal {
         let mut buf = vec![0u8; self.setting_engine.get_receive_mtu()];
         // Packets that we read as part of simulcast probing that we need to make available
         // if we do find a track later.
-        let mut buffered_packets: VecDeque<(Bytes, Attributes)> = VecDeque::default();
+        let mut buffered_packets: VecDeque<(rtp::packet::Packet, Attributes)> = VecDeque::default();
 
         let n = rtp_stream.read(&mut buf).await?;
 
@@ -955,8 +955,12 @@ impl PeerConnectionInternal {
             sid_extension_id as u8,
             rsid_extension_id as u8,
         )?;
+
+        let mut packet_buf = &buf.as_mut_slice()[..self.setting_engine.get_receive_mtu()];
+        let packet = rtp::packet::Packet::unmarshal(&mut packet_buf).unwrap();
+
         // TODO: Can we have attributes on the first packets?
-        buffered_packets.push_back((Bytes::copy_from_slice(&buf[..n]), Attributes::new()));
+        buffered_packets.push_back((packet, Attributes::new()));
 
         let params = self
             .media_engine
@@ -983,7 +987,7 @@ impl PeerConnectionInternal {
         let a = Attributes::new();
         for _ in 0..=SIMULCAST_PROBE_COUNT {
             if mid.is_empty() || (rid.is_empty() && rsid.is_empty()) {
-                let (n, _) = rtp_interceptor.read(&mut buf, &a).await?;
+                let (pkt, _) = rtp_interceptor.read(&mut buf, &a).await?;
                 let (m, r, rs, _) = handle_unknown_rtp_packet(
                     &buf[..n],
                     mid_extension_id as u8,
@@ -994,7 +998,7 @@ impl PeerConnectionInternal {
                 rid = r;
                 rsid = rs;
 
-                buffered_packets.push_back((Bytes::copy_from_slice(&buf[..n]), a.clone()));
+                buffered_packets.push_back((pkt, a.clone()));
                 continue;
             }
 
@@ -1074,8 +1078,8 @@ impl PeerConnectionInternal {
             tokio::spawn(async move {
                 if let Some(track) = receiver.track().await {
                     let mut b = vec![0u8; receive_mtu];
-                    let n = match track.peek(&mut b).await {
-                        Ok((n, _)) => n,
+                    let pkt = match track.peek(&mut b).await {
+                        Ok((pkt, _)) => pkt,
                         Err(err) => {
                             log::warn!(
                                 "Could not determine PayloadType for SSRC {} ({})",
@@ -1086,7 +1090,7 @@ impl PeerConnectionInternal {
                         }
                     };
 
-                    if let Err(err) = track.check_and_update_track(&b[..n]).await {
+                    if let Err(err) = track.check_and_update_track(&pkt).await {
                         log::warn!(
                             "Failed to set codec settings for track SSRC {} ({})",
                             track.ssrc(),

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -956,8 +956,7 @@ impl PeerConnectionInternal {
             rsid_extension_id as u8,
         )?;
 
-        let mut packet_buf = &buf.as_mut_slice()[..self.setting_engine.get_receive_mtu()];
-        let packet = rtp::packet::Packet::unmarshal(&mut packet_buf).unwrap();
+        let packet = rtp::packet::Packet::unmarshal(&mut buf.as_slice()).unwrap();
 
         // TODO: Can we have attributes on the first packets?
         buffered_packets.push_back((packet, Attributes::new()));

--- a/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -161,7 +161,10 @@ pub struct RTPReceiverInternal {
 
 impl RTPReceiverInternal {
     /// read reads incoming RTCP for this RTPReceiver
-    async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
+    async fn read(
+        &self,
+        b: &mut [u8],
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let mut state_watch_rx = self.state_tx.subscribe();
         // Ensure we are running or paused. When paused we still receive RTCP even if RTP traffic
         // isn't flowing.
@@ -190,7 +193,11 @@ impl RTPReceiverInternal {
     }
 
     /// read_simulcast reads incoming RTCP for this RTPReceiver for given rid
-    async fn read_simulcast(&self, b: &mut [u8], rid: &str) -> Result<(usize, Attributes)> {
+    async fn read_simulcast(
+        &self,
+        b: &mut [u8],
+        rid: &str,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let mut state_watch_rx = self.state_tx.subscribe();
 
         // Ensure we are running or paused. When paused we still recevie RTCP even if RTP traffic
@@ -228,10 +235,7 @@ impl RTPReceiverInternal {
         receive_mtu: usize,
     ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let mut b = vec![0u8; receive_mtu];
-        let (n, attributes) = self.read(&mut b).await?;
-
-        let mut buf = &b[..n];
-        let pkts = rtcp::packet::unmarshal(&mut buf)?;
+        let (pkts, attributes) = self.read(&mut b).await?;
 
         Ok((pkts, attributes))
     }
@@ -243,15 +247,16 @@ impl RTPReceiverInternal {
         receive_mtu: usize,
     ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let mut b = vec![0u8; receive_mtu];
-        let (n, attributes) = self.read_simulcast(&mut b, rid).await?;
-
-        let mut buf = &b[..n];
-        let pkts = rtcp::packet::unmarshal(&mut buf)?;
+        let (pkts, attributes) = self.read_simulcast(&mut b, rid).await?;
 
         Ok((pkts, attributes))
     }
 
-    pub(crate) async fn read_rtp(&self, b: &mut [u8], tid: usize) -> Result<(usize, Attributes)> {
+    pub(crate) async fn read_rtp(
+        &self,
+        b: &mut [u8],
+        tid: usize,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
         let mut state_watch_rx = self.state_tx.subscribe();
 
         // Ensure we are running.
@@ -613,12 +618,19 @@ impl RTCRtpReceiver {
     }
 
     /// read reads incoming RTCP for this RTPReceiver
-    pub async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
+    pub async fn read(
+        &self,
+        b: &mut [u8],
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         self.internal.read(b).await
     }
 
     /// read_simulcast reads incoming RTCP for this RTPReceiver for given rid
-    pub async fn read_simulcast(&self, b: &mut [u8], rid: &str) -> Result<(usize, Attributes)> {
+    pub async fn read_simulcast(
+        &self,
+        b: &mut [u8],
+        rid: &str,
+    ) -> Result<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         self.internal.read_simulcast(b, rid).await
     }
 
@@ -734,7 +746,11 @@ impl RTCRtpReceiver {
     }
 
     /// read_rtp should only be called by a track, this only exists so we can keep state in one place
-    pub(crate) async fn read_rtp(&self, b: &mut [u8], tid: usize) -> Result<(usize, Attributes)> {
+    pub(crate) async fn read_rtp(
+        &self,
+        b: &mut [u8],
+        tid: usize,
+    ) -> Result<(rtp::packet::Packet, Attributes)> {
         self.internal.read_rtp(b, tid).await
     }
 

--- a/webrtc/src/rtp_transceiver/srtp_writer_future.rs
+++ b/webrtc/src/rtp_transceiver/srtp_writer_future.rs
@@ -260,8 +260,16 @@ type IResult<T> = std::result::Result<T, interceptor::Error>;
 
 #[async_trait]
 impl RTCPReader for SrtpWriterFuture {
-    async fn read(&self, buf: &mut [u8], a: &Attributes) -> IResult<(usize, Attributes)> {
-        Ok((self.read(buf).await?, a.clone()))
+    async fn read(
+        &self,
+        buf: &mut [u8],
+        a: &Attributes,
+    ) -> IResult<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
+        let read = self.read(buf).await?;
+        let mut b = &buf[..read];
+
+        let pkt = rtcp::packet::unmarshal(&mut b)?;
+        Ok((pkt, a.clone()))
     }
 }
 

--- a/webrtc/src/rtp_transceiver/srtp_writer_future.rs
+++ b/webrtc/src/rtp_transceiver/srtp_writer_future.rs
@@ -266,9 +266,8 @@ impl RTCPReader for SrtpWriterFuture {
         a: &Attributes,
     ) -> IResult<(Vec<Box<dyn rtcp::packet::Packet + Send + Sync>>, Attributes)> {
         let read = self.read(buf).await?;
-        let mut b = &buf[..read];
+        let pkt = rtcp::packet::unmarshal(&mut &buf[..read])?;
 
-        let pkt = rtcp::packet::unmarshal(&mut b)?;
         Ok((pkt, a.clone()))
     }
 }

--- a/webrtc/src/track/track_remote/mod.rs
+++ b/webrtc/src/track/track_remote/mod.rs
@@ -5,9 +5,7 @@ use crate::rtp_transceiver::{PayloadType, SSRC};
 
 use crate::rtp_transceiver::rtp_receiver::RTPReceiverInternal;
 
-use crate::track::RTP_PAYLOAD_TYPE_BITMASK;
 use arc_swap::ArcSwapOption;
-use bytes::{Bytes, BytesMut};
 use interceptor::{Attributes, Interceptor};
 use std::collections::VecDeque;
 use std::future::Future;
@@ -16,8 +14,6 @@ use std::sync::atomic::{AtomicU32, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use tokio::sync::Mutex;
 use util::sync::Mutex as SyncMutex;
-
-use util::Unmarshal;
 
 lazy_static! {
     static ref TRACK_REMOTE_UNIQUE_ID: AtomicUsize = AtomicUsize::new(0);
@@ -34,7 +30,7 @@ struct Handlers {
 
 #[derive(Default)]
 struct TrackRemoteInternal {
-    peeked: VecDeque<(Bytes, Attributes)>,
+    peeked: VecDeque<(rtp::packet::Packet, Attributes)>,
 }
 
 /// TrackRemote represents a single inbound source of media
@@ -216,16 +212,14 @@ impl TrackRemote {
     ///
     /// **Cancel Safety:** This method is not cancel safe. Dropping the resulting [`Future`] before
     /// it returns [`Poll::Ready`] will cause data loss.
-    pub async fn read(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
+    pub async fn read(&self, b: &mut [u8]) -> Result<(rtp::packet::Packet, Attributes)> {
         {
             // Internal lock scope
             let mut internal = self.internal.lock().await;
-            if let Some((data, attributes)) = internal.peeked.pop_front() {
-                let n = std::cmp::min(b.len(), data.len());
-                b[..n].copy_from_slice(&data[..n]);
-                self.check_and_update_track(&b[..n]).await?;
+            if let Some((pkt, attributes)) = internal.peeked.pop_front() {
+                self.check_and_update_track(&pkt).await?;
 
-                return Ok((n, attributes));
+                return Ok((pkt, attributes));
             }
         };
 
@@ -234,20 +228,15 @@ impl TrackRemote {
             None => return Err(Error::ErrRTPReceiverNil),
         };
 
-        let (n, attributes) = receiver.read_rtp(b, self.tid).await?;
-        self.check_and_update_track(&b[..n]).await?;
-        Ok((n, attributes))
+        let (pkt, attributes) = receiver.read_rtp(b, self.tid).await?;
+        self.check_and_update_track(&pkt).await?;
+        Ok((pkt, attributes))
     }
 
     /// check_and_update_track checks payloadType for every incoming packet
     /// once a different payloadType is detected the track will be updated
-    pub(crate) async fn check_and_update_track(&self, b: &[u8]) -> Result<()> {
-        // NOTE: This method MUST not attempt to lock `Self::internal`, doing so will deadlock.
-        if b.len() < 2 {
-            return Err(Error::ErrRTPTooShort);
-        }
-
-        let payload_type = b[1] & RTP_PAYLOAD_TYPE_BITMASK;
+    pub(crate) async fn check_and_update_track(&self, pkt: &rtp::packet::Packet) -> Result<()> {
+        let payload_type = pkt.header.payload_type;
         if payload_type != self.payload_type() {
             let p = self
                 .media_engine
@@ -280,27 +269,23 @@ impl TrackRemote {
     /// read_rtp is a convenience method that wraps Read and unmarshals for you.
     pub async fn read_rtp(&self) -> Result<(rtp::packet::Packet, Attributes)> {
         let mut b = vec![0u8; self.receive_mtu];
-        let (n, attributes) = self.read(&mut b).await?;
+        let (pkt, attributes) = self.read(&mut b).await?;
 
-        let mut buf = &b[..n];
-        let r = rtp::packet::Packet::unmarshal(&mut buf)?;
-        Ok((r, attributes))
+        Ok((pkt, attributes))
     }
 
     /// peek is like Read, but it doesn't discard the packet read
-    pub(crate) async fn peek(&self, b: &mut [u8]) -> Result<(usize, Attributes)> {
-        let (n, a) = self.read(b).await?;
+    pub(crate) async fn peek(&self, b: &mut [u8]) -> Result<(rtp::packet::Packet, Attributes)> {
+        let (pkt, a) = self.read(b).await?;
 
         // this might overwrite data if somebody peeked between the Read
         // and us getting the lock.  Oh well, we'll just drop a packet in
         // that case.
-        let mut data = BytesMut::new();
-        data.extend(b[..n].to_vec());
         {
             let mut internal = self.internal.lock().await;
-            internal.peeked.push_back((data.freeze(), a.clone()));
+            internal.peeked.push_back((pkt.clone(), a.clone()));
         }
-        Ok((n, a))
+        Ok((pkt, a))
     }
 
     /// Set the initially peeked data for this track.
@@ -308,7 +293,10 @@ impl TrackRemote {
     /// This is useful when a track is first created to populate data read from the track in the
     /// process of identifying the track as part of simulcast probing. Using this during other
     /// parts of the track's lifecycle is probably an error.
-    pub(crate) async fn prepopulate_peeked_data(&self, data: VecDeque<(Bytes, Attributes)>) {
+    pub(crate) async fn prepopulate_peeked_data(
+        &self,
+        data: VecDeque<(rtp::packet::Packet, Attributes)>,
+    ) {
         let mut internal = self.internal.lock().await;
         internal.peeked = data;
     }


### PR DESCRIPTION
This PR optimizes multiple `unmarshal` in `Interceptor`.

closes  TODO: `interceptor/src/stats/interceptor.rs:732`
```
// TODO: This parsing happens redundantly in several interceptors, would be good if 
// could not do this.
```