### PR TITLE
Returning an alert when PSK authentication fails.

### DIFF
--- a/dtls/src/alert/mod.rs
+++ b/dtls/src/alert/mod.rs
@@ -62,6 +62,7 @@ pub(crate) enum AlertDescription {
     UserCanceled = 90,
     NoRenegotiation = 100,
     UnsupportedExtension = 110,
+    UnknownPskIdentity = 115,
     Invalid,
 }
 
@@ -93,6 +94,7 @@ impl fmt::Display for AlertDescription {
             AlertDescription::UserCanceled => write!(f, "UserCanceled"),
             AlertDescription::NoRenegotiation => write!(f, "NoRenegotiation"),
             AlertDescription::UnsupportedExtension => write!(f, "UnsupportedExtension"),
+            AlertDescription::UnknownPskIdentity => write!(f, "UnknownPskIdentity"),
             _ => write!(f, "Invalid alert description"),
         }
     }
@@ -126,6 +128,7 @@ impl From<u8> for AlertDescription {
             90 => AlertDescription::UserCanceled,
             100 => AlertDescription::NoRenegotiation,
             110 => AlertDescription::UnsupportedExtension,
+            115 => AlertDescription::UnknownPskIdentity,
             _ => AlertDescription::Invalid,
         }
     }

--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -968,7 +968,20 @@ impl DTLSConn {
                     Ok(pkt) => pkt,
                     Err(err) => {
                         debug!("{}: decrypt failed: {}", srv_cli_str(ctx.is_client), err);
-                        return (false, None, None);
+
+                        // If we get an error for PSK we need to return an error.
+                        if cipher_suite.is_psk() {
+                            return (
+                                false,
+                                Some(Alert {
+                                    alert_level: AlertLevel::Fatal,
+                                    alert_description: AlertDescription::UnknownPskIdentity,
+                                }),
+                                None,
+                            );
+                        } else {
+                            return (false, None, None);
+                        }
                     }
                 };
             }


### PR DESCRIPTION
As per RFC 4279 (Pre-Shared Key Ciphersuites for Transport Layer Security), Section 2:

>    If the server does not recognize the PSK identity, it MAY respond
   with an "unknown_psk_identity" alert message.  Alternatively, if the
   server wishes to hide the fact that the PSK identity was not known,
   it MAY continue the protocol as if the PSK identity existed but the
   key was incorrect: that is, respond with a "decrypt_error" alert.
