### PR TITLE
Fixed repository URLs

### DIFF
--- a/constraints/Cargo.toml
+++ b/constraints/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of WebRTC Media Constraints API"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-constraints"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/constraints"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/constraints"
 
 [dependencies]
 indexmap = "2"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of WebRTC DataChannel API"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-data"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/data"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/data"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "marshal"]  }

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of DTLS"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-dtls"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/dtls"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/dtls"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ description = "Examples of WebRTC.rs stack"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/examples"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/examples"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/examples"
 
 [dependencies]
 

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of ICE"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-ice"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/ice"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/ice"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet", "sync"] }

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of Pluggable RTP/RTCP processors"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/interceptor"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/interceptor"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/interceptor"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal", "sync"] }

--- a/mdns/Cargo.toml
+++ b/mdns/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of mDNS"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-mdns"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/mdns"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/mdns"
 
 [features]
 default = [ "reuse_port" ]

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of WebRTC Media API"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-media"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/media"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/media"
 
 [dependencies]
 rtp = { version = "0.11.0", path = "../rtp" }

--- a/rtcp/Cargo.toml
+++ b/rtcp/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of RTCP"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rtcp"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/rtcp"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/rtcp"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of RTP"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rtp"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/rtp"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/rtp"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["marshal"] }

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of SCTP"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-sctp"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/sctp"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/sctp"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn"] }

--- a/sdp/Cargo.toml
+++ b/sdp/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of SDP"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/sdp"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/sdp"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/sdp"
 
 [dependencies]
 url = "2"

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of SRTP"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-srtp"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/srtp"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/srtp"
 
 [features]
 openssl = ["dep:openssl"]

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of STUN"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/stun"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/stun"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/stun"
 
 [features]
 default = []

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -7,7 +7,7 @@ description = "A pure Rust implementation of TURN"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/turn"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/turn"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/turn"
 
 [dependencies]
 util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-features = false, features = ["conn", "vnet"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,7 +7,7 @@ description = "Utilities for WebRTC.rs stack"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/webrtc-util"
 homepage = "https://webrtc.rs"
-repository = "https://github.com/webrtc-rs/util"
+repository = "https://github.com/webrtc-rs/webrtc/tree/master/util"
 
 [features]
 default = ["buffer", "conn", "ifaces", "vnet", "marshal", "sync"]


### PR DESCRIPTION
Discovering all the sub-crates from docs.rs is sub-optimal, as the links to crates of the workspace are not all working.
Example: from https://docs.rs/webrtc-srtp/latest/webrtc_srtp/, the "Repository" link links to the archived, pre-workspace version of the crate.

This MR fixes them.