### PR TITLE
Fix of rtp header size calculation

### DIFF
--- a/media/src/io/ivf_writer/ivf_writer_test.rs
+++ b/media/src/io/ivf_writer/ivf_writer_test.rs
@@ -24,6 +24,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             csrc: vec![],
             padding: false,
             extensions: vec![],
+            extensions_padding: 0,
         },
         payload: raw_valid_pkt.slice(20..),
     };
@@ -51,6 +52,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             csrc: vec![],
             padding: raw_mid_part_pkt.len() % 4 != 0,
             extensions: vec![],
+            extensions_padding: 0,
         },
         payload: raw_mid_part_pkt.slice(20..),
     };
@@ -78,6 +80,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             csrc: vec![],
             padding: raw_keyframe_pkt.len() % 4 != 0,
             extensions: vec![],
+            extensions_padding: 0,
         },
         payload: raw_keyframe_pkt.slice(20..),
     };

--- a/media/src/io/ogg_writer/ogg_writer_test.rs
+++ b/media/src/io/ogg_writer/ogg_writer_test.rs
@@ -23,6 +23,7 @@ fn test_ogg_writer_add_packet_and_close() -> Result<()> {
             csrc: vec![],
             padding: false,
             extensions: vec![],
+            extensions_padding: 0,
         },
         payload: raw_pkt.slice(20..),
     };

--- a/media/src/io/sample_builder/mod.rs
+++ b/media/src/io/sample_builder/mod.rs
@@ -373,10 +373,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
         if self.prepared.empty() {
             return None;
         }
-        let result = std::mem::replace(
-            &mut self.prepared_samples[self.prepared.head as usize],
-            None,
-        );
+        let result = self.prepared_samples[self.prepared.head as usize].take();
         self.prepared.head = self.prepared.head.wrapping_add(1);
         result
     }

--- a/rtp/src/header.rs
+++ b/rtp/src/header.rs
@@ -47,7 +47,7 @@ pub struct Header {
     pub csrc: Vec<u32>,
     pub extension_profile: u16,
     pub extensions: Vec<Extension>,
-    pub extensions_padding: usize
+    pub extensions_padding: usize,
 }
 
 impl Unmarshal for Header {
@@ -197,7 +197,7 @@ impl Unmarshal for Header {
             csrc,
             extension_profile,
             extensions,
-            extensions_padding
+            extensions_padding,
         })
     }
 }

--- a/rtp/src/packetizer/packetizer_test.rs
+++ b/rtp/src/packetizer/packetizer_test.rs
@@ -77,6 +77,7 @@ fn test_packetizer_abs_send_time() -> Result<()> {
                 id: 1,
                 payload: Bytes::from_static(&[0x40, 0, 0]),
             }],
+            extensions_padding: 0,
         },
         payload: Bytes::from_static(&[0x11, 0x12, 0x13, 0x14]),
     };


### PR DESCRIPTION
I tried to retrieve media from mediasoup SFU. There is issue with calculation of RTP header size. I propose fix for this.

The stack does not count with padding data in header extensions field.
![image](https://github.com/webrtc-rs/webrtc/assets/9843950/9dbd4ff9-8c9a-48cd-ae00-c519ef787c20)
