### PR TITLE
Add as_any to Conn trait for accessing underlying Conn

### DIFF
--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -139,6 +139,10 @@ impl Conn for DTLSConn {
     async fn close(&self) -> UtilResult<()> {
         self.close().await.map_err(util::Error::from_std)
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 impl DTLSConn {

--- a/ice/src/agent/agent_test.rs
+++ b/ice/src/agent/agent_test.rs
@@ -614,6 +614,10 @@ impl Conn for MockPacketConn {
     async fn close(&self) -> std::result::Result<(), util::Error> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 fn build_msg(c: MessageClass, username: String, key: String) -> Result<Message> {

--- a/ice/src/agent/agent_transport.rs
+++ b/ice/src/agent/agent_transport.rs
@@ -243,4 +243,8 @@ impl Conn for AgentConn {
     async fn close(&self) -> std::result::Result<(), util::Error> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -41,6 +41,9 @@ impl Conn for MockConn {
     async fn close(&self) -> Result<(), util::Error> {
         Ok(())
     }
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 pub(crate) struct VNet {

--- a/ice/src/udp_mux/udp_mux_conn.rs
+++ b/ice/src/udp_mux/udp_mux_conn.rs
@@ -304,6 +304,10 @@ impl Conn for UDPMuxConn {
 
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 #[inline(always)]

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -46,6 +46,10 @@ impl Conn for DumbConn {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 fn create_association_internal(config: Config) -> AssociationInternal {

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -2104,7 +2104,7 @@ struct FakeEchoConn {
 }
 
 impl FakeEchoConn {
-    fn type_erased() -> impl Conn + AsAny {
+    fn type_erased() -> impl Conn {
         Self::default()
     }
 }
@@ -2118,16 +2118,6 @@ impl Default for FakeEchoConn {
             bytes_sent: AtomicUsize::new(0),
             bytes_received: AtomicUsize::new(0),
         }
-    }
-}
-
-trait AsAny {
-    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync);
-}
-
-impl AsAny for FakeEchoConn {
-    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
-        self
     }
 }
 
@@ -2181,6 +2171,10 @@ impl Conn for FakeEchoConn {
 
     async fn close(&self) -> UResult<()> {
         Ok(())
+    }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
     }
 }
 

--- a/turn/src/client/relay_conn.rs
+++ b/turn/src/client/relay_conn.rs
@@ -186,6 +186,10 @@ impl<T: RelayConnObserver + Send + Sync> Conn for RelayConn<T> {
             .map_err(|err| util::Error::Other(format!("{err}")));
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {

--- a/util/src/conn/conn_bridge.rs
+++ b/util/src/conn/conn_bridge.rs
@@ -65,6 +65,10 @@ impl Conn for BridgeConn {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 pub type FilterCbFn = Box<dyn Fn(&Bytes) -> bool + Send + Sync>;

--- a/util/src/conn/conn_disconnected_packet.rs
+++ b/util/src/conn/conn_disconnected_packet.rs
@@ -58,4 +58,8 @@ impl Conn for DisconnectedPacketConn {
     async fn close(&self) -> Result<()> {
         self.pconn.close().await
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/util/src/conn/conn_pipe.rs
+++ b/util/src/conn/conn_pipe.rs
@@ -73,4 +73,8 @@ impl Conn for Pipe {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/util/src/conn/conn_udp.rs
+++ b/util/src/conn/conn_udp.rs
@@ -35,4 +35,8 @@ impl Conn for UdpSocket {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/util/src/conn/conn_udp_listener.rs
+++ b/util/src/conn/conn_udp_listener.rs
@@ -291,4 +291,8 @@ impl Conn for UdpConn {
         conns.remove(self.raddr.to_string().as_str());
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/util/src/conn/mod.rs
+++ b/util/src/conn/mod.rs
@@ -34,6 +34,7 @@ pub trait Conn {
     fn local_addr(&self) -> Result<SocketAddr>;
     fn remote_addr(&self) -> Option<SocketAddr>;
     async fn close(&self) -> Result<()>;
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync);
 }
 
 /// A Listener is a generic network listener for connection-oriented protocols.

--- a/util/src/vnet/conn.rs
+++ b/util/src/vnet/conn.rs
@@ -156,4 +156,8 @@ impl Conn for UdpConn {
 
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/webrtc/src/mux/endpoint.rs
+++ b/webrtc/src/mux/endpoint.rs
@@ -70,4 +70,8 @@ impl Conn for Endpoint {
     async fn close(&self) -> Result<()> {
         self.next_conn.close().await
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }

--- a/webrtc/src/mux/mux_test.rs
+++ b/webrtc/src/mux/mux_test.rs
@@ -77,6 +77,10 @@ impl Conn for MuxErrorConn {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
This allows you to access the inner connection state of the DTLS connection. Having the connection identity is helpful in server code.