### PR TITLE
sdp: simulcast: Properly parse and set 'a=simulcast:'

### DIFF
--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) const UNSPECIFIED_STR: &str = "Unspecified";
 pub(crate) const RECEIVE_MTU: usize = 1460;
 
 pub(crate) const SDP_ATTRIBUTE_RID: &str = "rid";
+pub(crate) const SDP_ATTRIBUTE_SIMULCAST: &str = "simulcast";
 pub(crate) const GENERATED_CERTIFICATE_ORIGIN: &str = "WebRTC";
 pub(crate) const SDES_REPAIR_RTP_STREAM_ID_URI: &str =
     "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id";

--- a/webrtc/src/peer_connection/sdp/sdp_test.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_test.rs
@@ -703,7 +703,26 @@ async fn test_populate_sdp() -> Result<()> {
         .await;
 
         let mut rid_map = HashMap::new();
-        rid_map.insert("ridkey".to_owned(), "some".to_owned());
+        let rid_id = "ridkey".to_owned();
+        rid_map.insert(
+            rid_id.to_owned(),
+            SimulcastRid {
+                id: rid_id,
+                direction: SimulcastDirection::Recv,
+                params: "some".to_owned(),
+                paused: false,
+            },
+        );
+        let rid_id = "ridpaused".to_owned();
+        rid_map.insert(
+            rid_id.to_owned(),
+            SimulcastRid {
+                id: rid_id,
+                direction: SimulcastDirection::Recv,
+                params: "some2".to_owned(),
+                paused: true,
+            },
+        );
         let media_sections = vec![MediaSection {
             id: "video".to_owned(),
             transceivers: vec![tr],
@@ -732,23 +751,33 @@ async fn test_populate_sdp() -> Result<()> {
         .await?;
 
         // Test contains rid map keys
-        let mut found = false;
+        let mut found = 0;
         for desc in &offer_sdp.media_descriptions {
             if desc.media_name.media != "video" {
                 continue;
             }
-            for a in &desc.attributes {
-                if a.key == SDP_ATTRIBUTE_RID {
-                    if let Some(value) = &a.value {
-                        if value.contains("ridkey") {
-                            found = true;
-                            break;
-                        }
-                    }
-                }
+
+            let rid_map = get_rids(desc);
+            if let Some(rid) = rid_map.get("ridkey") {
+                assert!(!rid.paused, "Rid should be active");
+                assert_eq!(
+                    rid.direction,
+                    SimulcastDirection::Send,
+                    "Rid should be send"
+                );
+                found += 1;
+            }
+            if let Some(rid) = rid_map.get("ridpaused") {
+                assert!(rid.paused, "Rid should be paused");
+                assert_eq!(
+                    rid.direction,
+                    SimulcastDirection::Send,
+                    "Rid should be send"
+                );
+                found += 1;
             }
         }
-        assert!(found, "Rid key should be present");
+        assert_eq!(found, 2, "All Rid key should be present");
     }
 
     //"SetCodecPreferences"


### PR DESCRIPTION
This improves parsing and generation of SDP for simulcast attribute according to RFC8853.
Support for alternative formats are not implemented 100%.

Comparing to Pion implementation, this commit at least covers more, hopefully most usecases for webrtc-rs users.