### PR TITLE
Implement AV1 Payloader

### DIFF
--- a/rtp/src/codecs/av1/av1_test.rs
+++ b/rtp/src/codecs/av1/av1_test.rs
@@ -1,0 +1,454 @@
+use crate::codecs::av1::obu::{
+    OBU_HAS_EXTENSION_BIT, OBU_TYPE_FRAME, OBU_TYPE_FRAME_HEADER, OBU_TYPE_METADATA,
+    OBU_TYPE_SEQUENCE_HEADER, OBU_TYPE_TEMPORAL_DELIMITER, OBU_TYPE_TILE_GROUP, OBU_TYPE_TILE_LIST,
+};
+use crate::error::Result;
+
+use super::*;
+
+const OBU_EXTENSION_S1T1: u8 = 0b001_01_000;
+const NEW_CODED_VIDEO_SEQUENCE_BIT: u8 = 0b00_00_1000;
+
+struct Av1Obu {
+    header: u8,
+    extension: u8,
+    payload: Vec<u8>,
+}
+
+impl Av1Obu {
+    pub fn new(obu_type: u8) -> Self {
+        Self {
+            header: obu_type << 3 | OBU_HAS_SIZE_BIT,
+            extension: 0,
+            payload: vec![],
+        }
+    }
+
+    pub fn with_extension(mut self, extension: u8) -> Self {
+        self.extension = extension;
+        self.header |= OBU_HAS_EXTENSION_BIT;
+        self
+    }
+
+    pub fn without_size(mut self) -> Self {
+        self.header &= !OBU_HAS_SIZE_BIT;
+        self
+    }
+
+    pub fn with_payload(mut self, payload: Vec<u8>) -> Self {
+        self.payload = payload;
+        self
+    }
+}
+
+fn build_av1_frame(obus: &Vec<Av1Obu>) -> Bytes {
+    let mut raw = vec![];
+    for obu in obus {
+        raw.push(obu.header);
+        if obu.header & OBU_HAS_EXTENSION_BIT != 0 {
+            raw.push(obu.extension);
+        }
+        if obu.header & OBU_HAS_SIZE_BIT != 0 {
+            // write size in leb128 format.
+            let mut payload_size = obu.payload.len();
+            while payload_size >= 0b_1000_0000 {
+                raw.push(0b_1000_0000 | (payload_size & 0b_0111_1111) as u8);
+                payload_size >>= 7;
+            }
+            raw.push(payload_size as u8);
+        }
+        raw.extend_from_slice(&obu.payload);
+    }
+    Bytes::from(raw)
+}
+
+#[test]
+fn test_packetize_one_obu_without_size_and_extension() -> Result<()> {
+    let frame = build_av1_frame(&vec![Av1Obu::new(OBU_TYPE_FRAME)
+        .without_size()
+        .with_payload(vec![1, 2, 3, 4, 5, 6, 7])]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_01_0000,        // aggregation header
+            OBU_TYPE_FRAME << 3, // header
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_packetize_one_obu_without_size_with_extension() -> Result<()> {
+    let frame = build_av1_frame(&vec![Av1Obu::new(OBU_TYPE_FRAME)
+        .without_size()
+        .with_extension(OBU_EXTENSION_S1T1)
+        .with_payload(vec![2, 3, 4, 5, 6, 7])]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_01_0000,                                // aggregation header
+            OBU_TYPE_FRAME << 3 | OBU_HAS_EXTENSION_BIT, // header
+            OBU_EXTENSION_S1T1,                          // extension header
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn removes_obu_size_field_without_extension() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![11, 12, 13, 14, 15, 16, 17])
+    ]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_01_0000,        // aggregation header
+            OBU_TYPE_FRAME << 3, // header
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn removes_obu_size_field_with_extension() -> Result<()> {
+    let frame = build_av1_frame(&vec![Av1Obu::new(OBU_TYPE_FRAME)
+        .with_extension(OBU_EXTENSION_S1T1)
+        .with_payload(vec![1, 2, 3, 4, 5, 6, 7])]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_01_0000,                                // aggregation header
+            OBU_TYPE_FRAME << 3 | OBU_HAS_EXTENSION_BIT, // header
+            OBU_EXTENSION_S1T1,                          // extension header
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_omits_size_for_last_obu_when_three_obus_fits_into_the_packet() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_SEQUENCE_HEADER).with_payload(vec![1, 2, 3, 4, 5, 6]),
+        Av1Obu::new(OBU_TYPE_METADATA).with_payload(vec![11, 12, 13, 14]),
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![21, 22, 23, 24, 25, 26]),
+    ]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_11_1000,                  // aggregation header
+            7,                             // size of the first OBU
+            OBU_TYPE_SEQUENCE_HEADER << 3, // header of the first OBU
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            5,                      // size of the second OBU
+            OBU_TYPE_METADATA << 3, // header of the second OBU
+            11,
+            12,
+            13,
+            14,
+            OBU_TYPE_FRAME << 3, // header of the third OBU
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_use_size_for_all_obus_when_four_obus_fits_into_the_packet() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_SEQUENCE_HEADER).with_payload(vec![1, 2, 3, 4, 5, 6]),
+        Av1Obu::new(OBU_TYPE_METADATA).with_payload(vec![11, 12, 13, 14]),
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![21, 22, 23]),
+        Av1Obu::new(OBU_TYPE_TILE_GROUP).with_payload(vec![31, 32, 33, 34, 35, 36]),
+    ]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_00_1000,                  // aggregation header
+            7,                             // size of the first OBU
+            OBU_TYPE_SEQUENCE_HEADER << 3, // header of the first OBU
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            5,                      // size of the second OBU
+            OBU_TYPE_METADATA << 3, // header of the second OBU
+            11,
+            12,
+            13,
+            14,
+            4,                   // size of the third OBU
+            OBU_TYPE_FRAME << 3, // header of the third OBU
+            21,
+            22,
+            23,
+            7,                        // size of the fourth OBU
+            OBU_TYPE_TILE_GROUP << 3, // header of the fourth OBU
+            31,
+            32,
+            33,
+            34,
+            35,
+            36
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_discards_temporal_delimiter_and_tile_list_obu() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_TEMPORAL_DELIMITER),
+        Av1Obu::new(OBU_TYPE_METADATA),
+        Av1Obu::new(OBU_TYPE_TILE_LIST).with_payload(vec![1, 2, 3, 4, 5, 6]),
+        Av1Obu::new(OBU_TYPE_FRAME_HEADER).with_payload(vec![21, 22, 23]),
+        Av1Obu::new(OBU_TYPE_TILE_GROUP).with_payload(vec![31, 32, 33, 34, 35, 36]),
+    ]);
+    let mut payloader = Av1Payloader {};
+    assert_eq!(
+        payloader.payload(1200, &frame)?,
+        vec![vec![
+            0b00_11_0000,               // aggregation header
+            1,                          // size of the first OBU
+            OBU_TYPE_METADATA << 3,     // header of the first OBU
+            4,                          // size of the second OBU
+            OBU_TYPE_FRAME_HEADER << 3, // header of the second OBU
+            21,
+            22,
+            23,
+            OBU_TYPE_TILE_GROUP << 3, // header of the fourth OBU
+            31,
+            32,
+            33,
+            34,
+            35,
+            36
+        ]]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_two_obus_into_two_packet_force_split_obu_header() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_FRAME_HEADER)
+            .with_extension(OBU_EXTENSION_S1T1)
+            .with_payload(vec![21]),
+        Av1Obu::new(OBU_TYPE_TILE_GROUP)
+            .with_extension(OBU_EXTENSION_S1T1)
+            .with_payload(vec![11, 12, 13, 14]),
+    ]);
+    let mut payloader = Av1Payloader {};
+
+    // Craft expected payloads so that there is only one way to split original
+    // frame into two packets.
+    assert_eq!(
+        payloader.payload(6, &frame)?,
+        vec![
+            vec![
+                0b01_10_0000,                                       // aggregation header
+                3,                                                  // size of the first OBU
+                OBU_TYPE_FRAME_HEADER << 3 | OBU_HAS_EXTENSION_BIT, // header of the first OBU
+                OBU_EXTENSION_S1T1,                                 // extension header
+                21,
+                OBU_TYPE_TILE_GROUP << 3 | OBU_HAS_EXTENSION_BIT, // header of the second OBU
+            ],
+            vec![
+                0b10_01_0000, // aggregation header
+                OBU_EXTENSION_S1T1,
+                11,
+                12,
+                13,
+                14
+            ]
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_sets_n_bit_at_the_first_packet_of_a_key_frame_with_sequence_header() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_SEQUENCE_HEADER).with_payload(vec![1, 2, 3, 4, 5, 6, 7])
+    ]);
+    let mut payloader = Av1Payloader {};
+    let result = payloader.payload(6, &frame)?;
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result[0][0] & NEW_CODED_VIDEO_SEQUENCE_BIT,
+        NEW_CODED_VIDEO_SEQUENCE_BIT
+    );
+    assert_eq!(result[1][0] & NEW_CODED_VIDEO_SEQUENCE_BIT, 0);
+    Ok(())
+}
+
+#[test]
+fn test_doesnt_set_n_bit_at_the_packets_of_a_key_frame_without_sequence_header() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![1, 2, 3, 4, 5, 6, 7])
+    ]);
+    let mut payloader = Av1Payloader {};
+    let result = payloader.payload(6, &frame)?;
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0][0] & NEW_CODED_VIDEO_SEQUENCE_BIT, 0);
+    assert_eq!(result[1][0] & NEW_CODED_VIDEO_SEQUENCE_BIT, 0);
+    Ok(())
+}
+
+#[test]
+fn test_doesnt_set_n_bit_at_the_packets_of_a_delta_frame() -> Result<()> {
+    // TODO: implement delta frame detection.
+    Ok(())
+}
+
+#[test]
+fn test_split_single_obu_into_two_packets() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![11, 12, 13, 14, 15, 16, 17, 18, 19])
+    ]);
+    let mut payloader = Av1Payloader {};
+    // let result = payloader.payload(8, &frame)?;
+    // println!("{:?}", result[0].to_vec());
+    // println!("{:?}", result[1].to_vec());
+    assert_eq!(
+        payloader.payload(8, &frame)?,
+        vec![
+            vec![
+                0b01_01_0000,        // aggregation header
+                OBU_TYPE_FRAME << 3, // header
+                11,
+                12,
+                13,
+                14,
+                15,
+                16
+            ],
+            vec![
+                0b10_01_0000, // aggregation header
+                17,
+                18,
+                19
+            ],
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_split_single_obu_into_many_packets() -> Result<()> {
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![27; 1200])
+    ]);
+    let mut payloader = Av1Payloader {};
+    let result = payloader.payload(100, &frame)?;
+    assert_eq!(result.len(), 13);
+    assert_eq!(result[0], {
+        let mut ret = vec![
+            0b01_01_0000,        // aggregation header
+            OBU_TYPE_FRAME << 3, // header
+        ];
+        ret.extend(vec![27; 98]);
+        ret
+    });
+    for i in 1..12 {
+        assert_eq!(result[i], {
+            let mut ret = vec![
+                0b11_01_0000, // aggregation header
+            ];
+            ret.extend(vec![27; 99]);
+            ret
+        });
+    }
+    assert_eq!(result[12], {
+        let mut ret = vec![
+            0b10_01_0000, // aggregation header
+        ];
+        ret.extend(vec![27; 13]);
+        ret
+    });
+
+    Ok(())
+}
+
+#[test]
+fn test_split_two_obus_into_two_packets() -> Result<()> {
+    // 2nd OBU is too large to fit into one packet, so its head would be in the
+    // same packet as the 1st OBU.
+    let frame = build_av1_frame(&vec![
+        Av1Obu::new(OBU_TYPE_SEQUENCE_HEADER).with_payload(vec![11, 12]),
+        Av1Obu::new(OBU_TYPE_FRAME).with_payload(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    ]);
+    let mut payloader = Av1Payloader {};
+    let result = payloader.payload(8, &frame)?;
+    assert_eq!(
+        result,
+        vec![
+            vec![
+                0b01_10_1000,                  // aggregation header
+                3,                             // size of the first OBU
+                OBU_TYPE_SEQUENCE_HEADER << 3, // header
+                11,
+                12,
+                OBU_TYPE_FRAME << 3, // header of the second OBU
+                1,
+                2
+            ],
+            vec![
+                0b10_01_0000, // aggregation header
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ]
+        ]
+    );
+    Ok(())
+}

--- a/rtp/src/codecs/av1/av1_test.rs
+++ b/rtp/src/codecs/av1/av1_test.rs
@@ -6,7 +6,7 @@ use crate::error::Result;
 
 use super::*;
 
-const OBU_EXTENSION_S1T1: u8 = 0b001_01_000;
+const OBU_EXTENSION_S1T1: u8 = 0b0010_1000;
 const NEW_CODED_VIDEO_SEQUENCE_BIT: u8 = 0b00_00_1000;
 
 struct Av1Obu {
@@ -395,8 +395,8 @@ fn test_split_single_obu_into_many_packets() -> Result<()> {
         ret.extend(vec![27; 98]);
         ret
     });
-    for i in 1..12 {
-        assert_eq!(result[i], {
+    for packet in result.iter().take(12).skip(1) {
+        assert_eq!(packet.to_vec(), {
             let mut ret = vec![
                 0b11_01_0000, // aggregation header
             ];

--- a/rtp/src/codecs/av1/leb128.rs
+++ b/rtp/src/codecs/av1/leb128.rs
@@ -1,0 +1,64 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
+pub fn encode_leb128(mut val: u32) -> u32 {
+    let mut b = 0;
+    loop {
+        b |= val & 0b_0111_1111;
+        val >>= 7;
+        if val != 0 {
+            b |= 0b_1000_0000;
+            b <<= 8;
+        } else {
+            return b;
+        }
+    }
+}
+
+pub fn decode_leb128(mut val: u32) -> u32 {
+    let mut b = 0;
+    loop {
+        b |= val & 0b_0111_1111;
+        val >>= 8;
+        if val == 0 {
+            return b;
+        }
+        b <<= 7;
+    }
+}
+
+pub fn read_leb128(bytes: &Bytes) -> (u32, usize) {
+    let mut encoded = 0;
+    for i in 0..bytes.len() {
+        encoded |= bytes[i] as u32;
+        if bytes[i] & 0b_1000_0000 == 0 {
+            return (decode_leb128(encoded), i + 1);
+        }
+        encoded <<= 8;
+    }
+    (0, 0)
+}
+
+pub fn leb128_size(value: u32) -> usize {
+    let mut size = 0;
+    let mut value = value;
+    while value >= 0b_1000_0000 {
+        size += 1;
+        value >>= 7;
+    }
+    size + 1
+}
+
+pub trait BytesMutExt {
+    fn put_leb128(&mut self, n: u32);
+}
+
+impl BytesMutExt for BytesMut {
+    fn put_leb128(&mut self, n: u32) {
+        let encoded = encode_leb128(n);
+        let leb128_size = leb128_size(n);
+        for i in (0..leb128_size).rev() {
+            let byte = (encoded >> (i * 8)) as u8;
+            self.put_u8(byte)
+        }
+    }
+}

--- a/rtp/src/codecs/av1/leb128.rs
+++ b/rtp/src/codecs/av1/leb128.rs
@@ -55,8 +55,7 @@ pub trait BytesMutExt {
 impl BytesMutExt for BytesMut {
     fn put_leb128(&mut self, n: u32) {
         let encoded = encode_leb128(n);
-        let leb128_size = leb128_size(n);
-        for i in (0..leb128_size).rev() {
+        for i in (0..leb128_size(n)).rev() {
             let byte = (encoded >> (i * 8)) as u8;
             self.put_u8(byte)
         }

--- a/rtp/src/codecs/av1/leb128.rs
+++ b/rtp/src/codecs/av1/leb128.rs
@@ -54,10 +54,11 @@ pub trait BytesMutExt {
 
 impl BytesMutExt for BytesMut {
     fn put_leb128(&mut self, n: u32) {
-        let encoded = encode_leb128(n);
-        for i in (0..leb128_size(n)).rev() {
-            let byte = (encoded >> (i * 8)) as u8;
-            self.put_u8(byte)
+        let mut encoded = encode_leb128(n);
+        while encoded >= 0b_1000_0000 {
+            self.put_u8(0b_1000_0000 | (encoded & 0b_0111_1111) as u8);
+            encoded >>= 7;
         }
+        self.put_u8(encoded as u8);
     }
 }

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -1,0 +1,94 @@
+use std::cmp::min;
+
+use bytes::Bytes;
+
+use crate::packetizer::Payloader;
+
+#[derive(Default, Clone, Debug)]
+pub struct Av1Payloader {}
+
+const AV1_PAYLOADER_HEADER_SIZE: usize = 1;
+
+// fn encode_leb128(mut val: u32) -> u32 {
+//     let mut b = 0;
+//     loop {
+//         b |= val & 0b01111111;
+//         val >>= 7;
+//         if val != 0 {
+//             b |= 0x80;
+//             b <<= 8;
+//         } else {
+//             return b;
+//         }
+//     }
+// }
+
+fn encode_leb128(input: u32) -> u32 {
+    let mut output: u32 = 0;
+    let mut in_value = input;
+
+    loop {
+        output |= in_value & 0b0111_1111;
+        in_value >>= 7;
+
+        if in_value != 0 {
+            output |= 0b1000_0000;
+            output <<= 8;
+        } else {
+            return output;
+        }
+    }
+}
+
+impl Payloader for Av1Payloader {
+    fn payload(&mut self, mtu: usize, payload: &Bytes) -> crate::error::Result<Vec<Bytes>> {
+        let max_fragment_size = mtu - AV1_PAYLOADER_HEADER_SIZE;
+        let mut packets = vec![];
+        let mut payload_data_remaining = payload.len();
+        let mut payload_data_index = 0;
+
+        if min(max_fragment_size, payload_data_remaining) <= 0 {
+            return Ok(packets);
+        }
+
+        while payload_data_remaining > 0 {
+            let current_fragment_size = min(max_fragment_size, payload_data_remaining);
+            let leb128_size = if current_fragment_size >= 127 { 2 } else { 1 };
+
+            let mut packet = vec![0; AV1_PAYLOADER_HEADER_SIZE + leb128_size + current_fragment_size];
+            let leb128_value = encode_leb128(current_fragment_size as u32);
+            if leb128_size == 1 {
+                packet[1] = leb128_value as u8;
+            } else {
+                packet[1] = (leb128_value >> 8) as u8;
+                packet[2] = leb128_value as u8;
+            }
+            packet[AV1_PAYLOADER_HEADER_SIZE + leb128_size..]
+                .copy_from_slice(&payload[payload_data_index..payload_data_index + current_fragment_size]);
+
+            payload_data_remaining -= current_fragment_size;
+            payload_data_index += current_fragment_size;
+
+            if packets.len() == 0 {
+                // Set the N bit to 1 for the first packet
+                packet[0] |= 0b00001000;
+            }
+            if packets.len() > 0 {
+                // Set the Z bit to 0 for all but the first packet
+                packet[0] |= 0b10000000;
+            }
+            if payload_data_remaining != 0 {
+                // Set the Y bit to 1 for all but the last packet
+                packet[0] |= 0b01000000;
+            }
+
+            packets.push(Bytes::from(packet));
+        }
+
+        Ok(packets)
+    }
+
+    fn clone_to(&self) -> Box<dyn Payloader + Send + Sync> {
+        Box::new(self.clone())
+    }
+}

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -1,399 +1,48 @@
-use std::cmp::min;
-
 use bytes::{BufMut, Bytes, BytesMut};
 
+use crate::codecs::av1::leb128::BytesMutExt;
+use crate::codecs::av1::obu::{obu_has_extension, parse_obus, OBU_HAS_SIZE_BIT};
+use crate::codecs::av1::packetizer::{
+    get_aggregation_header, packetize, AGGREGATION_HEADER_SIZE, MAX_NUM_OBUS_TO_OMIT_SIZE,
+};
 use crate::packetizer::Payloader;
+
+mod leb128;
+mod obu;
+mod packetizer;
 
 #[derive(Default, Clone, Debug)]
 pub struct Av1Payloader {}
 
-const AGGREGATION_HEADER_SIZE: usize = 1;
-
-// when there are 3 or less OBU (fragments) in a packet, size of the last one
-// can be omited.
-const MAX_NUM_OBUS_TO_OMIT_SIZE: usize = 3;
-
-const OBU_SIZE_PRESENT_BIT: u8 = 0b0_0000_010;
-
-const OBU_TYPE_SEQUENCE_HEADER: u8 = 1;
-const OBU_TYPE_TEMPORAL_DELIMITER: u8 = 2;
-const OBU_TYPE_TILE_LIST: u8 = 3;
-const OBU_TYPE_PADDING: u8 = 15;
-
-fn encode_leb128(mut val: u32) -> u32 {
-    let mut b = 0;
-    loop {
-        b |= val & 0b01111111;
-        val >>= 7;
-        if val != 0 {
-            b |= 0x80;
-            b <<= 8;
-        } else {
-            return b;
-        }
-    }
-}
-
-fn decode_leb128(mut val: u32) -> u32 {
-    let mut b = 0;
-    loop {
-        b |= val & 0b01111111;
-        val >>= 8;
-        if val == 0 {
-            return b;
-        }
-        b <<= 7;
-    }
-}
-
-fn read_leb128(bytes: &Bytes) -> (u32, usize) {
-    let mut encoded = 0;
-    for i in 0..bytes.len() {
-        encoded |= bytes[i] as u32;
-        if bytes[i] & 0b1000_0000 == 0 {
-            return (decode_leb128(encoded), i + 1);
-        }
-        encoded <<= 8;
-    }
-    (0, 0)
-}
-
-fn leb128_size(value: u32) -> usize {
-    let mut size = 0;
-    let mut value = value;
-    while value >= 0x80 {
-        size += 1;
-        value >>= 7;
-    }
-    size + 1
-}
-
-fn max_fragment_size(remaining_bytes: usize) -> usize {
-    if remaining_bytes <= 1 {
-        return 0;
-    }
-    let mut i = 1;
-    loop {
-        if remaining_bytes < (1 << 7 * i) + i {
-            return remaining_bytes - i;
-        }
-        i += 1;
-    }
-}
-
-struct Obu {
-    header: u8,
-    extension_header: u8,
-    payload: Bytes,
-    size: usize,
-}
-
-fn obu_has_extension(header: u8) -> bool {
-    header & 0b0_0000_100 != 0
-}
-
-fn obu_has_size(header: u8) -> bool {
-    header & 0b0_0000_010 != 0
-}
-
-fn obu_type(header: u8) -> u8 {
-    (header & 0b0_1111_000) >> 3
-}
-
-struct Packet {
-    first_obu_index: usize,
-    num_obu_elements: usize,
-    first_obu_offset: usize,
-    last_obu_size: usize,
-    packet_size: usize,
-}
-
-impl Packet {
-    fn new(first_obu_index: usize) -> Self {
-        Self {
-            first_obu_index,
-            num_obu_elements: 0,
-            first_obu_offset: 0,
-            last_obu_size: 0,
-            packet_size: 0,
-        }
-    }
-}
-
-fn parse_obus(payload: &Bytes) -> Vec<Obu> {
-    let mut obus = vec![];
-    let mut consumed = 0;
-
-    while consumed < payload.len() {
-        let payload_remaining = payload.slice(consumed..);
-        let header = payload_remaining[0];
-        consumed += 1;
-        let mut obu_size = 1;
-        let extension_header = if obu_has_extension(header) {
-            if payload_remaining.len() < 2 {
-                // TODO Err "Payload too small for OBU extension header";
-                return vec![];
-            }
-            obu_size += 1;
-            consumed += 1;
-            payload_remaining[1]
-        } else {
-            0
-        };
-
-        let payload_without_header = payload_remaining.slice(obu_size..);
-        let obu_payload = if !obu_has_size(header) {
-            payload_without_header
-        } else {
-            if payload_without_header.len() < 1 {
-                // TODO Err "Payload too small for OBU size";
-                return vec![];
-            }
-            let (size, size_encoding_size) = read_leb128(&payload_without_header);
-            consumed += size_encoding_size + size as usize;
-            payload_without_header.slice(size_encoding_size..size_encoding_size + size as usize)
-            // payload_remaining.slice(obu_size..obu_size + size as usize)
-        };
-        obu_size += obu_payload.len();
-
-        let obu_type = obu_type(header);
-        if obu_type != OBU_TYPE_TEMPORAL_DELIMITER
-            && obu_type != OBU_TYPE_TILE_LIST
-            && obu_type != OBU_TYPE_PADDING
-        {
-            obus.push(Obu {
-                header,
-                extension_header,
-                payload: obu_payload,
-                size: obu_size,
-            });
-        }
-    }
-
-    obus
-}
-
-fn additional_bytes_for_previous_obu_element(packet: &Packet) -> usize {
-    if packet.packet_size == 0 {
-        // Packet is still empty => no last OBU element, no need to reserve space
-        // for it.
-        0
-    } else if packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE {
-        // There are so many obu elements in the packet, all of them must be
-        // prepended with the length field. That imply space for the length of the
-        // last obu element is already reserved.
-        0
-    } else {
-        leb128_size(packet.last_obu_size as u32)
-    }
-}
-
-fn packetize(obus: &Vec<Obu>, max_payload_size: usize) -> Vec<Packet> {
-    let mut packets = vec![];
-    if obus.is_empty() {
-        return packets;
-    }
-    if max_payload_size < 3 {
-        // TODO Err "Payload size too small";
-        return packets;
-    }
-    // Aggregation header will be present in all packets.
-    let max_payload_size = max_payload_size - AGGREGATION_HEADER_SIZE;
-
-    // Assemble packets. Push to current packet as much as it can hold before
-    // considering next one. That would normally cause uneven distribution across
-    // packets, specifically last one would be generally smaller.
-    packets.push(Packet::new(0));
-    let mut packet_remaining_bytes = max_payload_size;
-
-    for obu_index in 0..obus.len() {
-        let is_last_obu = obu_index == obus.len() - 1;
-        let obu = &obus[obu_index];
-
-        // Putting |obu| into the last packet would make last obu element stored in
-        // that packet not last. All not last OBU elements must be prepend with the
-        // element length. AdditionalBytesForPreviousObuElement calculates how many
-        // bytes are needed to store that length.
-        let mut previous_obu_extra_size =
-            additional_bytes_for_previous_obu_element(packets.last().unwrap());
-        let min_required_size =
-            if packets.last().unwrap().num_obu_elements >= MAX_NUM_OBUS_TO_OMIT_SIZE {
-                2
-            } else {
-                1
-            };
-        if packet_remaining_bytes < previous_obu_extra_size + min_required_size {
-            // Start a new packet.
-            packets.push(Packet::new(obu_index));
-            packet_remaining_bytes = max_payload_size;
-            previous_obu_extra_size = 0;
-        }
-        let mut packet = packets.pop().unwrap();
-        packet.packet_size += previous_obu_extra_size;
-        packet_remaining_bytes -= previous_obu_extra_size;
-        packet.num_obu_elements += 1;
-        let must_write_obu_element_size = packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE;
-
-        // Can fit all of the obu into the packet?
-        let mut required_bytes = obu.size;
-        if must_write_obu_element_size {
-            required_bytes += leb128_size(obu.size as u32);
-        }
-        if required_bytes < packet_remaining_bytes {
-            // Insert the obu into the packet unfragmented.
-            packet.last_obu_size = obu.size;
-            packet.packet_size += required_bytes;
-            packet_remaining_bytes -= required_bytes;
-            packets.push(packet);
-            continue;
-        }
-        // Fragment the obu.
-        let max_first_fragment_size = if must_write_obu_element_size {
-            max_fragment_size(packet_remaining_bytes)
-        } else {
-            packet_remaining_bytes
-        };
-        // Because available_bytes might be different than
-        // packet_remaining_bytes it might happen that max_first_fragment_size >=
-        // obu.size. Also, since checks above verified |obu| should not be put
-        // completely into the |packet|, leave at least 1 byte for later packet.
-        let first_fragment_size = min(obu.size - 1, max_first_fragment_size);
-        if first_fragment_size == 0 {
-            // Rather than writing 0-size element at the tail of the packet,
-            // 'uninsert' the |obu| from the |packet|.
-            packet.num_obu_elements -= 1;
-            packet.packet_size -= previous_obu_extra_size;
-        } else {
-            packet.packet_size += first_fragment_size;
-            if must_write_obu_element_size {
-                packet.packet_size += leb128_size(first_fragment_size as u32);
-            }
-            packet.last_obu_size = first_fragment_size;
-        }
-        packets.push(packet);
-        // Add middle fragments that occupy all of the packet.
-        // These are easy because
-        // - one obu per packet imply no need to store the size of the obu.
-        // - this packets are nor the first nor the last packets of the frame, so
-        // packet capacity is always limits.max_payload_len.
-        let mut obu_offset = first_fragment_size;
-        while obu_offset + max_payload_size < obu.size {
-            let mut packet = Packet::new(obu_index);
-            packet.num_obu_elements = 1;
-            packet.first_obu_offset = obu_offset;
-            let middle_fragment_size = max_payload_size;
-            packet.last_obu_size = middle_fragment_size;
-            packet.packet_size = middle_fragment_size;
-            packets.push(packet);
-            obu_offset += max_payload_size;
-        }
-        // Add the last fragment of the obu.
-        let mut last_fragment_size = obu.size - obu_offset;
-        // Check for corner case where last fragment of the last obu is too large
-        // to fit into last packet, but may fully fit into semi-last packet.
-        if is_last_obu && last_fragment_size > max_payload_size {
-            // Split last fragments into two.
-            // Try to even packet sizes rather than payload sizes across the last
-            // two packets.
-            let mut semi_last_fragment_size = last_fragment_size / 2;
-            // But leave at least one payload byte for the last packet to avoid
-            // weird scenarios where size of the fragment is zero and rtp payload has
-            // nothing except for an aggregation header.
-            if semi_last_fragment_size >= last_fragment_size {
-                semi_last_fragment_size = last_fragment_size - 1;
-            }
-            last_fragment_size -= semi_last_fragment_size;
-            let mut packet = Packet::new(obu_index);
-            packet.first_obu_offset = obu_offset;
-            packet.last_obu_size = semi_last_fragment_size;
-            packet.packet_size = semi_last_fragment_size;
-            packets.push(packet);
-            obu_offset += semi_last_fragment_size
-        }
-        let mut last_packet = Packet::new(obu_index);
-        last_packet.num_obu_elements = 1;
-        last_packet.first_obu_offset = obu_offset;
-        last_packet.last_obu_size = last_fragment_size;
-        last_packet.packet_size = last_fragment_size;
-        packets.push(last_packet);
-        packet_remaining_bytes = max_payload_size - last_fragment_size;
-    }
-
-    packets
-}
-
-fn get_aggregation_header(obus: &Vec<Obu>, packets: &Vec<Packet>, packet_index: usize) -> u8 {
-    let packet = &packets[packet_index];
-    let mut header: u8 = 0;
-
-    // Set Z flag: first obu element is continuation of the previous OBU.
-    let first_obu_element_is_fragment = packet.first_obu_offset > 0;
-    if first_obu_element_is_fragment {
-        header |= 1 << 7;
-    }
-
-    // Set Y flag: last obu element will be continuated in the next packet.
-    let last_obu_offset = if packet.num_obu_elements == 1 {
-        packet.first_obu_offset
-    } else {
-        0
-    };
-    let last_obu_is_fragment = last_obu_offset + packet.last_obu_size
-        < obus[packet.first_obu_index + packet.num_obu_elements - 1].size;
-    if last_obu_is_fragment {
-        header |= 1 << 6;
-    }
-
-    // Set W field: number of obu elements in the packet (when not too large).
-    if packet.num_obu_elements <= MAX_NUM_OBUS_TO_OMIT_SIZE {
-        header |= (packet.num_obu_elements as u8) << 4;
-    }
-
-    // Set N flag: beginning of a new coded video sequence.
-    // Encoder may produce key frame without a sequence header, thus double check
-    // incoming frame includes the sequence header. Since Temporal delimiter is
-    // already filtered out, sequence header should be the first obu when present.
-    if packet_index == 0 && obu_type(obus.first().unwrap().header) == OBU_TYPE_SEQUENCE_HEADER {
-        header |= 1 << 3;
-    }
-    header
-}
-
 impl Payloader for Av1Payloader {
     fn payload(&mut self, mtu: usize, payload: &Bytes) -> crate::error::Result<Vec<Bytes>> {
-        let obus = parse_obus(payload);
-        let packets = packetize(&obus, mtu);
+        let obus = parse_obus(payload)?;
+        let packets_metadata = packetize(&obus, mtu);
         let mut payloads = vec![];
-        for packet_index in 0..packets.len() {
-            let packet = &packets[packet_index];
-            let mut out = BytesMut::with_capacity(AGGREGATION_HEADER_SIZE + packet.packet_size);
-            let aggregation_header = get_aggregation_header(&obus, &packets, packet_index);
-            out.put_u8(aggregation_header);
+
+        for packet_index in 0..packets_metadata.len() {
+            let packet = &packets_metadata[packet_index];
             let mut obu_offset = packet.first_obu_offset;
+            let aggregation_header = get_aggregation_header(&obus, &packets_metadata, packet_index);
+
+            let mut out = BytesMut::with_capacity(AGGREGATION_HEADER_SIZE + packet.packet_size);
+            out.put_u8(aggregation_header);
+
             // Store all OBU elements except the last one.
             for i in 0..packet.num_obu_elements - 1 {
                 let obu = &obus[packet.first_obu_index + i];
                 let fragment_size = obu.size - obu_offset;
-                let leb128_fragment_size = encode_leb128(fragment_size as u32);
-                let leb128_fragment_size_size = leb128_size(fragment_size as u32);
-                for i in 0..leb128_fragment_size_size {
-                    out.put_u8(
-                        (leb128_fragment_size >> ((leb128_fragment_size_size - 1 - i) * 8)) as u8,
-                    )
-                }
+                out.put_leb128(fragment_size as u32);
                 if obu_offset == 0 {
-                    out.put_u8(obu.header & !OBU_SIZE_PRESENT_BIT);
+                    out.put_u8(obu.header & !OBU_HAS_SIZE_BIT);
                 }
                 if obu_offset <= 1 && obu_has_extension(obu.header) {
                     out.put_u8(obu.extension_header);
                 }
-                let payload_offset = {
-                    let headers_size = if obu_has_extension(obu.header) { 2 } else { 1 };
-                    if obu_offset <= headers_size {
-                        0
-                    } else {
-                        obu_offset - headers_size
-                    }
+                let payload_offset = if obu_offset > obu.header_size() {
+                    obu_offset - obu.header_size()
+                } else {
+                    0
                 };
                 let payload_size = obu.payload.len() - payload_offset;
                 out.put_slice(
@@ -409,33 +58,20 @@ impl Payloader for Av1Payloader {
             let last_obu = &obus[packet.first_obu_index + packet.num_obu_elements - 1];
             let mut fragment_size = packet.last_obu_size;
             if packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE {
-                let leb128_fragment_size = encode_leb128(fragment_size as u32);
-                let leb128_fragment_size_size = leb128_size(fragment_size as u32);
-                for i in 0..leb128_fragment_size_size {
-                    out.put_u8(
-                        (leb128_fragment_size >> ((leb128_fragment_size_size - 1 - i) * 8)) as u8,
-                    )
-                }
+                out.put_leb128(fragment_size as u32);
             }
             if obu_offset == 0 && fragment_size > 0 {
-                out.put_u8(last_obu.header & !OBU_SIZE_PRESENT_BIT);
+                out.put_u8(last_obu.header & !OBU_HAS_SIZE_BIT);
                 fragment_size -= 1;
             }
             if obu_offset <= 1 && obu_has_extension(last_obu.header) && fragment_size > 0 {
                 out.put_u8(last_obu.extension_header);
                 fragment_size -= 1;
             }
-            let payload_offset = {
-                let headers_size = if obu_has_extension(last_obu.header) {
-                    2
-                } else {
-                    1
-                };
-                if obu_offset <= headers_size {
-                    0
-                } else {
-                    obu_offset - headers_size
-                }
+            let payload_offset = if obu_offset > last_obu.header_size() {
+                obu_offset - last_obu.header_size()
+            } else {
+                0
             };
             out.put_slice(
                 last_obu
@@ -443,6 +79,7 @@ impl Payloader for Av1Payloader {
                     .slice(payload_offset..payload_offset + fragment_size)
                     .as_ref(),
             );
+
             payloads.push(out.freeze());
         }
         Ok(payloads)

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -1,5 +1,4 @@
 use std::cmp::min;
-use std::fmt::format;
 
 use bytes::{BufMut, Bytes, BytesMut};
 

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -7,6 +7,8 @@ use crate::codecs::av1::packetizer::{
 };
 use crate::packetizer::Payloader;
 
+#[cfg(test)]
+mod av1_test;
 mod leb128;
 mod obu;
 mod packetizer;
@@ -18,8 +20,6 @@ impl Payloader for Av1Payloader {
     /// Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
     /// Reference: https://aomediacodec.github.io/av1-rtp-spec/#45-payload-structure
     fn payload(&mut self, mtu: usize, payload: &Bytes) -> crate::error::Result<Vec<Bytes>> {
-        // example:
-        //
         // 0                   1                   2                   3
         // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -15,6 +15,7 @@ mod packetizer;
 pub struct Av1Payloader {}
 
 impl Payloader for Av1Payloader {
+    /// Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
     fn payload(&mut self, mtu: usize, payload: &Bytes) -> crate::error::Result<Vec<Bytes>> {
         let obus = parse_obus(payload)?;
         let packets_metadata = packetize(&obus, mtu);

--- a/rtp/src/codecs/av1/mod.rs
+++ b/rtp/src/codecs/av1/mod.rs
@@ -1,91 +1,452 @@
 use std::cmp::min;
+use std::fmt::format;
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::packetizer::Payloader;
 
 #[derive(Default, Clone, Debug)]
 pub struct Av1Payloader {}
 
-const AV1_PAYLOADER_HEADER_SIZE: usize = 1;
+const AGGREGATION_HEADER_SIZE: usize = 1;
 
-// fn encode_leb128(mut val: u32) -> u32 {
-//     let mut b = 0;
-//     loop {
-//         b |= val & 0b01111111;
-//         val >>= 7;
-//         if val != 0 {
-//             b |= 0x80;
-//             b <<= 8;
-//         } else {
-//             return b;
-//         }
-//     }
-// }
+// when there are 3 or less OBU (fragments) in a packet, size of the last one
+// can be omited.
+const MAX_NUM_OBUS_TO_OMIT_SIZE: usize = 3;
 
-fn encode_leb128(input: u32) -> u32 {
-    let mut output: u32 = 0;
-    let mut in_value = input;
+const OBU_SIZE_PRESENT_BIT: u8 = 0b0_0000_010;
 
+const OBU_TYPE_SEQUENCE_HEADER: u8 = 1;
+const OBU_TYPE_TEMPORAL_DELIMITER: u8 = 2;
+const OBU_TYPE_TILE_LIST: u8 = 3;
+const OBU_TYPE_PADDING: u8 = 15;
+
+fn encode_leb128(mut val: u32) -> u32 {
+    let mut b = 0;
     loop {
-        output |= in_value & 0b0111_1111;
-        in_value >>= 7;
-
-        if in_value != 0 {
-            output |= 0b1000_0000;
-            output <<= 8;
+        b |= val & 0b01111111;
+        val >>= 7;
+        if val != 0 {
+            b |= 0x80;
+            b <<= 8;
         } else {
-            return output;
+            return b;
         }
     }
 }
 
+fn decode_leb128(mut val: u32) -> u32 {
+    let mut b = 0;
+    loop {
+        b |= val & 0b01111111;
+        val >>= 8;
+        if val == 0 {
+            return b;
+        }
+        b <<= 7;
+    }
+}
+
+fn read_leb128(bytes: &Bytes) -> (u32, usize) {
+    let mut encoded = 0;
+    for i in 0..bytes.len() {
+        encoded |= bytes[i] as u32;
+        if bytes[i] & 0b1000_0000 == 0 {
+            return (decode_leb128(encoded), i + 1);
+        }
+        encoded <<= 8;
+    }
+    (0, 0)
+}
+
+fn leb128_size(value: u32) -> usize {
+    let mut size = 0;
+    let mut value = value;
+    while value >= 0x80 {
+        size += 1;
+        value >>= 7;
+    }
+    size + 1
+}
+
+fn max_fragment_size(remaining_bytes: usize) -> usize {
+    if remaining_bytes <= 1 {
+        return 0;
+    }
+    let mut i = 1;
+    loop {
+        if remaining_bytes < (1 << 7 * i) + i {
+            return remaining_bytes - i;
+        }
+        i += 1;
+    }
+}
+
+struct Obu {
+    header: u8,
+    extension_header: u8,
+    payload: Bytes,
+    size: usize,
+}
+
+fn obu_has_extension(header: u8) -> bool {
+    header & 0b0_0000_100 != 0
+}
+
+fn obu_has_size(header: u8) -> bool {
+    header & 0b0_0000_010 != 0
+}
+
+fn obu_type(header: u8) -> u8 {
+    (header & 0b0_1111_000) >> 3
+}
+
+struct Packet {
+    first_obu_index: usize,
+    num_obu_elements: usize,
+    first_obu_offset: usize,
+    last_obu_size: usize,
+    packet_size: usize,
+}
+
+impl Packet {
+    fn new(first_obu_index: usize) -> Self {
+        Self {
+            first_obu_index,
+            num_obu_elements: 0,
+            first_obu_offset: 0,
+            last_obu_size: 0,
+            packet_size: 0,
+        }
+    }
+}
+
+fn parse_obus(payload: &Bytes) -> Vec<Obu> {
+    let mut obus = vec![];
+    let mut consumed = 0;
+
+    while consumed < payload.len() {
+        let payload_remaining = payload.slice(consumed..);
+        let header = payload_remaining[0];
+        consumed += 1;
+        let mut obu_size = 1;
+        let extension_header = if obu_has_extension(header) {
+            if payload_remaining.len() < 2 {
+                // TODO Err "Payload too small for OBU extension header";
+                return vec![];
+            }
+            obu_size += 1;
+            consumed += 1;
+            payload_remaining[1]
+        } else {
+            0
+        };
+
+        let payload_without_header = payload_remaining.slice(obu_size..);
+        let obu_payload = if !obu_has_size(header) {
+            payload_without_header
+        } else {
+            if payload_without_header.len() < 1 {
+                // TODO Err "Payload too small for OBU size";
+                return vec![];
+            }
+            let (size, size_encoding_size) = read_leb128(&payload_without_header);
+            consumed += size_encoding_size + size as usize;
+            payload_without_header.slice(size_encoding_size..size_encoding_size + size as usize)
+            // payload_remaining.slice(obu_size..obu_size + size as usize)
+        };
+        obu_size += obu_payload.len();
+
+        let obu_type = obu_type(header);
+        if obu_type != OBU_TYPE_TEMPORAL_DELIMITER
+            && obu_type != OBU_TYPE_TILE_LIST
+            && obu_type != OBU_TYPE_PADDING
+        {
+            obus.push(Obu {
+                header,
+                extension_header,
+                payload: obu_payload,
+                size: obu_size,
+            });
+        }
+    }
+
+    obus
+}
+
+fn additional_bytes_for_previous_obu_element(packet: &Packet) -> usize {
+    if packet.packet_size == 0 {
+        // Packet is still empty => no last OBU element, no need to reserve space
+        // for it.
+        0
+    } else if packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE {
+        // There are so many obu elements in the packet, all of them must be
+        // prepended with the length field. That imply space for the length of the
+        // last obu element is already reserved.
+        0
+    } else {
+        leb128_size(packet.last_obu_size as u32)
+    }
+}
+
+fn packetize(obus: &Vec<Obu>, max_payload_size: usize) -> Vec<Packet> {
+    let mut packets = vec![];
+    if obus.is_empty() {
+        return packets;
+    }
+    if max_payload_size < 3 {
+        // TODO Err "Payload size too small";
+        return packets;
+    }
+    // Aggregation header will be present in all packets.
+    let max_payload_size = max_payload_size - AGGREGATION_HEADER_SIZE;
+
+    // Assemble packets. Push to current packet as much as it can hold before
+    // considering next one. That would normally cause uneven distribution across
+    // packets, specifically last one would be generally smaller.
+    packets.push(Packet::new(0));
+    let mut packet_remaining_bytes = max_payload_size;
+
+    for obu_index in 0..obus.len() {
+        let is_last_obu = obu_index == obus.len() - 1;
+        let obu = &obus[obu_index];
+
+        // Putting |obu| into the last packet would make last obu element stored in
+        // that packet not last. All not last OBU elements must be prepend with the
+        // element length. AdditionalBytesForPreviousObuElement calculates how many
+        // bytes are needed to store that length.
+        let mut previous_obu_extra_size =
+            additional_bytes_for_previous_obu_element(packets.last().unwrap());
+        let min_required_size =
+            if packets.last().unwrap().num_obu_elements >= MAX_NUM_OBUS_TO_OMIT_SIZE {
+                2
+            } else {
+                1
+            };
+        if packet_remaining_bytes < previous_obu_extra_size + min_required_size {
+            // Start a new packet.
+            packets.push(Packet::new(obu_index));
+            packet_remaining_bytes = max_payload_size;
+            previous_obu_extra_size = 0;
+        }
+        let mut packet = packets.pop().unwrap();
+        packet.packet_size += previous_obu_extra_size;
+        packet_remaining_bytes -= previous_obu_extra_size;
+        packet.num_obu_elements += 1;
+        let must_write_obu_element_size = packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE;
+
+        // Can fit all of the obu into the packet?
+        let mut required_bytes = obu.size;
+        if must_write_obu_element_size {
+            required_bytes += leb128_size(obu.size as u32);
+        }
+        if required_bytes < packet_remaining_bytes {
+            // Insert the obu into the packet unfragmented.
+            packet.last_obu_size = obu.size;
+            packet.packet_size += required_bytes;
+            packet_remaining_bytes -= required_bytes;
+            packets.push(packet);
+            continue;
+        }
+        // Fragment the obu.
+        let max_first_fragment_size = if must_write_obu_element_size {
+            max_fragment_size(packet_remaining_bytes)
+        } else {
+            packet_remaining_bytes
+        };
+        // Because available_bytes might be different than
+        // packet_remaining_bytes it might happen that max_first_fragment_size >=
+        // obu.size. Also, since checks above verified |obu| should not be put
+        // completely into the |packet|, leave at least 1 byte for later packet.
+        let first_fragment_size = min(obu.size - 1, max_first_fragment_size);
+        if first_fragment_size == 0 {
+            // Rather than writing 0-size element at the tail of the packet,
+            // 'uninsert' the |obu| from the |packet|.
+            packet.num_obu_elements -= 1;
+            packet.packet_size -= previous_obu_extra_size;
+        } else {
+            packet.packet_size += first_fragment_size;
+            if must_write_obu_element_size {
+                packet.packet_size += leb128_size(first_fragment_size as u32);
+            }
+            packet.last_obu_size = first_fragment_size;
+        }
+        packets.push(packet);
+        // Add middle fragments that occupy all of the packet.
+        // These are easy because
+        // - one obu per packet imply no need to store the size of the obu.
+        // - this packets are nor the first nor the last packets of the frame, so
+        // packet capacity is always limits.max_payload_len.
+        let mut obu_offset = first_fragment_size;
+        while obu_offset + max_payload_size < obu.size {
+            let mut packet = Packet::new(obu_index);
+            packet.num_obu_elements = 1;
+            packet.first_obu_offset = obu_offset;
+            let middle_fragment_size = max_payload_size;
+            packet.last_obu_size = middle_fragment_size;
+            packet.packet_size = middle_fragment_size;
+            packets.push(packet);
+            obu_offset += max_payload_size;
+        }
+        // Add the last fragment of the obu.
+        let mut last_fragment_size = obu.size - obu_offset;
+        // Check for corner case where last fragment of the last obu is too large
+        // to fit into last packet, but may fully fit into semi-last packet.
+        if is_last_obu && last_fragment_size > max_payload_size {
+            // Split last fragments into two.
+            // Try to even packet sizes rather than payload sizes across the last
+            // two packets.
+            let mut semi_last_fragment_size = last_fragment_size / 2;
+            // But leave at least one payload byte for the last packet to avoid
+            // weird scenarios where size of the fragment is zero and rtp payload has
+            // nothing except for an aggregation header.
+            if semi_last_fragment_size >= last_fragment_size {
+                semi_last_fragment_size = last_fragment_size - 1;
+            }
+            last_fragment_size -= semi_last_fragment_size;
+            let mut packet = Packet::new(obu_index);
+            packet.first_obu_offset = obu_offset;
+            packet.last_obu_size = semi_last_fragment_size;
+            packet.packet_size = semi_last_fragment_size;
+            packets.push(packet);
+            obu_offset += semi_last_fragment_size
+        }
+        let mut last_packet = Packet::new(obu_index);
+        last_packet.num_obu_elements = 1;
+        last_packet.first_obu_offset = obu_offset;
+        last_packet.last_obu_size = last_fragment_size;
+        last_packet.packet_size = last_fragment_size;
+        packets.push(last_packet);
+        packet_remaining_bytes = max_payload_size - last_fragment_size;
+    }
+
+    packets
+}
+
+fn get_aggregation_header(obus: &Vec<Obu>, packets: &Vec<Packet>, packet_index: usize) -> u8 {
+    let packet = &packets[packet_index];
+    let mut header: u8 = 0;
+
+    // Set Z flag: first obu element is continuation of the previous OBU.
+    let first_obu_element_is_fragment = packet.first_obu_offset > 0;
+    if first_obu_element_is_fragment {
+        header |= 1 << 7;
+    }
+
+    // Set Y flag: last obu element will be continuated in the next packet.
+    let last_obu_offset = if packet.num_obu_elements == 1 {
+        packet.first_obu_offset
+    } else {
+        0
+    };
+    let last_obu_is_fragment = last_obu_offset + packet.last_obu_size
+        < obus[packet.first_obu_index + packet.num_obu_elements - 1].size;
+    if last_obu_is_fragment {
+        header |= 1 << 6;
+    }
+
+    // Set W field: number of obu elements in the packet (when not too large).
+    if packet.num_obu_elements <= MAX_NUM_OBUS_TO_OMIT_SIZE {
+        header |= (packet.num_obu_elements as u8) << 4;
+    }
+
+    // Set N flag: beginning of a new coded video sequence.
+    // Encoder may produce key frame without a sequence header, thus double check
+    // incoming frame includes the sequence header. Since Temporal delimiter is
+    // already filtered out, sequence header should be the first obu when present.
+    if packet_index == 0 && obu_type(obus.first().unwrap().header) == OBU_TYPE_SEQUENCE_HEADER {
+        header |= 1 << 3;
+    }
+    header
+}
+
 impl Payloader for Av1Payloader {
     fn payload(&mut self, mtu: usize, payload: &Bytes) -> crate::error::Result<Vec<Bytes>> {
-        let max_fragment_size = mtu - AV1_PAYLOADER_HEADER_SIZE;
-        let mut packets = vec![];
-        let mut payload_data_remaining = payload.len();
-        let mut payload_data_index = 0;
+        let obus = parse_obus(payload);
+        let packets = packetize(&obus, mtu);
+        let mut payloads = vec![];
+        for packet_index in 0..packets.len() {
+            let packet = &packets[packet_index];
+            let mut out = BytesMut::with_capacity(AGGREGATION_HEADER_SIZE + packet.packet_size);
+            let aggregation_header = get_aggregation_header(&obus, &packets, packet_index);
+            out.put_u8(aggregation_header);
+            let mut obu_offset = packet.first_obu_offset;
+            // Store all OBU elements except the last one.
+            for i in 0..packet.num_obu_elements - 1 {
+                let obu = &obus[packet.first_obu_index + i];
+                let fragment_size = obu.size - obu_offset;
+                let leb128_fragment_size = encode_leb128(fragment_size as u32);
+                let leb128_fragment_size_size = leb128_size(fragment_size as u32);
+                for i in 0..leb128_fragment_size_size {
+                    out.put_u8(
+                        (leb128_fragment_size >> ((leb128_fragment_size_size - 1 - i) * 8)) as u8,
+                    )
+                }
+                if obu_offset == 0 {
+                    out.put_u8(obu.header & !OBU_SIZE_PRESENT_BIT);
+                }
+                if obu_offset <= 1 && obu_has_extension(obu.header) {
+                    out.put_u8(obu.extension_header);
+                }
+                let payload_offset = {
+                    let headers_size = if obu_has_extension(obu.header) { 2 } else { 1 };
+                    if obu_offset <= headers_size {
+                        0
+                    } else {
+                        obu_offset - headers_size
+                    }
+                };
+                let payload_size = obu.payload.len() - payload_offset;
+                out.put_slice(
+                    obu.payload
+                        .slice(payload_offset..payload_offset + payload_size)
+                        .as_ref(),
+                );
+                // All obus are stored from the beginning, except, may be, the first one.
+                obu_offset = 0;
+            }
 
-        if min(max_fragment_size, payload_data_remaining) <= 0 {
-            return Ok(packets);
+            // Store the last OBU element.
+            let last_obu = &obus[packet.first_obu_index + packet.num_obu_elements - 1];
+            let mut fragment_size = packet.last_obu_size;
+            if packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE {
+                let leb128_fragment_size = encode_leb128(fragment_size as u32);
+                let leb128_fragment_size_size = leb128_size(fragment_size as u32);
+                for i in 0..leb128_fragment_size_size {
+                    out.put_u8(
+                        (leb128_fragment_size >> ((leb128_fragment_size_size - 1 - i) * 8)) as u8,
+                    )
+                }
+            }
+            if obu_offset == 0 && fragment_size > 0 {
+                out.put_u8(last_obu.header & !OBU_SIZE_PRESENT_BIT);
+                fragment_size -= 1;
+            }
+            if obu_offset <= 1 && obu_has_extension(last_obu.header) && fragment_size > 0 {
+                out.put_u8(last_obu.extension_header);
+                fragment_size -= 1;
+            }
+            let payload_offset = {
+                let headers_size = if obu_has_extension(last_obu.header) {
+                    2
+                } else {
+                    1
+                };
+                if obu_offset <= headers_size {
+                    0
+                } else {
+                    obu_offset - headers_size
+                }
+            };
+            out.put_slice(
+                last_obu
+                    .payload
+                    .slice(payload_offset..payload_offset + fragment_size)
+                    .as_ref(),
+            );
+            payloads.push(out.freeze());
         }
-
-        while payload_data_remaining > 0 {
-            let current_fragment_size = min(max_fragment_size, payload_data_remaining);
-            let leb128_size = if current_fragment_size >= 127 { 2 } else { 1 };
-
-            let mut packet = vec![0; AV1_PAYLOADER_HEADER_SIZE + leb128_size + current_fragment_size];
-            let leb128_value = encode_leb128(current_fragment_size as u32);
-            if leb128_size == 1 {
-                packet[1] = leb128_value as u8;
-            } else {
-                packet[1] = (leb128_value >> 8) as u8;
-                packet[2] = leb128_value as u8;
-            }
-            packet[AV1_PAYLOADER_HEADER_SIZE + leb128_size..]
-                .copy_from_slice(&payload[payload_data_index..payload_data_index + current_fragment_size]);
-
-            payload_data_remaining -= current_fragment_size;
-            payload_data_index += current_fragment_size;
-
-            if packets.len() == 0 {
-                // Set the N bit to 1 for the first packet
-                packet[0] |= 0b00001000;
-            }
-            if packets.len() > 0 {
-                // Set the Z bit to 0 for all but the first packet
-                packet[0] |= 0b10000000;
-            }
-            if payload_data_remaining != 0 {
-                // Set the Y bit to 1 for all but the last packet
-                packet[0] |= 0b01000000;
-            }
-
-            packets.push(Bytes::from(packet));
-        }
-
-        Ok(packets)
+        Ok(payloads)
     }
 
     fn clone_to(&self) -> Box<dyn Payloader + Send + Sync> {

--- a/rtp/src/codecs/av1/obu.rs
+++ b/rtp/src/codecs/av1/obu.rs
@@ -13,9 +13,14 @@ pub const OBU_TYPE_MASK: u8 = 0b0_1111_000;
 
 pub const OBU_TYPE_SEQUENCE_HEADER: u8 = 1;
 pub const OBU_TYPE_TEMPORAL_DELIMITER: u8 = 2;
-pub const OBU_TYPE_TILE_LIST: u8 = 3;
+pub const OBU_TYPE_FRAME_HEADER: u8 = 3;
+pub const OBU_TYPE_TILE_GROUP: u8 = 4;
+pub const OBU_TYPE_METADATA: u8 = 5;
+pub const OBU_TYPE_FRAME: u8 = 6;
+pub const OBU_TYPE_TILE_LIST: u8 = 8;
 pub const OBU_TYPE_PADDING: u8 = 15;
 
+#[derive(Debug, Clone)]
 pub struct Obu {
     pub header: u8,
     pub extension_header: u8,

--- a/rtp/src/codecs/av1/obu.rs
+++ b/rtp/src/codecs/av1/obu.rs
@@ -1,0 +1,104 @@
+use bytes::Bytes;
+
+use crate::codecs::av1::leb128::read_leb128;
+use crate::error::Result;
+use crate::Error::{ErrPayloadTooSmallForObuExtensionHeader, ErrPayloadTooSmallForObuPayloadSize};
+
+pub const OBU_HAS_EXTENSION_BIT: u8 = 0b0_0000_100;
+pub const OBU_HAS_SIZE_BIT: u8 = 0b0_0000_010;
+pub const OBU_TYPE_MASK: u8 = 0b0_1111_000;
+
+pub const OBU_TYPE_SEQUENCE_HEADER: u8 = 1;
+pub const OBU_TYPE_TEMPORAL_DELIMITER: u8 = 2;
+pub const OBU_TYPE_TILE_LIST: u8 = 3;
+pub const OBU_TYPE_PADDING: u8 = 15;
+
+pub struct Obu {
+    pub header: u8,
+    pub extension_header: u8,
+    pub payload: Bytes,
+    pub size: usize,
+}
+
+impl Obu {
+    pub fn header_size(&self) -> usize {
+        if obu_has_extension(self.header) {
+            2
+        } else {
+            1
+        }
+    }
+}
+
+/// Parses the raw payload into a list of OBU elements.
+pub fn parse_obus(payload: &Bytes) -> Result<Vec<Obu>> {
+    let mut obus = vec![];
+    let mut payload_data_remaining = payload.len() as isize;
+    let mut payload_data_index: usize = 0;
+
+    while payload_data_remaining > 0 {
+        // Read OBU header.
+        let header = payload[payload_data_index];
+        let has_extension = obu_has_extension(header);
+        let has_size = obu_has_size(header);
+        let obu_type = obu_type(header);
+
+        // Read OBU extension header.
+        let extension_header = if has_extension {
+            if payload_data_remaining < 2 {
+                return Err(ErrPayloadTooSmallForObuExtensionHeader);
+            }
+            payload[payload_data_index + 1]
+        } else {
+            0
+        };
+        let obu_header_size = if has_extension { 2 } else { 1 };
+        let payload_without_header = payload.slice(payload_data_index + obu_header_size..);
+
+        // Read OBU payload.
+        let obu_payload = if !has_size {
+            payload_without_header
+        } else {
+            if payload_without_header.is_empty() {
+                return Err(ErrPayloadTooSmallForObuPayloadSize);
+            }
+            let (obu_payload_size, leb128_size) = read_leb128(&payload_without_header);
+            payload_data_remaining -= leb128_size as isize;
+            payload_data_index += leb128_size;
+            payload_without_header.slice(leb128_size..leb128_size + obu_payload_size as usize)
+        };
+
+        let obu_size = obu_header_size + obu_payload.len();
+        if !should_ignore_obu_type(obu_type) {
+            obus.push(Obu {
+                header,
+                extension_header,
+                payload: obu_payload,
+                size: obu_size,
+            });
+        }
+
+        payload_data_remaining -= obu_size as isize;
+        payload_data_index += obu_size;
+    }
+
+    Ok(obus)
+}
+
+pub fn obu_has_extension(header: u8) -> bool {
+    header & OBU_HAS_EXTENSION_BIT != 0
+}
+
+pub fn obu_has_size(header: u8) -> bool {
+    header & OBU_HAS_SIZE_BIT != 0
+}
+
+pub fn obu_type(header: u8) -> u8 {
+    (header & OBU_TYPE_MASK) >> 3
+}
+
+fn should_ignore_obu_type(obu_type: u8) -> bool {
+    obu_type == OBU_TYPE_TEMPORAL_DELIMITER
+        || obu_type == OBU_TYPE_TILE_LIST
+        || obu_type == OBU_TYPE_PADDING
+}

--- a/rtp/src/codecs/av1/obu.rs
+++ b/rtp/src/codecs/av1/obu.rs
@@ -1,4 +1,6 @@
-/// Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
+//! Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
+//! Reference: https://aomediacodec.github.io/av1-spec/#obu-syntax
+
 use bytes::Bytes;
 
 use crate::codecs::av1::leb128::read_leb128;
@@ -18,6 +20,7 @@ pub struct Obu {
     pub header: u8,
     pub extension_header: u8,
     pub payload: Bytes,
+    /// size of the header and payload combined.
     pub size: usize,
 }
 
@@ -31,7 +34,8 @@ impl Obu {
     }
 }
 
-/// Parses the raw payload into a list of OBU elements.
+/// Parses the payload into series of OBUs.
+/// Reference: https://aomediacodec.github.io/av1-spec/#obu-syntax
 pub fn parse_obus(payload: &Bytes) -> Result<Vec<Obu>> {
     let mut obus = vec![];
     let mut payload_data_remaining = payload.len() as isize;

--- a/rtp/src/codecs/av1/obu.rs
+++ b/rtp/src/codecs/av1/obu.rs
@@ -7,9 +7,9 @@ use crate::codecs::av1::leb128::read_leb128;
 use crate::error::Result;
 use crate::Error::{ErrPayloadTooSmallForObuExtensionHeader, ErrPayloadTooSmallForObuPayloadSize};
 
-pub const OBU_HAS_EXTENSION_BIT: u8 = 0b0_0000_100;
-pub const OBU_HAS_SIZE_BIT: u8 = 0b0_0000_010;
-pub const OBU_TYPE_MASK: u8 = 0b0_1111_000;
+pub const OBU_HAS_EXTENSION_BIT: u8 = 0b0000_0100;
+pub const OBU_HAS_SIZE_BIT: u8 = 0b0000_0010;
+pub const OBU_TYPE_MASK: u8 = 0b0111_1000;
 
 pub const OBU_TYPE_SEQUENCE_HEADER: u8 = 1;
 pub const OBU_TYPE_TEMPORAL_DELIMITER: u8 = 2;

--- a/rtp/src/codecs/av1/obu.rs
+++ b/rtp/src/codecs/av1/obu.rs
@@ -1,3 +1,4 @@
+/// Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
 use bytes::Bytes;
 
 use crate::codecs::av1::leb128::read_leb128;

--- a/rtp/src/codecs/av1/packetizer.rs
+++ b/rtp/src/codecs/av1/packetizer.rs
@@ -1,3 +1,4 @@
+/// Based on https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc
 use std::cmp::min;
 
 use crate::codecs::av1::leb128::leb128_size;

--- a/rtp/src/codecs/av1/packetizer.rs
+++ b/rtp/src/codecs/av1/packetizer.rs
@@ -1,0 +1,238 @@
+use std::cmp::min;
+
+use crate::codecs::av1::leb128::leb128_size;
+use crate::codecs::av1::obu::{obu_type, Obu, OBU_TYPE_SEQUENCE_HEADER};
+
+// When there are 3 or less OBU (fragments) in a packet, size of the last one
+// can be omitted.
+pub const MAX_NUM_OBUS_TO_OMIT_SIZE: usize = 3;
+pub const AGGREGATION_HEADER_SIZE: usize = 1;
+
+pub struct PacketMetadata {
+    pub first_obu_index: usize,
+    pub num_obu_elements: usize,
+    pub first_obu_offset: usize,
+    pub last_obu_size: usize,
+    pub packet_size: usize,
+}
+
+impl PacketMetadata {
+    fn new(first_obu_index: usize) -> Self {
+        Self {
+            first_obu_index,
+            num_obu_elements: 0,
+            first_obu_offset: 0,
+            last_obu_size: 0,
+            packet_size: 0,
+        }
+    }
+}
+
+/// Returns the instructions for how to packetize the OBU elements into RTP packets.
+pub fn packetize(obus: &Vec<Obu>, mtu: usize) -> Vec<PacketMetadata> {
+    if obus.is_empty() {
+        return vec![];
+    }
+    // Ignore certain edge cases where packets should be very small. They are
+    // impractical but adds complexity to handle.
+    if mtu < 3 {
+        return vec![];
+    }
+
+    let mut packets = vec![];
+
+    // Aggregation header will be present in all packets.
+    let max_payload_size = mtu - AGGREGATION_HEADER_SIZE;
+
+    // Assemble packets. Push to current packet as much as it can hold before
+    // considering next one. That would normally cause uneven distribution across
+    // packets, specifically last one would be generally smaller.
+    packets.push(PacketMetadata::new(0));
+    let mut packet_remaining_bytes = max_payload_size;
+
+    for obu_index in 0..obus.len() {
+        let is_last_obu = obu_index == obus.len() - 1;
+        let obu = &obus[obu_index];
+
+        // Putting |obu| into the last packet would make last obu element stored in
+        // that packet not last. All not last OBU elements must be prepend with the
+        // element length. AdditionalBytesForPreviousObuElement calculates how many
+        // bytes are needed to store that length.
+        let mut packet = packets.pop().unwrap();
+        let mut previous_obu_extra_size = additional_bytes_for_previous_obu_element(&packet);
+        let min_required_size = if packet.num_obu_elements >= MAX_NUM_OBUS_TO_OMIT_SIZE {
+            2
+        } else {
+            1
+        };
+        if packet_remaining_bytes < previous_obu_extra_size + min_required_size {
+            // Start a new packet.
+            packets.push(packet);
+            packet = PacketMetadata::new(obu_index);
+            packet_remaining_bytes = max_payload_size;
+            previous_obu_extra_size = 0;
+        }
+        packet.packet_size += previous_obu_extra_size;
+        packet_remaining_bytes -= previous_obu_extra_size;
+        packet.num_obu_elements += 1;
+        let must_write_obu_element_size = packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE;
+
+        // Can fit all of the obu into the packet?
+        let mut required_bytes = obu.size;
+        if must_write_obu_element_size {
+            required_bytes += leb128_size(obu.size as u32);
+        }
+        if required_bytes < packet_remaining_bytes {
+            // Insert the obu into the packet unfragmented.
+            packet.last_obu_size = obu.size;
+            packet.packet_size += required_bytes;
+            packet_remaining_bytes -= required_bytes;
+            packets.push(packet);
+            continue;
+        }
+
+        // Fragment the obu.
+        let max_first_fragment_size = if must_write_obu_element_size {
+            max_fragment_size(packet_remaining_bytes)
+        } else {
+            packet_remaining_bytes
+        };
+        // Because available_bytes might be different than
+        // packet_remaining_bytes it might happen that max_first_fragment_size >=
+        // obu.size. Also, since checks above verified |obu| should not be put
+        // completely into the |packet|, leave at least 1 byte for later packet.
+        let first_fragment_size = min(obu.size - 1, max_first_fragment_size);
+        if first_fragment_size == 0 {
+            // Rather than writing 0-size element at the tail of the packet,
+            // 'uninsert' the |obu| from the |packet|.
+            packet.num_obu_elements -= 1;
+            packet.packet_size -= previous_obu_extra_size;
+        } else {
+            packet.packet_size += first_fragment_size;
+            if must_write_obu_element_size {
+                packet.packet_size += leb128_size(first_fragment_size as u32);
+            }
+            packet.last_obu_size = first_fragment_size;
+        }
+        packets.push(packet);
+
+        // Add middle fragments that occupy all of the packet.
+        // These are easy because
+        // - one obu per packet imply no need to store the size of the obu.
+        // - this packets are nor the first nor the last packets of the frame, so
+        // packet capacity is always limits.max_payload_len.
+        let mut obu_offset = first_fragment_size;
+        while obu_offset + max_payload_size < obu.size {
+            let mut packet = PacketMetadata::new(obu_index);
+            packet.num_obu_elements = 1;
+            packet.first_obu_offset = obu_offset;
+            let middle_fragment_size = max_payload_size;
+            packet.last_obu_size = middle_fragment_size;
+            packet.packet_size = middle_fragment_size;
+            packets.push(packet);
+            obu_offset += max_payload_size;
+        }
+
+        // Add the last fragment of the obu.
+        let mut last_fragment_size = obu.size - obu_offset;
+        // Check for corner case where last fragment of the last obu is too large
+        // to fit into last packet, but may fully fit into semi-last packet.
+        if is_last_obu && last_fragment_size > max_payload_size {
+            // Split last fragments into two.
+            // Try to even packet sizes rather than payload sizes across the last
+            // two packets.
+            let mut semi_last_fragment_size = last_fragment_size / 2;
+            // But leave at least one payload byte for the last packet to avoid
+            // weird scenarios where size of the fragment is zero and rtp payload has
+            // nothing except for an aggregation header.
+            if semi_last_fragment_size >= last_fragment_size {
+                semi_last_fragment_size = last_fragment_size - 1;
+            }
+            last_fragment_size -= semi_last_fragment_size;
+            let mut packet = PacketMetadata::new(obu_index);
+            packet.first_obu_offset = obu_offset;
+            packet.last_obu_size = semi_last_fragment_size;
+            packet.packet_size = semi_last_fragment_size;
+            packets.push(packet);
+            obu_offset += semi_last_fragment_size
+        }
+        let mut last_packet = PacketMetadata::new(obu_index);
+        last_packet.num_obu_elements = 1;
+        last_packet.first_obu_offset = obu_offset;
+        last_packet.last_obu_size = last_fragment_size;
+        last_packet.packet_size = last_fragment_size;
+        packets.push(last_packet);
+        packet_remaining_bytes = max_payload_size - last_fragment_size;
+    }
+
+    packets
+}
+
+pub fn get_aggregation_header(
+    obus: &Vec<Obu>,
+    packets: &Vec<PacketMetadata>,
+    packet_index: usize,
+) -> u8 {
+    let packet = &packets[packet_index];
+    let mut header: u8 = 0;
+
+    // Set Z flag: first obu element is continuation of the previous OBU.
+    let first_obu_element_is_fragment = packet.first_obu_offset > 0;
+    if first_obu_element_is_fragment {
+        header |= 1 << 7;
+    }
+
+    // Set Y flag: last obu element will be continuated in the next packet.
+    let last_obu_offset = if packet.num_obu_elements == 1 {
+        packet.first_obu_offset
+    } else {
+        0
+    };
+    let last_obu_is_fragment = last_obu_offset + packet.last_obu_size
+        < obus[packet.first_obu_index + packet.num_obu_elements - 1].size;
+    if last_obu_is_fragment {
+        header |= 1 << 6;
+    }
+
+    // Set W field: number of obu elements in the packet (when not too large).
+    if packet.num_obu_elements <= MAX_NUM_OBUS_TO_OMIT_SIZE {
+        header |= (packet.num_obu_elements as u8) << 4;
+    }
+
+    // Set N flag: beginning of a new coded video sequence.
+    // Encoder may produce key frame without a sequence header, thus double check
+    // incoming frame includes the sequence header. Since Temporal delimiter is
+    // already filtered out, sequence header should be the first obu when present.
+    if packet_index == 0 && obu_type(obus.first().unwrap().header) == OBU_TYPE_SEQUENCE_HEADER {
+        header |= 1 << 3;
+    }
+    header
+}
+
+fn additional_bytes_for_previous_obu_element(packet: &PacketMetadata) -> usize {
+    if packet.packet_size == 0 {
+        // Packet is still empty => no last OBU element, no need to reserve space
+        // for it.
+        0
+    } else if packet.num_obu_elements > MAX_NUM_OBUS_TO_OMIT_SIZE {
+        // There are so many obu elements in the packet, all of them must be
+        // prepended with the length field. That imply space for the length of the
+        // last obu element is already reserved.
+        0
+    } else {
+        leb128_size(packet.last_obu_size as u32)
+    }
+}
+
+fn max_fragment_size(remaining_bytes: usize) -> usize {
+    if remaining_bytes <= 1 {
+        return 0;
+    }
+    let mut i = 1;
+    loop {
+        if remaining_bytes < (1 << 7 * i) + i {
+            return remaining_bytes - i;
+        }
+        i += 1;
+    }
+}

--- a/rtp/src/codecs/mod.rs
+++ b/rtp/src/codecs/mod.rs
@@ -1,7 +1,7 @@
+pub mod av1;
 pub mod g7xx;
 pub mod h264;
 pub mod h265;
 pub mod opus;
 pub mod vp8;
 pub mod vp9;
-pub mod av1;

--- a/rtp/src/codecs/mod.rs
+++ b/rtp/src/codecs/mod.rs
@@ -4,3 +4,4 @@ pub mod h265;
 pub mod opus;
 pub mod vp8;
 pub mod vp9;
+pub mod av1;

--- a/rtp/src/error.rs
+++ b/rtp/src/error.rs
@@ -45,6 +45,11 @@ pub enum Error {
     #[error("invalid h265 packet type")]
     ErrInvalidH265PacketType,
 
+    #[error("payload is too small for OBU extension header")]
+    ErrPayloadTooSmallForObuExtensionHeader,
+    #[error("payload is too small for OBU payload size")]
+    ErrPayloadTooSmallForObuPayloadSize,
+
     #[error("extension_payload must be in 32-bit words")]
     HeaderExtensionPayloadNot32BitWords,
     #[error("audio level overflow")]

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -274,9 +274,20 @@ impl MediaEngine {
                     sdp_fmtp_line:
                         "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032"
                             .to_owned(),
-                    rtcp_feedback: video_rtcp_feedback,
+                    rtcp_feedback: video_rtcp_feedback.clone(),
                 },
                 payload_type: 123,
+                ..Default::default()
+            },
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_AV1.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line: "profile-id=0".to_owned(),
+                    rtcp_feedback: video_rtcp_feedback,
+                },
+                payload_type: 41,
                 ..Default::default()
             },
             RTCRtpCodecParameters {

--- a/webrtc/src/rtp_transceiver/rtp_codec.rs
+++ b/webrtc/src/rtp_transceiver/rtp_codec.rs
@@ -80,6 +80,8 @@ impl RTCRtpCodecCapability {
             || mime_type == MIME_TYPE_TELEPHONE_EVENT.to_lowercase()
         {
             Ok(Box::<rtp::codecs::g7xx::G7xxPayloader>::default())
+        } else if mime_type == MIME_TYPE_AV1.to_lowercase() {
+            Ok(Box::<rtp::codecs::av1::Av1Payloader>::default())
         } else {
             Err(Error::ErrNoPayloaderForCodec)
         }


### PR DESCRIPTION
## What

Addresses https://github.com/webrtc-rs/webrtc/issues/193.

This PR implements the payloader for AV1, based on Chromium's implementation in C++: https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc, which supports packetizing payloads containing multiple OBUs.

Other references used are: 
- https://aomediacodec.github.io/av1-rtp-spec/#4-payload-format
- https://aomediacodec.github.io/av1-spec

## Testing
- Relevant unit tests were ported over.
- Tested as being used in my own project (https://github.com/mira-screen-share/sharer/), which streams screen capture video encoded by FFMPEG `libsvtav1` and `libaom-av1` encoders. The video stream can be decoded by Chrome with no apparent issues.

## Caveats
1. In the current implementation, the setting of N-bit in the RTP AV1 aggregation header is technically incorrect, since:
	- According to the [AV1 RTP spec](https://aomediacodec.github.io/av1-rtp-spec/#44-av1-aggregation-header): 
		> N: MUST be set to 1 if the packet is the first packet of a coded video sequence, and MUST be set to 0 otherwise.
	- And, according to the [AV1 spec]():
		> A new coded video sequence is defined to start at each temporal unit which satisfies both of the following conditions:
	    > - A sequence header OBU appears before the first frame header.
	    > - The first frame header has frame_type equal to KEY_FRAME, show_frame equal
	    >    to 1, show_existing_frame equal to 0, and temporal_id equal to 0.
	- In [Chromium's implementation](https://chromium.googlesource.com/external/webrtc/+/4e513346ec56c829b3a6010664998469fc237b35/modules/rtp_rtcp/source/rtp_packetizer_av1.cc#345), setting of the N-bit is guarded by
		```cpp
	    frame_type_ == VideoFrameType::kVideoFrameKey 
		   && packet_index_ == 0 
		   && ObuType(obus_.front().header) == kObuTypeSequenceHeader
		```
		which checks that the frame is a key frame (as opposed to an empty or delta frame), in conjunction to the first OBU in the temporal unit being a Sequence Header.
	- However, the frame type is not directly available to us, so we simply assume that all temporal units starting with a Sequence Header OBU is a key frame. i.e. setting the N-bit whenever
	    ```rust
	    packet_index == 0 && obu_type(obus.first().unwrap().header) == OBU_TYPE_SEQUENCE_HEADER
	    ```
    This will cause delta frames that start with a (redundant, but permitted) Sequence Header OBU to be treated as a key frame. Thus if the encoder does produce such delta frames, they will be marked as key frames incorrectly.
    To fix this, we will need a way to distinguish delta frames from key frames, perhaps by parsing the Frame Header OBUs and extracting the `frame_type`, as specified in the [AV1 spec](https://aomediacodec.github.io/av1-spec/#uncompressed-header-syntax).
2. The current implementation assumes that the `payload` passed to `Payloader::payload` contains only OBUs that all belong to the same temporal unit, as does the Chromium implementation. This might not necessarily be true depending on how the library is used downstream (e.g. payloading 2 frames at the same time, for whatever reason).