### PR TITLE
fix linux ipv6 handling

### DIFF
--- a/util/src/ifaces/ffi/unix/mod.rs
+++ b/util/src/ifaces/ffi/unix/mod.rs
@@ -100,33 +100,13 @@ pub fn nix_socketaddr_to_sockaddr(sa: *mut nix::sys::socket::sockaddr) -> Option
             let sa: *const nix::sys::socket::sockaddr_in = sa as *const nix::libc::sockaddr_in;
             let sa = &unsafe { *sa };
             let (addr, port) = (sa.sin_addr.s_addr, sa.sin_port);
-            (
-                IpAddr::V4(net::Ipv4Addr::new(
-                    (addr & 0x000000FF) as u8,
-                    ((addr & 0x0000FF00) >> 8) as u8,
-                    ((addr & 0x00FF0000) >> 16) as u8,
-                    ((addr & 0xFF000000) >> 24) as u8,
-                )),
-                port,
-            )
+            (IpAddr::V4(Into::into(u32::from_be(addr))), port)
         }
         AF_INET6 => {
             let sa: *const nix::sys::socket::sockaddr_in6 = sa as *const nix::libc::sockaddr_in6;
             let sa = &unsafe { *sa };
             let (addr, port) = (sa.sin6_addr.s6_addr, sa.sin6_port);
-            (
-                IpAddr::V6(net::Ipv6Addr::new(
-                    addr[0] as u16,
-                    addr[1] as u16,
-                    addr[2] as u16,
-                    addr[3] as u16,
-                    addr[4] as u16,
-                    addr[5] as u16,
-                    addr[6] as u16,
-                    addr[7] as u16,
-                )),
-                port,
-            )
+            (Into::into(addr), port)
         }
         _ => return None,
     };

--- a/util/src/vnet/interface.rs
+++ b/util/src/vnet/interface.rs
@@ -28,35 +28,11 @@ impl Interface {
     }
 
     pub fn convert(addr: SocketAddr, mask: Option<SocketAddr>) -> Result<IpNet> {
-        let prefix = if let Some(mask) = mask {
-            match (addr, mask) {
-                (SocketAddr::V4(_), SocketAddr::V4(mask)) => {
-                    let octets = mask.ip().octets();
-                    let mut prefix = 0;
-                    for octet in &octets {
-                        for i in 0..8 {
-                            prefix += (*octet >> (7 - i)) & 0x1;
-                        }
-                    }
-                    prefix
-                }
-                (SocketAddr::V6(_), SocketAddr::V6(mask)) => {
-                    let octets = mask.ip().octets();
-                    let mut prefix = 0;
-                    for octet in &octets {
-                        for i in 0..8 {
-                            prefix += (*octet >> (7 - i)) & 0x1;
-                        }
-                    }
-                    prefix
-                }
-                _ => return Err(Error::ErrInvalidMask),
-            }
+        if let Some(mask) = mask {
+            Ok(IpNet::with_netmask(addr.ip(), mask.ip()).map_err(|_| Error::ErrInvalidMask)?)
         } else {
-            32
-        };
-        let s = format!("{}/{}", addr.ip(), prefix);
-
-        Ok(IpNet::from_str(&s)?)
+            Ok(IpNet::new(addr.ip(), if addr.is_ipv4() { 32 } else { 128 })
+                .expect("ipv4 should always work with prefix 32 and ipv6 with prefix 128"))
+        }
     }
 }

--- a/util/src/vnet/interface.rs
+++ b/util/src/vnet/interface.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::str::FromStr;
 
 use ipnet::*;
 


### PR DESCRIPTION
Hi!

In Linux, the last 8 octets from Ipv6 were being discarded when gathering local interfaces, making Ipv6 bindings fail.

This PR further simplifies Ip parsing.

(Relates to #473 )