### PR TITLE
mdns: Skip rest of mdns questions when parsing packet

### DIFF
--- a/mdns/src/conn/mod.rs
+++ b/mdns/src/conn/mod.rs
@@ -351,6 +351,9 @@ async fn run(
         }
     }
 
+    // There might be more than MAX_MESSAGE_RECORDS questions, so skip the rest
+    let _ = p.skip_all_questions();
+
     for _ in 0..=MAX_MESSAGE_RECORDS {
         let a = match p.answer_header() {
             Ok(a) => a,


### PR DESCRIPTION
This fixes the annoying warning when receiving a mdns packet with more than 3 questions

[2023-11-09T12:04:04Z WARN  webrtc_mdns::conn] Failed to parse mDNS packet parsing/packing of this type isn't available yet [2023-11-09T12:04:08Z WARN  webrtc_mdns::conn] Failed to parse mDNS packet parsing/packing of this type isn't available yet [2023-11-09T12:04:17Z WARN  webrtc_mdns::conn] Failed to parse mDNS packet parsing/packing of this type isn't available yet