### PR TITLE
Fix of dtls connection with lite ice role

### DIFF
--- a/media/src/io/sample_builder/mod.rs
+++ b/media/src/io/sample_builder/mod.rs
@@ -373,10 +373,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
         if self.prepared.empty() {
             return None;
         }
-        let result = std::mem::replace(
-            &mut self.prepared_samples[self.prepared.head as usize],
-            None,
-        );
+        let result = self.prepared_samples[self.prepared.head as usize].take();
         self.prepared.head = self.prepared.head.wrapping_add(1);
         result
     }

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -911,7 +911,7 @@ impl RTCPeerConnection {
         let remote_description: RTCSessionDescription;
         if let Some(desc) = remote_desc {
             remote_description = desc;
-        }else{
+        } else {
             return Err(Error::ErrNoRemoteDescription);
         }
         if use_identity {
@@ -931,7 +931,7 @@ impl RTCPeerConnection {
             .to_connection_role();
         if connection_role == ConnectionRole::Unspecified {
             connection_role = DEFAULT_DTLS_ROLE_ANSWER.to_connection_role();
-            if let  Some(parsed) = remote_description.parsed {
+            if let Some(parsed) = remote_description.parsed {
                 if Self::is_lite_set(&parsed) && !self.internal.setting_engine.candidates.ice_lite {
                     connection_role = DTLSRole::Server.to_connection_role();
                 }
@@ -1306,13 +1306,13 @@ impl RTCPeerConnection {
         self.current_local_description().await
     }
 
-    pub fn is_lite_set(desc: &SessionDescription) -> bool{
+    pub fn is_lite_set(desc: &SessionDescription) -> bool {
         for a in &desc.attributes {
             if a.key.trim() == ATTR_KEY_ICELITE {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// set_remote_description sets the SessionDescription of the remote peer

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -926,6 +926,9 @@ impl RTCPeerConnection {
             .to_connection_role();
         if connection_role == ConnectionRole::Unspecified {
             connection_role = DEFAULT_DTLS_ROLE_ANSWER.to_connection_role();
+            if remote_is_lite && !self.internal.setting_engine.candidates.ice_lite {
+                connection_role = DTLSRole::Server.to_connection_role();
+            }
         }
 
         let local_transceivers = self.get_transceivers().await;


### PR DESCRIPTION
Currently the stack cannot handle ICE-LITE peer and correctly initiate connection. This fix adjusts the correct DTLS role for ICE-LITE peer 

[Pion commit](https://github.com/pion/webrtc/commit/8796a5c5a7359e12f0164823631d6e25579a4260#diff-c94e5058864f96b58c5e039ac0485b3a9640613f32a9e31bba905dc3f8438e7a)