### PR TITLE
Fix simulcast for firefox

### DIFF
--- a/sdp/src/extmap/mod.rs
+++ b/sdp/src/extmap/mod.rs
@@ -20,6 +20,9 @@ pub const TRANSPORT_CC_URI: &str =
     "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01";
 pub const SDES_MID_URI: &str = "urn:ietf:params:rtp-hdrext:sdes:mid";
 pub const SDES_RTP_STREAM_ID_URI: &str = "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id";
+pub const SDES_REPAIR_RTP_STREAM_ID_URI: &str =
+    "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id";
+
 pub const AUDIO_LEVEL_URI: &str = "urn:ietf:params:rtp-hdrext:ssrc-audio-level";
 pub const VIDEO_ORIENTATION_URI: &str = "urn:3gpp:video-orientation";
 

--- a/webrtc/src/lib.rs
+++ b/webrtc/src/lib.rs
@@ -42,5 +42,3 @@ pub(crate) const RECEIVE_MTU: usize = 1460;
 pub(crate) const SDP_ATTRIBUTE_RID: &str = "rid";
 pub(crate) const SDP_ATTRIBUTE_SIMULCAST: &str = "simulcast";
 pub(crate) const GENERATED_CERTIFICATE_ORIGIN: &str = "WebRTC";
