### PR TITLE
Implement pion commit 2184 - mux: drop packets when buffer is full

### DIFF
--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -1991,22 +1991,18 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
     let done_ch_tx0 = Arc::clone(&done_ch_tx);
     tokio::spawn(async move {
         let mut buf = vec![0u8; 32];
-        loop {
-            log::debug!("s.read_sctp begin");
-            match s0.read_sctp(&mut buf).await {
-                Ok((0, PayloadProtocolIdentifier::Unknown)) => {
-                    log::debug!("s0.read_sctp EOF");
-                    let _ = done_ch_tx0.send(Some(Error::ErrEof)).await;
-                    break;
-                }
-                Ok(_) => {
-                    panic!("must be error");
-                }
-                Err(err) => {
-                    log::debug!("s0.read_sctp err {:?}", err);
-                    let _ = done_ch_tx0.send(Some(err)).await;
-                    break;
-                }
+        log::debug!("s.read_sctp begin");
+        match s0.read_sctp(&mut buf).await {
+            Ok((0, PayloadProtocolIdentifier::Unknown)) => {
+                log::debug!("s0.read_sctp EOF");
+                let _ = done_ch_tx0.send(Some(Error::ErrEof)).await;
+            }
+            Ok(_) => {
+                panic!("must be error");
+            }
+            Err(err) => {
+                log::debug!("s0.read_sctp err {:?}", err);
+                let _ = done_ch_tx0.send(Some(err)).await;
             }
         }
     });

--- a/webrtc/src/mux/mod.rs
+++ b/webrtc/src/mux/mod.rs
@@ -134,10 +134,11 @@ impl Mux {
         }
 
         if let Some(ep) = endpoint {
-            match ep.buffer.write(buf).await
-            {
+            match ep.buffer.write(buf).await {
                 // Expected when bytes are received faster than the endpoint can process them
-                Err(Error::ErrBufferFull) => log::info!("mux: endpoint buffer is full, dropping packet"),
+                Err(Error::ErrBufferFull) => {
+                    log::info!("mux: endpoint buffer is full, dropping packet")
+                }
                 Ok(_) => (),
                 Err(e) => return Err(crate::Error::Util(e)),
             }

--- a/webrtc/src/mux/mux_test.rs
+++ b/webrtc/src/mux/mux_test.rs
@@ -6,25 +6,9 @@ use async_trait::async_trait;
 use util::conn::conn_pipe::pipe;
 
 use super::*;
-use crate::mux::mux_func::match_all;
+use crate::mux::mux_func::{match_all, match_srtp};
 
 const TEST_PIPE_BUFFER_SIZE: usize = 8192;
-
-async fn pipe_memory() -> (Arc<Endpoint>, impl Conn) {
-    // In memory pipe
-    let (ca, cb) = pipe();
-
-    let mut m = Mux::new(Config {
-        conn: Arc::new(ca),
-        buffer_size: TEST_PIPE_BUFFER_SIZE,
-    });
-
-    let e = m.new_endpoint(Box::new(match_all)).await;
-    m.remove_endpoint(&e).await;
-    let e = m.new_endpoint(Box::new(match_all)).await;
-
-    (e, cb)
-}
 
 #[tokio::test]
 async fn test_no_endpoints() -> crate::error::Result<()> {
@@ -124,6 +108,28 @@ async fn test_non_fatal_read() -> Result<()> {
 
     let n = e.recv(&mut buff).await?;
     assert_eq!(&buff[..n], expected_data);
+
+    m.close().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_non_fatal_dispatch() -> Result<()> {
+    let (ca, cb) = pipe();
+
+    let mut m = Mux::new(Config {
+        conn: Arc::new(ca),
+        buffer_size: TEST_PIPE_BUFFER_SIZE,
+    });
+
+    let e = m.new_endpoint(Box::new(match_srtp)).await;
+    e.buffer.set_limit_size(1).await;
+
+    for _ in 0..25 {
+        let srtp_packet = [128, 1, 2, 3, 4].to_vec();
+        cb.send(&srtp_packet).await?;
+    }
 
     m.close().await;
 


### PR DESCRIPTION
This PR implements [pion commit 2184](https://github.com/pion/webrtc/pull/2184). 

Currently it's assumed that the read buffer will never fill, and so any failure to `write` should be cause to return an `Err`. This isn't always true however, particularly in high load scenarios. Per `pion` fixes, we should instead log and drop packets when the buffer is full, and continue to return an error in other failure cases.

See https://github.com/pion/webrtc/issues/2152 and https://github.com/pion/webrtc/issues/2180 for more details.