### PR TITLE
Fix `set_extension`

### DIFF
--- a/rtp/src/header.rs
+++ b/rtp/src/header.rs
@@ -390,8 +390,14 @@ impl Header {
             self.extension = true;
             let mut extension_profile_len = 0;
             self.extension_profile = match payload.len() {
-                0..=16 => { extension_profile_len = 1 ; EXTENSION_PROFILE_ONE_BYTE},
-                17..=255 => { extension_profile_len = 2; EXTENSION_PROFILE_TWO_BYTE},
+                0..=16 => {
+                    extension_profile_len = 1;
+                    EXTENSION_PROFILE_ONE_BYTE
+                }
+                17..=255 => {
+                    extension_profile_len = 2;
+                    EXTENSION_PROFILE_TWO_BYTE
+                }
                 _ => self.extension_profile,
             };
 


### PR DESCRIPTION
after #454 i started getting
Error "marshal_to output size {n}, but expect {l}"
this was due to a change in packet header size calculation in #454

This PR fixes the behavior of `set_extension`.