### PR TITLE
unify add/remove_track arguments for peer connections

### DIFF
--- a/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
+++ b/examples/examples/play-from-disk-renegotiation/play-from-disk-renegotiation.rs
@@ -212,9 +212,12 @@ async fn remove_video(
     r: Request<Body>,
 ) -> Result<Response<Body>, hyper::Error> {
     let senders = pc.get_senders().await;
+
     if !senders.is_empty() {
-        if let Err(err) = pc.remove_track(&senders[0]).await {
-            panic!("{}", err);
+        if let Some(track) = senders[0].track().await {
+            if let Err(err) = pc.remove_track(track).await {
+                panic!("{}", err);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, RTCPeerConnection's remove_track took a `&Arc<RTCRtpSender>` while its add_track took an `Arc<dyn TrackLocal + Send + Sync>` for its argument, and semantically it makes sense for these two methods to have the same parameters. 

This would delegate checking whether the track exists on a given sender to the user before removing the track (as seen in the changes to the example), but I think its rare that a user would want to remove a track based on the sender rather than explicitly specifying the track.