### PR TITLE
Added PlayoutDelayExtension to control receiver jitter buffer size

### DIFF
--- a/rtp/src/error.rs
+++ b/rtp/src/error.rs
@@ -54,6 +54,8 @@ pub enum Error {
     HeaderExtensionPayloadNot32BitWords,
     #[error("audio level overflow")]
     AudioLevelOverflow,
+    #[error("playout delay overflow")]
+    PlayoutDelayOverflow,
     #[error("payload is not large enough")]
     PayloadIsNotLargeEnough,
     #[error("STAP-A declared size({0}) is larger than buffer({1})")]

--- a/rtp/src/extension/mod.rs
+++ b/rtp/src/extension/mod.rs
@@ -5,6 +5,7 @@ use util::{Marshal, MarshalSize};
 
 pub mod abs_send_time_extension;
 pub mod audio_level_extension;
+pub mod playout_delay_extension;
 pub mod transport_cc_extension;
 pub mod video_orientation_extension;
 
@@ -12,6 +13,7 @@ pub mod video_orientation_extension;
 pub enum HeaderExtension {
     AbsSendTime(abs_send_time_extension::AbsSendTimeExtension),
     AudioLevel(audio_level_extension::AudioLevelExtension),
+    PlayoutDelay(playout_delay_extension::PlayoutDelayExtension),
     TransportCc(transport_cc_extension::TransportCcExtension),
     VideoOrientation(video_orientation_extension::VideoOrientationExtension),
 
@@ -29,6 +31,7 @@ impl HeaderExtension {
         match self {
             AbsSendTime(_) => "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time".into(),
             AudioLevel(_) => "urn:ietf:params:rtp-hdrext:ssrc-audio-level".into(),
+            PlayoutDelay(_) => "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay".into(),
             TransportCc(_) => {
                 "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01".into()
             }
@@ -56,6 +59,7 @@ impl MarshalSize for HeaderExtension {
         match self {
             AbsSendTime(ext) => ext.marshal_size(),
             AudioLevel(ext) => ext.marshal_size(),
+            PlayoutDelay(ext) => ext.marshal_size(),
             TransportCc(ext) => ext.marshal_size(),
             VideoOrientation(ext) => ext.marshal_size(),
             Custom { extension: ext, .. } => ext.marshal_size(),
@@ -69,6 +73,7 @@ impl Marshal for HeaderExtension {
         match self {
             AbsSendTime(ext) => ext.marshal_to(buf),
             AudioLevel(ext) => ext.marshal_to(buf),
+            PlayoutDelay(ext) => ext.marshal_to(buf),
             TransportCc(ext) => ext.marshal_to(buf),
             VideoOrientation(ext) => ext.marshal_to(buf),
             Custom { extension: ext, .. } => ext.marshal_to(buf),
@@ -83,6 +88,7 @@ impl fmt::Debug for HeaderExtension {
         match self {
             AbsSendTime(ext) => f.debug_tuple("AbsSendTime").field(ext).finish(),
             AudioLevel(ext) => f.debug_tuple("AudioLevel").field(ext).finish(),
+            PlayoutDelay(ext) => f.debug_tuple("PlayoutDelay").field(ext).finish(),
             TransportCc(ext) => f.debug_tuple("TransportCc").field(ext).finish(),
             VideoOrientation(ext) => f.debug_tuple("VideoOrientation").field(ext).finish(),
             Custom { uri, extension: _ } => f.debug_struct("Custom").field("uri", uri).finish(),

--- a/rtp/src/extension/playout_delay_extension/mod.rs
+++ b/rtp/src/extension/playout_delay_extension/mod.rs
@@ -1,0 +1,82 @@
+#[cfg(test)]
+mod playout_delay_extension_test;
+
+use bytes::BufMut;
+use util::marshal::{Marshal, MarshalSize, Unmarshal};
+
+use crate::error::Error;
+
+pub const PLAYOUT_DELAY_EXTENSION_SIZE: usize = 3;
+pub const PLAYOUT_DELAY_MAX_VALUE: u16 = (1 << 12) - 1;
+
+/// PlayoutDelayExtension is an extension payload format described in
+/// http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+/// 0                   1                   2                   3
+/// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |  ID   | len=2 |       MIN delay       |       MAX delay       |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+pub struct PlayoutDelayExtension {
+    pub min_delay: u16,
+    pub max_delay: u16,
+}
+
+impl Unmarshal for PlayoutDelayExtension {
+    /// Unmarshal parses the passed byte slice and stores the result in the members.
+    fn unmarshal<B>(buf: &mut B) -> util::Result<Self>
+    where
+        Self: Sized,
+        B: bytes::Buf,
+    {
+        if buf.remaining() < PLAYOUT_DELAY_EXTENSION_SIZE {
+            return Err(Error::ErrBufferTooSmall.into());
+        }
+
+        let b0 = buf.get_u8();
+        let b1 = buf.get_u8();
+        let b2 = buf.get_u8();
+
+        let min_delay = u16::from_be_bytes([b0, b1]) >> 4;
+        let max_delay = u16::from_be_bytes([b1, b2]) & 0x0FFF;
+
+        Ok(PlayoutDelayExtension {
+            min_delay,
+            max_delay,
+        })
+    }
+}
+
+impl MarshalSize for PlayoutDelayExtension {
+    /// MarshalSize returns the size of the PlayoutDelayExtension once marshaled.
+    fn marshal_size(&self) -> usize {
+        PLAYOUT_DELAY_EXTENSION_SIZE
+    }
+}
+
+impl Marshal for PlayoutDelayExtension {
+    /// MarshalTo serializes the members to buffer
+    fn marshal_to(&self, mut buf: &mut [u8]) -> util::Result<usize> {
+        if buf.remaining_mut() < PLAYOUT_DELAY_EXTENSION_SIZE {
+            return Err(Error::ErrBufferTooSmall.into());
+        }
+        if self.min_delay > PLAYOUT_DELAY_MAX_VALUE || self.max_delay > PLAYOUT_DELAY_MAX_VALUE {
+            return Err(Error::PlayoutDelayOverflow.into());
+        }
+
+        buf.put_u8((self.min_delay >> 4) as u8);
+        buf.put_u8(((self.min_delay << 4) as u8) | (self.max_delay >> 8) as u8);
+        buf.put_u8(self.max_delay as u8);
+
+        Ok(PLAYOUT_DELAY_EXTENSION_SIZE)
+    }
+}
+
+impl PlayoutDelayExtension {
+    pub fn new(min_delay: u16, max_delay: u16) -> Self {
+        PlayoutDelayExtension {
+            min_delay,
+            max_delay,
+        }
+    }
+}

--- a/rtp/src/extension/playout_delay_extension/playout_delay_extension_test.rs
+++ b/rtp/src/extension/playout_delay_extension/playout_delay_extension_test.rs
@@ -1,0 +1,38 @@
+use bytes::BytesMut;
+
+use crate::error::Result;
+
+use super::*;
+
+#[test]
+fn test_playout_delay_extension_roundtrip() -> Result<()> {
+    let test = PlayoutDelayExtension {
+        max_delay: 2345,
+        min_delay: 1234,
+    };
+
+    let mut raw = BytesMut::with_capacity(test.marshal_size());
+    raw.resize(test.marshal_size(), 0);
+    test.marshal_to(&mut raw)?;
+    let raw = raw.freeze();
+    let buf = &mut raw.clone();
+    let out = PlayoutDelayExtension::unmarshal(buf)?;
+    assert_eq!(test, out);
+
+    Ok(())
+}
+
+#[test]
+fn test_playout_delay_value_overflow() -> Result<()> {
+    let test = PlayoutDelayExtension {
+        max_delay: u16::MAX,
+        min_delay: u16::MAX,
+    };
+
+    let mut dst = BytesMut::with_capacity(test.marshal_size());
+    dst.resize(test.marshal_size(), 0);
+    let result = test.marshal_to(&mut dst);
+    assert!(result.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a `PlayoutDelayExtension` per https://webrtc.googlesource.com/src/+/main/docs/native-code/rtp-hdrext/playout-delay/README.md, using https://github.com/pion/rtp/blob/master/playoutdelayextension.go for reference.