### PR TITLE
use the new feature of the crc crate for more throughput in sctp

### DIFF
--- a/sctp/CHANGELOG.md
+++ b/sctp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Use the new algorithm in crc crate for better throughput [#569](https://github.com/webrtc-rs/webrtc/pull/569)
+
 ## v0.8.0
 
 * Fix 'attempt to add with overflow' panic in dev profile [#393](https://github.com/webrtc-rs/webrtc/pull/393)

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.32.0", features = [
 ] }
 bytes = "1"
 rand = "0.8"
-crc = "3"
+crc = "3.2.1"
 async-trait = "0.1"
 log = "0.4"
 thiserror = "1"

--- a/sctp/src/util.rs
+++ b/sctp/src/util.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use crc::{Crc, CRC_32_ISCSI};
+use crc::{Crc, CRC_32_ISCSI, Table};
 
 pub(crate) const PADDING_MULTIPLE: usize = 4;
 
@@ -11,7 +11,7 @@ pub(crate) fn get_padding_size(len: usize) -> usize {
 /// We need to use it for the checksum and don't want to allocate/clear each time.
 pub(crate) static FOUR_ZEROES: Bytes = Bytes::from_static(&[0, 0, 0, 0]);
 
-pub(crate) const ISCSI_CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+pub(crate) const ISCSI_CRC: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&CRC_32_ISCSI);
 
 /// Fastest way to do a crc32 without allocating.
 pub(crate) fn generate_packet_checksum(raw: &Bytes) -> u32 {


### PR DESCRIPTION
The crc crate has released finally released a new version featuring an improved algorithm that greatly increases performance. The new algorithm uses a few Kb more of lookup tables which is why it has to be enabled explicitly. This PR bumps the version of the crc crate to the required level and enables that new algorithm.

Crc performance is a significant bottleneck in the sctp throughput as showcased by the throughput example:

### Before:
```
Throughput: 67238910 Bytes/s, 1026 pkts, 1026 loops
Send 1031 pkts
Throughput: 68025330 Bytes/s, 1038 pkts, 1038 loops
Send 1038 pkts
Throughput: 68484075 Bytes/s, 1045 pkts, 1045 loops
Send 1049 pkts
Throughput: 68353005 Bytes/s, 1043 pkts, 1043 loops
Send 1046 pkts
Throughput: 68746215 Bytes/s, 1049 pkts, 1049 loops
Send 1050 pkts
Throughput: 67632120 Bytes/s, 1032 pkts, 1032 loops
Send 1037 pkts
```

### After:
```
Throughput: 85523175 Bytes/s, 1305 pkts, 1305 loops
Send 1311 pkts
Throughput: 86768340 Bytes/s, 1324 pkts, 1324 loops
Send 1325 pkts
Throughput: 86899410 Bytes/s, 1326 pkts, 1326 loops
Send 1328 pkts
Throughput: 86440665 Bytes/s, 1319 pkts, 1319 loops
Send 1319 pkts
Throughput: 86637270 Bytes/s, 1322 pkts, 1322 loops
Send 1323 pkts
Throughput: 86899410 Bytes/s, 1326 pkts, 1326 loops
Send 1328 pkts

```

Edit: About the formatting CI: I can only reproduce one of the two fixes locally, but that one isn't related to this PR. The one related to this PR I can't reproduce locally (cargo fmt just doesn't produce this output for me...?!)

Do you want me to fix these two? I'd be glad to do it but I don't want to clutter the PR either