### PR TITLE
Improve error types in `webrtc-constraints`, using `thiserror`

### DIFF
--- a/constraints/Cargo.toml
+++ b/constraints/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.63.0"
 indexmap = "1.9.1"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 ordered-float = { version = "3.0.0", default-features = false }
+thiserror = "1.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/constraints/src/algorithms/select_settings.rs
+++ b/constraints/src/algorithms/select_settings.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use thiserror::Error;
+
 use crate::algorithms::fitness_distance::SettingFitnessDistanceError;
 use crate::errors::OverconstrainedError;
 use crate::{MediaTrackSettings, SanitizedMediaTrackConstraints};
@@ -24,16 +26,11 @@ pub enum DeviceInformationExposureMode {
 }
 
 /// An error type indicating a failure of the `SelectSettings` algorithm.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum SelectSettingsError {
     /// An error caused by one or more over-constrained settings.
-    Overconstrained(OverconstrainedError),
-}
-
-impl From<OverconstrainedError> for SelectSettingsError {
-    fn from(error: OverconstrainedError) -> Self {
-        Self::Overconstrained(error)
-    }
+    #[error(transparent)]
+    Overconstrained(#[from] OverconstrainedError),
 }
 
 /// This function implements steps 1-5 of the `SelectSettings` algorithm

--- a/constraints/src/errors.rs
+++ b/constraints/src/errors.rs
@@ -4,11 +4,13 @@
 
 use std::collections::HashMap;
 
+use thiserror::Error;
+
 use crate::algorithms::{ConstraintFailureInfo, SettingFitnessDistanceErrorKind};
 use crate::MediaTrackProperty;
 
 /// An error indicating one or more over-constrained settings.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub struct OverconstrainedError {
     /// The offending constraint's name.
     pub constraint: MediaTrackProperty,
@@ -27,15 +29,13 @@ impl Default for OverconstrainedError {
 
 impl std::fmt::Display for OverconstrainedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Overconstrained property {:?}", self.constraint)?;
+        write!(f, "Over-constrained property {:?}", self.constraint)?;
         if let Some(message) = self.message.as_ref() {
             write!(f, ": {message}")?;
         }
         Ok(())
     }
 }
-
-impl std::error::Error for OverconstrainedError {}
 
 impl OverconstrainedError {
     pub(super) fn exposing_device_information(


### PR DESCRIPTION
The `SelectSettingsError` type was missing an impl for `std::error::Error`. While at it I migrated to using `thiserror`, like the rest of the workspace.