### PR TITLE
Send side Simulcast/Track encodings

### DIFF
--- a/webrtc/src/api/mod.rs
+++ b/webrtc/src/api/mod.rs
@@ -157,9 +157,11 @@ impl API {
         transport: Arc<RTCDtlsTransport>,
         interceptor: Arc<dyn Interceptor + Send + Sync>,
     ) -> RTCRtpSender {
+        let kind = track.as_ref().map(|t| t.kind()).unwrap_or_default();
         RTCRtpSender::new(
             self.setting_engine.get_receive_mtu(),
             track,
+            kind,
             transport,
             Arc::clone(&self.media_engine),
             interceptor,

--- a/webrtc/src/error.rs
+++ b/webrtc/src/error.rs
@@ -199,6 +199,10 @@ pub enum Error {
     #[error("new track must be of the same kind as previous")]
     ErrRTPSenderNewTrackHasIncorrectKind,
 
+    /// ErrRTPSenderNewTrackHasIncorrectEnvelope indicates that the new track has a different envelope than the previous/original
+    #[error("new track must have the same envelope as previous")]
+    ErrRTPSenderNewTrackHasIncorrectEnvelope,
+
     /// ErrRTPSenderDataSent indicates that the sequence number transformer tries to be enabled after the data sending began
     #[error("Sequence number transformer must be enabled before sending data")]
     ErrRTPSenderDataSent,
@@ -328,6 +332,20 @@ pub enum Error {
     },
     #[error("Track must not be nil")]
     ErrRTPSenderTrackNil,
+    #[error("Sender has already been stopped")]
+    ErrRTPSenderStopped,
+    #[error("Sender Track has been removed or replaced to nil")]
+    ErrRTPSenderTrackRemoved,
+    #[error("Sender cannot add encoding as rid is empty")]
+    ErrRTPSenderRidNil,
+    #[error("Sender cannot add encoding as there is no base track")]
+    ErrRTPSenderNoBaseEncoding,
+    #[error("Sender cannot add encoding as provided track does not match base track")]
+    ErrRTPSenderBaseEncodingMismatch,
+    #[error("Sender cannot encoding due to RID collision")]
+    ErrRTPSenderRIDCollision,
+    #[error("Sender does not have track for RID")]
+    ErrRTPSenderNoTrackForRID,
     #[error("RTPSender must not be nil")]
     ErrRTPSenderNil,
     #[error("RTPReceiver must not be nil")]

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -1410,6 +1410,7 @@ impl RTCPeerConnection {
                                 RTCRtpSender::new(
                                     receive_mtu,
                                     None,
+                                    kind,
                                     Arc::clone(&self.internal.dtls_transport),
                                     Arc::clone(&self.internal.media_engine),
                                     Arc::clone(&self.interceptor),
@@ -1608,7 +1609,10 @@ impl RTCPeerConnection {
         let current_transceivers = self.internal.rtp_transceivers.lock().await;
         for transceiver in &*current_transceivers {
             let sender = transceiver.sender().await;
-            if sender.is_negotiated() && !sender.has_sent() {
+            if !sender.track_encodings.lock().await.is_empty()
+                && sender.is_negotiated()
+                && !sender.has_sent()
+            {
                 sender.send(&sender.get_parameters().await).await?;
             }
         }

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -876,6 +876,8 @@ impl PeerConnectionInternal {
         let only_media_section = &remote_description.media_descriptions[0];
         let mut stream_id = "";
         let mut id = "";
+        let mut has_rid = false;
+        let mut has_ssrc = false;
 
         for a in &only_media_section.attributes {
             match a.key.as_str() {
@@ -888,10 +890,16 @@ impl PeerConnectionInternal {
                         }
                     }
                 }
-                ATTR_KEY_SSRC => return Err(Error::ErrPeerConnSingleMediaSectionHasExplicitSSRC),
-                SDP_ATTRIBUTE_RID => return Ok(false),
+                ATTR_KEY_SSRC => has_ssrc = true,
+                SDP_ATTRIBUTE_RID => has_rid = true,
                 _ => {}
             };
+        }
+
+        if has_rid {
+            return Ok(false);
+        } else if has_ssrc {
+            return Err(Error::ErrPeerConnSingleMediaSectionHasExplicitSSRC);
         }
 
         let mut incoming = TrackDetails {

--- a/webrtc/src/peer_connection/peer_connection_test.rs
+++ b/webrtc/src/peer_connection/peer_connection_test.rs
@@ -19,6 +19,7 @@ use crate::ice_transport::ice_server::RTCIceServer;
 use crate::peer_connection::configuration::RTCConfiguration;
 use crate::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
 use crate::stats::StatsReportType;
+use crate::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
 use crate::track::track_local::track_local_static_sample::TrackLocalStaticSample;
 use crate::Error;
 
@@ -511,6 +512,158 @@ async fn peer() -> Result<()> {
     }
 
     peer_connection.close().await?;
+
+    Ok(())
+}
+
+pub(crate) fn on_connected() -> (OnPeerConnectionStateChangeHdlrFn, mpsc::Receiver<()>) {
+    let (done_tx, done_rx) = mpsc::channel::<()>(1);
+    let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+    let hdlr_fn: OnPeerConnectionStateChangeHdlrFn =
+        Box::new(move |state: RTCPeerConnectionState| {
+            let done_tx_clone = Arc::clone(&done_tx);
+            Box::pin(async move {
+                if state == RTCPeerConnectionState::Connected {
+                    let mut tx = done_tx_clone.lock().await;
+                    tx.take();
+                }
+            })
+        });
+    (hdlr_fn, done_rx)
+}
+
+// Everytime we receive a new SSRC we probe it and try to determine the proper way to handle it.
+// In most cases a Track explicitly declares a SSRC and a OnTrack is fired. In two cases we don't
+// know the SSRC ahead of time
+// * Undeclared SSRC in a single media section
+// * Simulcast
+//
+// The Undeclared SSRC processing code would run before Simulcast. If a Simulcast Offer/Answer only
+// contained one Media Section we would never fire the OnTrack. We would assume it was a failed
+// Undeclared SSRC processing. This test asserts that we properly handled this.
+#[tokio::test]
+async fn test_peer_connection_simulcast_no_data_channel() -> Result<()> {
+    let mut m = MediaEngine::default();
+    for ext in [
+        ::sdp::extmap::SDES_MID_URI,
+        ::sdp::extmap::SDES_RTP_STREAM_ID_URI,
+    ] {
+        m.register_header_extension(
+            RTCRtpHeaderExtensionCapability {
+                uri: ext.to_owned(),
+            },
+            RTPCodecType::Video,
+            None,
+        )?;
+    }
+    m.register_default_codecs()?;
+    let api = APIBuilder::new().with_media_engine(m).build();
+
+    let (mut pc_send, mut pc_recv) = new_pair(&api).await?;
+    let (send_notifier, mut send_connected) = on_connected();
+    let (recv_notifier, mut recv_connected) = on_connected();
+    pc_send.on_peer_connection_state_change(send_notifier);
+    pc_recv.on_peer_connection_state_change(recv_notifier);
+    let (track_tx, mut track_rx) = mpsc::unbounded_channel();
+    pc_recv.on_track(Box::new(move |t, _, _| {
+        let rid = t.rid().to_owned();
+        let _ = track_tx.send(rid);
+        Box::pin(async move {})
+    }));
+
+    let id = "video";
+    let stream_id = "webrtc-rs";
+    let track = Arc::new(TrackLocalStaticRTP::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        id.to_owned(),
+        "a".to_owned(),
+        stream_id.to_owned(),
+    ));
+    let track_a = Arc::clone(&track);
+    let transceiver = pc_send.add_transceiver_from_track(track, None).await?;
+    let sender = transceiver.sender().await;
+
+    let track = Arc::new(TrackLocalStaticRTP::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        id.to_owned(),
+        "b".to_owned(),
+        stream_id.to_owned(),
+    ));
+    let track_b = Arc::clone(&track);
+    sender.add_encoding(track).await?;
+
+    let (mid_id, rid_id) = {
+        let params = sender.get_parameters().await;
+        (
+            params
+                .rtp_parameters
+                .header_extensions
+                .iter()
+                .find(|e| e.uri == ::sdp::extmap::SDES_MID_URI)
+                .map(|e| e.id as u8)
+                .unwrap(),
+            params
+                .rtp_parameters
+                .header_extensions
+                .iter()
+                .find(|e| e.uri == ::sdp::extmap::SDES_RTP_STREAM_ID_URI)
+                .map(|e| e.id as u8)
+                .unwrap(),
+        )
+    };
+
+    let track = Arc::new(TrackLocalStaticRTP::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        id.to_owned(),
+        "c".to_owned(),
+        stream_id.to_owned(),
+    ));
+    let track_c = Arc::clone(&track);
+    sender.add_encoding(track).await?;
+
+    // signaling
+    signal_pair(&mut pc_send, &mut pc_recv).await?;
+    let _ = send_connected.recv().await;
+    let _ = recv_connected.recv().await;
+
+    let mid = transceiver.mid().unwrap();
+    for sequence_number in [0; 100] {
+        let mut pkt = rtp::packet::Packet {
+            header: rtp::header::Header {
+                version: 2,
+                sequence_number,
+                payload_type: 96,
+                ..Default::default()
+            },
+            payload: Bytes::from_static(&[0; 2]),
+        };
+        pkt.header
+            .set_extension(mid_id, Bytes::copy_from_slice(mid.as_bytes()))?;
+
+        pkt.header.set_extension(rid_id, Bytes::from_static(b"a"))?;
+        track_a.write_rtp_with_extensions(&pkt, &[]).await?;
+
+        pkt.header.set_extension(rid_id, Bytes::from_static(b"b"))?;
+        track_b.write_rtp_with_extensions(&pkt, &[]).await?;
+
+        pkt.header.set_extension(rid_id, Bytes::from_static(b"c"))?;
+        track_c.write_rtp_with_extensions(&pkt, &[]).await?;
+    }
+
+    assert_eq!(track_rx.recv().await.unwrap(), "a".to_owned());
+    assert_eq!(track_rx.recv().await.unwrap(), "b".to_owned());
+    assert_eq!(track_rx.recv().await.unwrap(), "c".to_owned());
+
+    close_pair_now(&pc_send, &pc_recv).await;
 
     Ok(())
 }

--- a/webrtc/src/peer_connection/sdp/sdp_test.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_test.rs
@@ -650,6 +650,7 @@ async fn test_media_description_fingerprints() -> Result<()> {
                 RTCRtpSender::new(
                     api.setting_engine.get_receive_mtu(),
                     Some(track),
+                    RTPCodecType::Video,
                     Arc::new(RTCDtlsTransport::default()),
                     Arc::clone(&api.media_engine),
                     Arc::clone(&interceptor),

--- a/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -241,12 +241,12 @@ impl RTCRtpSender {
     /// get_parameters describes the current configuration for the encoding and
     /// transmission of media on the sender's track.
     pub async fn get_parameters(&self) -> RTCRtpSendParameters {
-        let kind = {
+        let (kind, rid) = {
             let track = self.track.lock().await;
             if let Some(t) = &*track {
-                t.kind()
+                (t.kind(), t.rid().to_owned())
             } else {
-                RTPCodecType::default()
+                (RTPCodecType::default(), "".to_owned())
             }
         };
 
@@ -256,6 +256,7 @@ impl RTCRtpSender {
                     .media_engine
                     .get_rtp_parameters_by_kind(kind, RTCRtpTransceiverDirection::Sendonly),
                 encodings: vec![RTCRtpEncodingParameters {
+                    rid: rid.into(),
                     ssrc: self.ssrc,
                     payload_type: self.payload_type,
                     ..Default::default()

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -14,6 +14,7 @@ use crate::peer_connection::peer_connection_test::{
     until_connection_state,
 };
 use crate::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
+use crate::rtp_transceiver::RTCRtpCodecParameters;
 use crate::track::track_local::track_local_static_sample::TrackLocalStaticSample;
 
 #[tokio::test]
@@ -135,10 +136,14 @@ async fn test_rtp_sender_get_parameters() -> Result<()> {
     signal_pair(&mut offerer, &mut answerer).await?;
 
     let sender = rtp_transceiver.sender().await;
+    assert!(sender.track().await.is_some());
     let parameters = sender.get_parameters().await;
     assert_ne!(0, parameters.rtp_parameters.codecs.len());
     assert_eq!(1, parameters.encodings.len());
-    assert_eq!(sender.ssrc, parameters.encodings[0].ssrc);
+    assert_eq!(
+        sender.track_encodings.lock().await[0].ssrc,
+        parameters.encodings[0].ssrc
+    );
     assert!(parameters.encodings[0].rid.is_empty());
 
     close_pair_now(&offerer, &answerer).await;
@@ -176,7 +181,10 @@ async fn test_rtp_sender_get_parameters_with_rid() -> Result<()> {
     let parameters = sender.get_parameters().await;
     assert_ne!(0, parameters.rtp_parameters.codecs.len());
     assert_eq!(1, parameters.encodings.len());
-    assert_eq!(sender.ssrc, parameters.encodings[0].ssrc);
+    assert_eq!(
+        sender.track_encodings.lock().await[0].ssrc,
+        parameters.encodings[0].ssrc
+    );
     assert_eq!(rid, parameters.encodings[0].rid);
 
     close_pair_now(&offerer, &answerer).await;
@@ -323,23 +331,19 @@ async fn test_rtp_sender_replace_track_invalid_codec_change() -> Result<()> {
 
     {
         let tr = rtp_sender.rtp_transceiver.lock();
-        if let Some(t) = &*tr {
-            if let Some(t) = t.upgrade() {
-                t.set_codec_preferences(vec![RTCRtpCodecParameters {
-                    capability: RTCRtpCodecCapability {
-                        mime_type: MIME_TYPE_VP8.to_owned(),
-                        ..Default::default()
-                    },
-                    payload_type: 96,
-                    ..Default::default()
-                }])
-                .await?;
-            } else {
-                panic!();
-            }
-        } else {
-            panic!();
-        }
+        let t = tr
+            .as_ref()
+            .and_then(|t| t.upgrade())
+            .expect("Weak transceiver valid");
+        t.set_codec_preferences(vec![RTCRtpCodecParameters {
+            capability: RTCRtpCodecCapability {
+                mime_type: MIME_TYPE_VP8.to_owned(),
+                ..Default::default()
+            },
+            payload_type: 96,
+            ..Default::default()
+        }])
+        .await?;
     }
 
     signal_pair(&mut sender, &mut receiver).await?;
@@ -368,6 +372,164 @@ async fn test_rtp_sender_replace_track_invalid_codec_change() -> Result<()> {
     } else {
         panic!();
     }
+
+    close_pair_now(&sender, &receiver).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rtp_sender_add_encoding() -> Result<()> {
+    let mut m = MediaEngine::default();
+    m.register_default_codecs()?;
+    let api = APIBuilder::new().with_media_engine(m).build();
+
+    let (sender, receiver) = new_pair(&api).await?;
+    let track = Arc::new(TrackLocalStaticSample::new(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    let rtp_sender = sender.add_track(track).await?;
+
+    let track = Arc::new(TrackLocalStaticSample::new(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderRidNil,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "h".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderNoBaseEncoding,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "f".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    let rtp_sender = sender.add_track(track).await?;
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video-foobar".to_owned(),
+        "h".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderBaseEncodingMismatch,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "h".to_owned(),
+        "webrtc-rs-foobar".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderBaseEncodingMismatch,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_OPUS.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "h".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderBaseEncodingMismatch,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "f".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderRIDCollision,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "h".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    rtp_sender.add_encoding(track).await?;
+
+    rtp_sender.send(&rtp_sender.get_parameters().await).await?;
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "f".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderSendAlreadyCalled,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
+
+    rtp_sender.stop().await?;
+
+    let track = Arc::new(TrackLocalStaticSample::new_with_rid(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            ..Default::default()
+        },
+        "video".to_owned(),
+        "f".to_owned(),
+        "webrtc-rs".to_owned(),
+    ));
+    assert_eq!(
+        Error::ErrRTPSenderStopped,
+        rtp_sender.add_encoding(track).await.unwrap_err()
+    );
 
     close_pair_now(&sender, &receiver).await;
     Ok(())

--- a/webrtc/src/track/track_local/mod.rs
+++ b/webrtc/src/track/track_local/mod.rs
@@ -89,6 +89,9 @@ pub trait TrackLocal {
     /// and stream_id would be 'desktop' or 'webcam'
     fn id(&self) -> &str;
 
+    /// RID is the RTP Stream ID for this track.
+    fn rid(&self) -> Option<&str>;
+
     /// stream_id is the group this track belongs too. This must be unique
     fn stream_id(&self) -> &str;
 

--- a/webrtc/src/track/track_local/mod.rs
+++ b/webrtc/src/track/track_local/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use interceptor::{Attributes, RTPWriter};
 use portable_atomic::AtomicBool;
+use smol_str::SmolStr;
 use tokio::sync::Mutex;
 use util::Unmarshal;
 
@@ -38,6 +39,7 @@ pub struct TrackLocalContext {
     pub(crate) ssrc: SSRC,
     pub(crate) write_stream: Option<Arc<dyn TrackLocalWriter + Send + Sync>>,
     pub(crate) paused: Arc<AtomicBool>,
+    pub(crate) mid: Option<SmolStr>,
 }
 
 impl TrackLocalContext {
@@ -112,6 +114,7 @@ pub(crate) struct TrackBinding {
     params: RTCRtpParameters,
     write_stream: Option<Arc<dyn TrackLocalWriter + Send + Sync>>,
     sender_paused: Arc<AtomicBool>,
+    hdr_ext_ids: Vec<rtp::header::Extension>,
 }
 
 impl TrackBinding {

--- a/webrtc/src/track/track_local/track_local_static_rtp.rs
+++ b/webrtc/src/track/track_local/track_local_static_rtp.rs
@@ -14,16 +14,34 @@ pub struct TrackLocalStaticRTP {
     pub(crate) bindings: Mutex<Vec<Arc<TrackBinding>>>,
     codec: RTCRtpCodecCapability,
     id: String,
+    rid: Option<String>,
     stream_id: String,
 }
 
 impl TrackLocalStaticRTP {
-    /// returns a TrackLocalStaticRTP.
+    /// returns a TrackLocalStaticRTP without rid.
     pub fn new(codec: RTCRtpCodecCapability, id: String, stream_id: String) -> Self {
         TrackLocalStaticRTP {
             codec,
             bindings: Mutex::new(vec![]),
             id,
+            rid: None,
+            stream_id,
+        }
+    }
+
+    /// returns a TrackLocalStaticRTP with rid.
+    pub fn new_with_rid(
+        codec: RTCRtpCodecCapability,
+        id: String,
+        rid: String,
+        stream_id: String,
+    ) -> Self {
+        TrackLocalStaticRTP {
+            codec,
+            bindings: Mutex::new(vec![]),
+            id,
+            rid: Some(rid),
             stream_id,
         }
     }
@@ -188,6 +206,11 @@ impl TrackLocal for TrackLocalStaticRTP {
     /// and StreamID would be 'desktop' or 'webcam'
     fn id(&self) -> &str {
         self.id.as_str()
+    }
+
+    /// RID is the RTP Stream ID for this track.
+    fn rid(&self) -> Option<&str> {
+        self.rid.as_deref()
     }
 
     /// stream_id is the group this track belongs too. This must be unique

--- a/webrtc/src/track/track_local/track_local_static_rtp.rs
+++ b/webrtc/src/track/track_local/track_local_static_rtp.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use tokio::sync::Mutex;
 use util::{Marshal, MarshalSize};
 
@@ -117,6 +117,13 @@ impl TrackLocalStaticRTP {
             pkt.header.ssrc = b.ssrc;
             pkt.header.payload_type = b.payload_type;
 
+            for ext in b.hdr_ext_ids.iter() {
+                let payload = ext.payload.to_owned();
+                if let Err(err) = pkt.header.set_extension(ext.id, payload) {
+                    write_errs.push(Error::Rtp(err));
+                }
+            }
+
             for (uri, data) in extension_data.iter() {
                 if let Some(id) = b
                     .params
@@ -161,18 +168,45 @@ impl TrackLocal for TrackLocalStaticRTP {
             capability: self.codec.clone(),
             ..Default::default()
         };
+        let mut hdr_ext_ids = vec![];
+        if let Some(id) = t
+            .header_extensions()
+            .iter()
+            .find(|e| e.uri == ::sdp::extmap::SDES_MID_URI)
+            .map(|e| e.id as u8)
+        {
+            if let Some(payload) = t
+                .mid
+                .as_ref()
+                .map(|mid| Bytes::copy_from_slice(mid.as_bytes()))
+            {
+                hdr_ext_ids.push(rtp::header::Extension { id, payload });
+            }
+        }
+
+        if let Some(id) = t
+            .header_extensions()
+            .iter()
+            .find(|e| e.uri == ::sdp::extmap::SDES_RTP_STREAM_ID_URI)
+            .map(|e| e.id as u8)
+        {
+            if let Some(payload) = self.rid().map(|rid| rid.to_owned().into()) {
+                hdr_ext_ids.push(rtp::header::Extension { id, payload });
+            }
+        }
 
         let (codec, match_type) = codec_parameters_fuzzy_search(&parameters, t.codec_parameters());
         if match_type != CodecMatch::None {
             {
                 let mut bindings = self.bindings.lock().await;
                 bindings.push(Arc::new(TrackBinding {
+                    id: t.id(),
                     ssrc: t.ssrc(),
                     payload_type: codec.payload_type,
-                    write_stream: t.write_stream(),
                     params: t.params.clone(),
-                    id: t.id(),
+                    write_stream: t.write_stream(),
                     sender_paused: t.paused.clone(),
+                    hdr_ext_ids,
                 }));
             }
 

--- a/webrtc/src/track/track_local/track_local_static_sample.rs
+++ b/webrtc/src/track/track_local/track_local_static_sample.rs
@@ -24,9 +24,29 @@ pub struct TrackLocalStaticSample {
 }
 
 impl TrackLocalStaticSample {
-    /// returns a TrackLocalStaticSample
+    /// returns a TrackLocalStaticSample without RID
     pub fn new(codec: RTCRtpCodecCapability, id: String, stream_id: String) -> Self {
         let rtp_track = TrackLocalStaticRTP::new(codec, id, stream_id);
+
+        TrackLocalStaticSample {
+            rtp_track,
+            internal: Mutex::new(TrackLocalStaticSampleInternal {
+                packetizer: None,
+                sequencer: None,
+                clock_rate: 0.0f64,
+                did_warn_about_wonky_pause: false,
+            }),
+        }
+    }
+
+    /// returns a TrackLocalStaticSample with RID
+    pub fn new_with_rid(
+        codec: RTCRtpCodecCapability,
+        id: String,
+        rid: String,
+        stream_id: String,
+    ) -> Self {
+        let rtp_track = TrackLocalStaticRTP::new_with_rid(codec, id, rid, stream_id);
 
         TrackLocalStaticSample {
             rtp_track,
@@ -219,6 +239,11 @@ impl TrackLocal for TrackLocalStaticSample {
     /// and StreamID would be 'desktop' or 'webcam'
     fn id(&self) -> &str {
         self.rtp_track.id()
+    }
+
+    /// RID is the RTP Stream ID for this track.
+    fn rid(&self) -> Option<&str> {
+        self.rtp_track.rid()
     }
 
     /// stream_id is the group this track belongs too. This must be unique


### PR DESCRIPTION
Most of this is ported from different patches in pion related to send side simulcast.

First and foremost, a track can now be created with a specific RID, and `RtpSender::add_encoding()` is used for adding track encodings. Also, MID and RID RTP header extensions are automatically added when sending RTP/Samples on local tracks. All of this would only work if MID and RID header extensions are enabled/registered on media engine.