### PR TITLE
fix understated `ipnet` version requirement

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -22,7 +22,7 @@ sync = []
 tokio = { version = "1.32.0", features = ["full"] }
 lazy_static = "1"
 async-trait = "0.1"
-ipnet = "2"
+ipnet = "2.6.0"
 log = "0.4"
 rand = "0.8"
 bytes = "1"


### PR DESCRIPTION
`webrtc-util` uses `IpNet::with_netmask`, which was introduced in version 2.6.0. If someone is using a `Cargo.lock` with an older version of `ipnet`, they'll get a compile error when introducing `webrtc-util` (or upgrading it to after this call was added). Adding the correct version requirement in `Cargo.toml` forces the upgrade to fix this.