### PR TITLE
Error clarification

### DIFF
--- a/srtp/src/cipher/cipher_aes_cm_hmac_sha1.rs
+++ b/srtp/src/cipher/cipher_aes_cm_hmac_sha1.rs
@@ -302,6 +302,10 @@ impl Cipher for CipherAesCmHmacSha1 {
 
         // Split the auth tag and the cipher text into two parts.
         let actual_tag = &encrypted[encrypted.len() - self.auth_tag_len()..];
+        if actual_tag.len() != self.auth_tag_len() {
+            return Err(Error::RtcpInvalidLengthAuthTag);
+        }
+
         let cipher_text = &encrypted[..encrypted.len() - self.auth_tag_len()];
 
         // Generate the auth tag we expect to see from the ciphertext.

--- a/srtp/src/error.rs
+++ b/srtp/src/error.rs
@@ -69,6 +69,8 @@ pub enum Error {
     SrtcpTooSmall(usize, usize),
     #[error("failed to verify rtp auth tag")]
     RtpFailedToVerifyAuthTag,
+    #[error("tag is too short")]
+    RtcpInvalidLengthAuthTag,
     #[error("failed to verify rtcp auth tag")]
     RtcpFailedToVerifyAuthTag,
     #[error("SessionSRTP has been closed")]


### PR DESCRIPTION
I get `failed to verify rtsp auth tag` (`RtcpFailedToVerifyAuthTag`) errors intermittently but the description of the error is not sufficient to identify the problem.

it could be:
different encryption methods,
broken package,
wrong auth tag