### PR TITLE
Fix mDNS INBOUND_BUFFER_SIZE. Fixes Windows misbehaving.

### DIFF
--- a/mdns/src/conn/mod.rs
+++ b/mdns/src/conn/mod.rs
@@ -22,7 +22,7 @@ mod conn_test;
 
 pub const DEFAULT_DEST_ADDR: &str = "224.0.0.251:5353";
 
-const INBOUND_BUFFER_SIZE: usize = 512;
+const INBOUND_BUFFER_SIZE: usize = 65535;
 const DEFAULT_QUERY_INTERVAL: Duration = Duration::from_secs(1);
 const MAX_MESSAGE_RECORDS: usize = 3;
 const RESPONSE_TTL: u32 = 120;


### PR DESCRIPTION
Currently, the `INBOUND_BUFFER_SIZE` is 512 bytes, which means that the data gets truncated in the `recv_from` call in `start` when the incoming payload is larger (happens a lot in our office network, for example).

The problem is that this happens silently on Unix systems and everything works OK (well, the messages are truncated, but still). Unfortunately on Windows `socket.recv_from` actually returns an error in this case - `WSAEMSGSIZE (10040)` and mDNS starts logging errors and doesn't behave the same.

This is currently blocking us using using WebRTC via this crate on Windows.

For more info, see:
https://docs.rs/mio/latest/mio/net/struct.UdpSocket.html#method.recv_from as excerpted here:
![image](https://github.com/webrtc-rs/webrtc/assets/8321194/2d84781b-859e-468b-9ff8-7e99a09e57b9)

The UDP buffer can be up to 64k so this PR bumps it to the maximum size to avoid this difference in behavoir. Realistically, it'll almost never be above 1500 unless using jumbo frames or some other exotic network setup, but better safe than sorry.

The alternative would be to check the error message for `WSAEMSGSIZE` and treat it as success to behave like Unix, but unfortunately once an Error is returned from `socket.recv_from` we can't get the length and address that `Ok` contains.