-pub(crate) const SDES_REPAIR_RTP_STREAM_ID_URI: &str =
-    "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id";

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1068,8 +1068,8 @@ impl PeerConnectionInternal {
         on_track_handler: Arc<ArcSwapOption<Mutex<OnTrackHdlrFn>>>,
     ) {
         receiver.start(incoming).await;
-        for t in receiver.tracks().await {
-            if t.ssrc() == 0 {
+        for track in receiver.tracks().await {
+            if track.ssrc() == 0 {
                 return;
             }
 
@@ -1077,31 +1077,29 @@ impl PeerConnectionInternal {
             let transceiver = Arc::clone(&transceiver);
             let on_track_handler = Arc::clone(&on_track_handler);
             tokio::spawn(async move {
-                if let Some(track) = receiver.track().await {
-                    let mut b = vec![0u8; receive_mtu];
-                    let pkt = match track.peek(&mut b).await {
-                        Ok((pkt, _)) => pkt,
-                        Err(err) => {
-                            log::warn!(
-                                "Could not determine PayloadType for SSRC {} ({})",
-                                track.ssrc(),
-                                err
-                            );
-                            return;
-                        }
-                    };
-
-                    if let Err(err) = track.check_and_update_track(&pkt).await {
+                let mut b = vec![0u8; receive_mtu];
+                let pkt = match track.peek(&mut b).await {
+                    Ok((pkt, _)) => pkt,
+                    Err(err) => {
                         log::warn!(
-                            "Failed to set codec settings for track SSRC {} ({})",
+                            "Could not determine PayloadType for SSRC {} ({})",
                             track.ssrc(),
                             err
                         );
                         return;
                     }
+                };
 
-                    RTCPeerConnection::do_track(on_track_handler, track, receiver, transceiver);
+                if let Err(err) = track.check_and_update_track(&pkt).await {
+                    log::warn!(
+                        "Failed to set codec settings for track SSRC {} ({})",
+                        track.ssrc(),
+                        err
+                    );
+                    return;
                 }
+
+                RTCPeerConnection::do_track(on_track_handler, track, receiver, transceiver);
             });
         }
     }

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -15,7 +15,7 @@ use crate::stats::{
     StatsReportType,
 };
 use crate::track::TrackStream;
-use crate::{SDES_REPAIR_RTP_STREAM_ID_URI, SDP_ATTRIBUTE_RID};
+use crate::SDP_ATTRIBUTE_RID;
 
 pub(crate) struct PeerConnectionInternal {
     /// a value containing the last known greater mid value
@@ -940,7 +940,7 @@ impl PeerConnectionInternal {
         let (rsid_extension_id, _, _) = self
             .media_engine
             .get_header_extension_id(RTCRtpHeaderExtensionCapability {
-                uri: SDES_REPAIR_RTP_STREAM_ID_URI.to_owned(),
+                uri: ::sdp::extmap::SDES_REPAIR_RTP_STREAM_ID_URI.to_owned(),
             })
             .await;
 

--- a/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -487,18 +487,6 @@ impl RTCRtpReceiver {
         }
     }
 
-    /// track returns the RtpTransceiver TrackRemote
-    pub async fn track(&self) -> Option<Arc<TrackRemote>> {
-        let tracks = self.internal.tracks.read().await;
-        if tracks.len() != 1 {
-            None
-        } else {
-            // Clippy bug (reported at https://github.com/rust-lang/rust-clippy/issues/12560) suggests .first().cloned()
-            #[allow(clippy::map_clone)]
-            tracks.first().map(|t| Arc::clone(&t.track))
-        }
-    }
-
     /// tracks returns the RtpTransceiver traclockks
     /// A RTPReceiver to support Simulcast may now have multiple tracks
     pub async fn tracks(&self) -> Vec<Arc<TrackRemote>> {

--- a/webrtc/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/rtp_receiver_test.rs
@@ -92,36 +92,38 @@ async fn test_set_rtp_parameters() -> Result<()> {
         Box::pin(async move {
             receiver.set_rtp_parameters(P.clone()).await;
 
-            if let Some(t) = receiver.track().await {
-                let incoming_track_codecs = t.codec();
+            let tracks = receiver.tracks().await;
+            assert_eq!(tracks.len(), 1);
+            let t = tracks.first().unwrap();
 
-                assert_eq!(P.header_extensions, t.params().header_extensions);
-                assert_eq!(
-                    P.codecs[0].capability.mime_type,
-                    incoming_track_codecs.capability.mime_type
-                );
-                assert_eq!(
-                    P.codecs[0].capability.clock_rate,
-                    incoming_track_codecs.capability.clock_rate
-                );
-                assert_eq!(
-                    P.codecs[0].capability.channels,
-                    incoming_track_codecs.capability.channels
-                );
-                assert_eq!(
-                    P.codecs[0].capability.sdp_fmtp_line,
-                    incoming_track_codecs.capability.sdp_fmtp_line
-                );
-                assert_eq!(
-                    P.codecs[0].capability.rtcp_feedback,
-                    incoming_track_codecs.capability.rtcp_feedback
-                );
-                assert_eq!(P.codecs[0].payload_type, incoming_track_codecs.payload_type);
+            let incoming_track_codecs = t.codec();
 
-                {
-                    let mut done = seen_packet_tx2.lock().await;
-                    done.take();
-                }
+            assert_eq!(P.header_extensions, t.params().header_extensions);
+            assert_eq!(
+                P.codecs[0].capability.mime_type,
+                incoming_track_codecs.capability.mime_type
+            );
+            assert_eq!(
+                P.codecs[0].capability.clock_rate,
+                incoming_track_codecs.capability.clock_rate
+            );
+            assert_eq!(
+                P.codecs[0].capability.channels,
+                incoming_track_codecs.capability.channels
+            );
+            assert_eq!(
+                P.codecs[0].capability.sdp_fmtp_line,
+                incoming_track_codecs.capability.sdp_fmtp_line
+            );
+            assert_eq!(
+                P.codecs[0].capability.rtcp_feedback,
+                incoming_track_codecs.capability.rtcp_feedback
+            );
+            assert_eq!(P.codecs[0].payload_type, incoming_track_codecs.payload_type);
+
+            {
+                let mut done = seen_packet_tx2.lock().await;
+                done.take();
             }
         })
     }));


### PR DESCRIPTION
This is a patchset which at least improves using webrtc-rs on a SFU with simulcast and firefox as a client

I found that the simulcast example didn't work for Firefox. It might not really work now either, but this should be a step on the way.
Please let me know what you think :) 