### PR TITLE
Broaden compatibility for embedded platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "bytes",
  "chrono",
  "log",
+ "portable-atomic",
  "rand",
  "rtcp",
  "rtp",
@@ -1809,6 +1810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2010,7 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "portable-atomic",
  "rand",
  "serde",
  "thiserror",
@@ -2558,6 +2566,7 @@ dependencies = [
  "hex",
  "log",
  "md-5",
+ "portable-atomic",
  "rand",
  "ring 0.17.7",
  "stun",
@@ -2767,6 +2776,7 @@ dependencies = [
  "lazy_static",
  "log",
  "pem",
+ "portable-atomic",
  "rand",
  "rcgen",
  "regex",
@@ -2818,6 +2828,7 @@ dependencies = [
  "chrono",
  "env_logger",
  "log",
+ "portable-atomic",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -2847,6 +2858,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
+ "portable-atomic",
  "rand",
  "rand_core",
  "rcgen",
@@ -2879,6 +2891,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
+ "portable-atomic",
  "rand",
  "regex",
  "serde",
@@ -2936,6 +2949,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "portable-atomic",
  "rand",
  "thiserror",
  "tokio",
@@ -2984,6 +2998,7 @@ dependencies = [
  "libc",
  "log",
  "nix",
+ "portable-atomic",
  "rand",
  "thiserror",
  "tokio",

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -13,10 +13,22 @@ repository = "https://github.com/webrtc-rs/data"
 util = { version = "0.8.1", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "marshal"]  }
 sctp = { version = "0.9.1", path = "../sctp", package = "webrtc-sctp" }
 
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 bytes = "1"
 log = "0.4"
 thiserror = "1"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4" # must match the min version of the `tokio` crate above

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -5,12 +5,13 @@ use std::borrow::Borrow;
 use std::future::Future;
 use std::net::Shutdown;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{fmt, io};
 
 use bytes::{Buf, Bytes};
+use portable_atomic::AtomicUsize;
 use sctp::association::Association;
 use sctp::chunk::chunk_payload_data::PayloadProtocolIdentifier;
 use sctp::stream::*;

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -26,7 +26,18 @@ aes = "0.8"
 cbc = { version = "0.1", features = [ "block-padding", "alloc"] }
 aes-gcm = "0.10"
 ccm = "0.5"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 async-trait = "0.1"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 x509-parser = "0.15"
@@ -40,6 +51,7 @@ subtle = "2"
 log = "0.4"
 thiserror = "1"
 pem = { version = "3", optional = true }
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -4,11 +4,12 @@ mod conn_test;
 use std::io::{BufReader, BufWriter};
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::*;
+use portable_atomic::{AtomicBool, AtomicU16};
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 use util::replay_detector::*;

--- a/dtls/src/state.rs
+++ b/dtls/src/state.rs
@@ -1,9 +1,10 @@
 use std::io::{BufWriter, Cursor};
 use std::marker::{Send, Sync};
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use portable_atomic::AtomicU16;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use util::{KeyingMaterialExporter, KeyingMaterialExporterError};

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -23,10 +23,22 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 waitgroup = "0.1"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use portable_atomic::{AtomicBool, AtomicU64};
 
 use arc_swap::ArcSwapOption;
 use util::sync::Mutex as SyncMutex;

--- a/ice/src/agent/agent_transport.rs
+++ b/ice/src/agent/agent_transport.rs
@@ -1,8 +1,9 @@
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
+use portable_atomic::AtomicBool;
 use util::Conn;
 
 use super::*;

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -1,9 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::result::Result;
 use std::str::FromStr;
-use std::sync::atomic::AtomicU64;
 
 use async_trait::async_trait;
+use portable_atomic::AtomicU64;
 use util::vnet::chunk::Chunk;
 use util::vnet::router::Nic;
 use util::vnet::*;

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -26,6 +26,7 @@ use agent_config::*;
 use agent_internal::*;
 use agent_stats::*;
 use mdns::conn::*;
+use portable_atomic::{AtomicU8, AtomicUsize};
 use stun::agent::*;
 use stun::attributes::*;
 use stun::fingerprint::*;

--- a/ice/src/candidate/candidate_base.rs
+++ b/ice/src/candidate/candidate_base.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 use std::ops::Add;
-use std::sync::atomic::{AtomicU16, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use crc::{Crc, CRC_32_ISCSI};
+use portable_atomic::{AtomicU16, AtomicU64, AtomicU8};
 use tokio::sync::{broadcast, Mutex};
 use util::sync::Mutex as SyncMutex;
 

--- a/ice/src/candidate/candidate_host.rs
+++ b/ice/src/candidate/candidate_host.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use portable_atomic::{AtomicU16, AtomicU8};
 
 use super::candidate_base::*;
 use super::*;

--- a/ice/src/candidate/candidate_peer_reflexive.rs
+++ b/ice/src/candidate/candidate_peer_reflexive.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use portable_atomic::{AtomicU16, AtomicU8};
 
 use util::sync::Mutex as SyncMutex;
 

--- a/ice/src/candidate/candidate_relay.rs
+++ b/ice/src/candidate/candidate_relay.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use portable_atomic::{AtomicU16, AtomicU8};
 use std::sync::Arc;
 
 use util::sync::Mutex as SyncMutex;

--- a/ice/src/candidate/candidate_server_reflexive.rs
+++ b/ice/src/candidate/candidate_server_reflexive.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU16, AtomicU8};
+use portable_atomic::{AtomicU16, AtomicU8};
 
 use util::sync::Mutex as SyncMutex;
 

--- a/ice/src/candidate/mod.rs
+++ b/ice/src/candidate/mod.rs
@@ -15,12 +15,13 @@ pub mod candidate_server_reflexive;
 
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
 use candidate_base::*;
+use portable_atomic::{AtomicBool, AtomicU16, AtomicU8};
 use serde::Serialize;
 use tokio::sync::{broadcast, Mutex};
 

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1"
 rand = "0.8"
 waitgroup = "0.1"
 log = "0.4"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/interceptor/src/twcc/sender/mod.rs
+++ b/interceptor/src/twcc/sender/mod.rs
@@ -2,9 +2,10 @@ mod sender_stream;
 #[cfg(test)]
 mod sender_test;
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicU32;
 use rtp::extension::transport_cc_extension::TransportCcExtension;
 use sender_stream::SenderStream;
 use tokio::sync::Mutex;

--- a/mdns/Cargo.toml
+++ b/mdns/Cargo.toml
@@ -16,7 +16,18 @@ reuse_port = []
 [dependencies]
 util = { version = "0.8.1", path = "../util", package = "webrtc-util", default-features = false, features = ["ifaces"] }
 
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 socket2 = { version = "0.5", features = ["all"] }
 log = "0.4"
 thiserror = "1"

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -16,6 +16,7 @@ bytes = "1"
 rand = "0.8"
 thiserror = "1"
 serde = { version = "1", features = ["derive"] }
+portable-atomic = "1.6"
 
 [dev-dependencies]
 chrono = "0.4.28"

--- a/rtp/src/sequence.rs
+++ b/rtp/src/sequence.rs
@@ -1,6 +1,8 @@
 use std::fmt;
-use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+
+use portable_atomic::{AtomicU16, AtomicU64};
 
 /// Sequencer generates sequential sequence numbers for building RTP packets
 pub trait Sequencer: fmt::Debug {

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -13,13 +13,25 @@ repository = "https://github.com/webrtc-rs/sctp"
 util = { version = "0.8.1", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
 arc-swap = "1"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 bytes = "1"
 rand = "0.8"
 crc = "3"
 async-trait = "0.1"
 log = "0.4"
 thiserror = "1"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/sctp/src/association/association_internal.rs
+++ b/sctp/src/association/association_internal.rs
@@ -1,9 +1,8 @@
 #[cfg(test)]
 mod association_internal_test;
 
-use std::sync::atomic::AtomicBool;
-
 use async_trait::async_trait;
+use portable_atomic::AtomicBool;
 
 use super::*;
 use crate::param::param_forward_tsn_supported::ParamForwardTsnSupported;

--- a/sctp/src/association/association_stats.rs
+++ b/sctp/src/association/association_stats.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use portable_atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 #[derive(Default, Debug)]
 pub(crate) struct AssociationStats {

--- a/sctp/src/association/mod.rs
+++ b/sctp/src/association/mod.rs
@@ -6,13 +6,14 @@ mod association_stats;
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use association_internal::*;
 use association_stats::*;
 use bytes::{Bytes, BytesMut};
+use portable_atomic::{AtomicBool, AtomicU32, AtomicU8, AtomicUsize};
 use rand::random;
 use tokio::sync::{broadcast, mpsc, Mutex};
 use util::Conn;

--- a/sctp/src/chunk/chunk_payload_data.rs
+++ b/sctp/src/chunk/chunk_payload_data.rs
@@ -1,9 +1,10 @@
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use portable_atomic::AtomicBool;
 
 use super::chunk_header::*;
 use super::chunk_type::*;

--- a/sctp/src/queue/payload_queue.rs
+++ b/sctp/src/queue/payload_queue.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+
+use portable_atomic::AtomicUsize;
 
 use crate::chunk::chunk_payload_data::ChunkPayloadData;
 use crate::chunk::chunk_selective_ack::GapAckBlock;

--- a/sctp/src/queue/pending_queue.rs
+++ b/sctp/src/queue/pending_queue.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 
+use portable_atomic::{AtomicBool, AtomicUsize};
 use tokio::sync::{Mutex, Semaphore};
 use util::sync::RwLock;
 

--- a/sctp/src/queue/queue_test.rs
+++ b/sctp/src/queue/queue_test.rs
@@ -442,8 +442,9 @@ async fn test_pending_queue_append() -> Result<()> {
 ///////////////////////////////////////////////////////////////////
 //reassembly_queue_test
 ///////////////////////////////////////////////////////////////////
-use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
+
+use portable_atomic::AtomicUsize;
 
 use super::reassembly_queue::*;
 

--- a/sctp/src/stream/mod.rs
+++ b/sctp/src/stream/mod.rs
@@ -4,13 +4,14 @@ mod stream_test;
 use std::future::Future;
 use std::net::Shutdown;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{fmt, io};
 
 use arc_swap::ArcSwapOption;
 use bytes::Bytes;
+use portable_atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU8, AtomicUsize};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::{mpsc, Mutex, Notify};
 

--- a/sctp/src/stream/stream_test.rs
+++ b/sctp/src/stream/stream_test.rs
@@ -1,6 +1,7 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicU32;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::*;

--- a/sctp/src/timer/timer_test.rs
+++ b/sctp/src/timer/timer_test.rs
@@ -3,10 +3,11 @@
 // Silence warning on `..Default::default()` with no effect:
 #![allow(clippy::needless_update)]
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use portable_atomic::AtomicU32;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
 

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -30,7 +30,18 @@ sha1 = "0.10"
 ctr = "0.9"
 aes = "0.8"
 subtle = "2"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 log = "0.4"
 aead = { version = "0.5", features = ["std"] }
 aes-gcm = { version = "0.10", features = ["std"] }

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -16,7 +16,18 @@ bench = []
 [dependencies]
 util = { version = "0.8.1", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }
 
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 lazy_static = "1"
 url = "2"
 rand = "0.8"

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -13,7 +13,18 @@ repository = "https://github.com/webrtc-rs/turn"
 util = { version = "0.8.1", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet"] }
 stun = { version = "0.5.1", path = "../stun" }
 
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tokio-util = "0.7"
 futures = "0.3"
 async-trait = "0.1"
@@ -23,6 +34,7 @@ rand = "0.8"
 ring = "0.17"
 md-5 = "0.10"
 thiserror = "1"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/turn/src/allocation/channel_bind.rs
+++ b/turn/src/allocation/channel_bind.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 mod channel_bind_test;
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicBool;
 use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -9,12 +9,13 @@ pub mod permission;
 use std::collections::HashMap;
 use std::marker::{Send, Sync};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use channel_bind::*;
 use five_tuple::*;
 use permission::*;
+use portable_atomic::{AtomicBool, AtomicUsize};
 use stun::agent::*;
 use stun::message::*;
 use stun::textattrs::Username;

--- a/turn/src/allocation/permission.rs
+++ b/turn/src/allocation/permission.rs
@@ -1,6 +1,7 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicBool;
 use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 

--- a/turn/src/client/permission.rs
+++ b/turn/src/client/permission.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+
+use portable_atomic::AtomicU8;
 
 #[derive(Default, Copy, Clone, PartialEq, Debug)]
 pub(crate) enum PermState {

--- a/turn/src/client/transaction.rs
+++ b/turn/src/client/transaction.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicU16;
 use stun::message::*;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -19,7 +19,18 @@ marshal = []
 sync = []
 
 [dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 lazy_static = "1"
 async-trait = "0.1"
 ipnet = "2.6.0"
@@ -27,6 +38,7 @@ log = "0.4"
 rand = "0.8"
 bytes = "1"
 thiserror = "1"
+portable-atomic = "1.6"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.26.2"

--- a/util/src/conn/conn_bridge.rs
+++ b/util/src/conn/conn_bridge.rs
@@ -1,10 +1,11 @@
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use portable_atomic::AtomicUsize;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 

--- a/util/src/conn/conn_udp_listener.rs
+++ b/util/src/conn/conn_udp_listener.rs
@@ -2,8 +2,8 @@ use core::sync::atomic::Ordering;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::AtomicBool;
 
+use portable_atomic::AtomicBool;
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, watch, Mutex};
 

--- a/util/src/vnet/chunk.rs
+++ b/util/src/vnet/chunk.rs
@@ -5,8 +5,10 @@ use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::{BitAnd, BitOr};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::SystemTime;
+
+use portable_atomic::AtomicU64;
 
 use super::net::*;
 use crate::error::Result;

--- a/util/src/vnet/conn.rs
+++ b/util/src/vnet/conn.rs
@@ -2,10 +2,11 @@
 mod conn_test;
 
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use portable_atomic::AtomicBool;
 use tokio::sync::{mpsc, Mutex};
 
 use crate::conn::Conn;

--- a/util/src/vnet/conn/conn_test.rs
+++ b/util/src/vnet/conn/conn_test.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
-use std::sync::atomic::AtomicUsize;
+
+use portable_atomic::AtomicUsize;
 
 use super::*;
 

--- a/util/src/vnet/nat.rs
+++ b/util/src/vnet/nat.rs
@@ -4,10 +4,11 @@ mod nat_test;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::ops::Add;
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use portable_atomic::AtomicU16;
 use tokio::sync::Mutex;
 use tokio::time::Duration;
 

--- a/util/src/vnet/net.rs
+++ b/util/src/vnet/net.rs
@@ -4,11 +4,12 @@ mod net_test;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ipnet::IpNet;
+use portable_atomic::AtomicU64;
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 

--- a/util/src/vnet/router.rs
+++ b/util/src/vnet/router.rs
@@ -7,12 +7,13 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::{Add, Sub};
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
 use ipnet::*;
+use portable_atomic::AtomicU64;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Duration;
 

--- a/util/src/vnet/router/router_test.rs
+++ b/util/src/vnet/router/router_test.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicI32, AtomicUsize};
+use portable_atomic::{AtomicI32, AtomicUsize};
 
 use super::*;
 

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -27,7 +27,18 @@ turn = { version = "0.7.1", path = "../turn" }
 util = { version = "0.8.1", path = "../util", package = "webrtc-util" }
 
 arc-swap = "1"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 log = "0.4"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
@@ -48,6 +59,7 @@ hex = "0.4"
 pem = { version = "3", optional = true }
 time = "0.3"
 cfg-if = "1"
+portable-atomic = "1.6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -3,9 +3,10 @@ mod media_engine_test;
 
 use std::collections::HashMap;
 use std::ops::Range;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use portable_atomic::AtomicBool;
 use sdp::description::session::SessionDescription;
 use util::sync::Mutex as SyncMutex;
 

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -8,7 +8,7 @@ pub mod data_channel_state;
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
@@ -18,6 +18,7 @@ use data::message::message_channel_open::ChannelType;
 use data_channel_message::*;
 use data_channel_parameters::*;
 use data_channel_state::RTCDataChannelState;
+use portable_atomic::{AtomicBool, AtomicU16, AtomicU8, AtomicUsize};
 use sctp::stream::OnBufferedAmountLowFn;
 use tokio::sync::{Mutex, Notify};
 use util::sync::Mutex as SyncMutex;

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
@@ -12,6 +12,7 @@ use dtls::extension::extension_use_srtp::SrtpProtectionProfile;
 use dtls_role::*;
 use interceptor::stream_info::StreamInfo;
 use interceptor::{Interceptor, RTCPReader, RTPReader};
+use portable_atomic::{AtomicBool, AtomicU8};
 use sha2::{Digest, Sha256};
 use srtp::protection_profile::ProtectionProfile;
 use srtp::session::Session;

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
 use ice::agent::Agent;
 use ice::candidate::{Candidate, CandidateType};
 use ice::url::Url;
+use portable_atomic::AtomicU8;
 use tokio::sync::Mutex;
 
 use crate::api::setting_engine::SettingEngine;

--- a/webrtc/src/ice_transport/ice_transport_test.rs
+++ b/webrtc/src/ice_transport/ice_transport_test.rs
@@ -1,5 +1,4 @@
-use std::sync::atomic::AtomicU32;
-
+use portable_atomic::AtomicU32;
 use tokio::time::Duration;
 use waitgroup::WaitGroup;
 

--- a/webrtc/src/ice_transport/mod.rs
+++ b/webrtc/src/ice_transport/mod.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
@@ -10,6 +10,7 @@ use ice_candidate::RTCIceCandidate;
 use ice_candidate_pair::RTCIceCandidatePair;
 use ice_gatherer::RTCIceGatherer;
 use ice_role::RTCIceRole;
+use portable_atomic::AtomicU8;
 use tokio::sync::{mpsc, Mutex};
 use util::Conn;
 

--- a/webrtc/src/mux/mod.rs
+++ b/webrtc/src/mux/mod.rs
@@ -5,9 +5,10 @@ pub mod endpoint;
 pub mod mux_func;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicUsize;
 use tokio::sync::{mpsc, Mutex};
 use util::{Buffer, Conn};
 

--- a/webrtc/src/mux/mux_test.rs
+++ b/webrtc/src/mux/mux_test.rs
@@ -1,8 +1,9 @@
 use std::io;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
+use portable_atomic::AtomicUsize;
 use util::conn::conn_pipe::pipe;
 
 use super::*;

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -17,7 +17,7 @@ pub mod signaling_state;
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -29,6 +29,7 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use interceptor::{stats, Attributes, Interceptor, RTCPWriter};
 use peer_connection_internal::*;
+use portable_atomic::{AtomicBool, AtomicU64, AtomicU8};
 use rand::{thread_rng, Rng};
 use rcgen::KeyPair;
 use smol_str::SmolStr;

--- a/webrtc/src/peer_connection/operation/mod.rs
+++ b/webrtc/src/peer_connection/operation/mod.rs
@@ -4,9 +4,10 @@ mod operation_test;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use portable_atomic::AtomicUsize;
 use tokio::sync::mpsc;
 use waitgroup::WaitGroup;
 

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
-use std::sync::atomic::AtomicIsize;
 use std::sync::Weak;
 
 use arc_swap::ArcSwapOption;
+use portable_atomic::AtomicIsize;
 use smol_str::SmolStr;
 use tokio::time::Instant;
 use util::Unmarshal;

--- a/webrtc/src/peer_connection/peer_connection_test.rs
+++ b/webrtc/src/peer_connection/peer_connection_test.rs
@@ -1,9 +1,9 @@
-use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use interceptor::registry::Registry;
 use media::Sample;
+use portable_atomic::AtomicU32;
 use tokio::time::Duration;
 use util::vnet::net::{Net, NetConfig};
 use util::vnet::router::{Router, RouterConfig};

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -4,12 +4,13 @@ mod rtp_transceiver_test;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use interceptor::stream_info::{RTPHeaderExtension, StreamInfo};
 use interceptor::Attributes;
 use log::trace;
+use portable_atomic::{AtomicBool, AtomicU8};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use tokio::sync::{Mutex, OnceCell};

--- a/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -1,12 +1,13 @@
 #[cfg(test)]
 mod rtp_sender_test;
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 
 use ice::rand::generate_crypto_random_string;
 use interceptor::stream_info::StreamInfo;
 use interceptor::{Attributes, Interceptor, RTCPReader, RTPWriter};
+use portable_atomic::AtomicBool;
 use tokio::sync::{mpsc, Mutex, Notify};
 use util::sync::Mutex as SyncMutex;
 

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -1,6 +1,5 @@
-use std::sync::atomic::AtomicU64;
-
 use bytes::Bytes;
+use portable_atomic::AtomicU64;
 use tokio::time::Duration;
 use waitgroup::WaitGroup;
 

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_test.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::AtomicUsize;
+use portable_atomic::AtomicUsize;
 
 use super::*;
 use crate::api::media_engine::{MIME_TYPE_OPUS, MIME_TYPE_VP8, MIME_TYPE_VP9};

--- a/webrtc/src/rtp_transceiver/srtp_writer_future.rs
+++ b/webrtc/src/rtp_transceiver/srtp_writer_future.rs
@@ -1,9 +1,10 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use interceptor::{Attributes, RTCPReader, RTPWriter};
+use portable_atomic::AtomicBool;
 use srtp::session::Session;
 use srtp::stream::Stream;
 use tokio::sync::Mutex;

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -7,12 +7,13 @@ pub mod sctp_transport_state;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
 use data::data_channel::DataChannel;
 use data::message::message_channel_open::ChannelType;
+use portable_atomic::{AtomicBool, AtomicU32, AtomicU8};
 use sctp::association::Association;
 use sctp_transport_state::RTCSctpTransportState;
 use tokio::sync::{Mutex, Notify};

--- a/webrtc/src/sctp_transport/sctp_transport_test.rs
+++ b/webrtc/src/sctp_transport/sctp_transport_test.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::AtomicU16;
+use portable_atomic::AtomicU16;
 
 use super::*;
 

--- a/webrtc/src/track/track_local/mod.rs
+++ b/webrtc/src/track/track_local/mod.rs
@@ -6,11 +6,12 @@ pub mod track_local_static_sample;
 
 use std::any::Any;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use interceptor::{Attributes, RTPWriter};
+use portable_atomic::AtomicBool;
 use tokio::sync::Mutex;
 use util::Unmarshal;
 

--- a/webrtc/src/track/track_remote/mod.rs
+++ b/webrtc/src/track/track_remote/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU32, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 
 use arc_swap::ArcSwapOption;
 use interceptor::{Attributes, Interceptor};
+use portable_atomic::{AtomicU32, AtomicU8, AtomicUsize};
 use smol_str::SmolStr;
 use tokio::sync::Mutex;
 use util::sync::Mutex as SyncMutex;


### PR DESCRIPTION
I'm working on compiling WebRTC on the Xtensa (ESP32s3) platform. Tokio was recently updated to support more platforms, but certain features are not available (and may never be). The "process" and "signal" features aren't used by WebRTC. Rather than use the "full" feature group, the relevant Cargo.toml's have been updated to list the set of features included in "full", excluding the "process" and "signal" features. WebRTC builds ok against Tokio with those features disabled.

* Remove dependence on unneeded Tokio 'process' and 'signal' features
* Comprehensive migration to portable_atomic