### PR TITLE
make helper methods on ProtectionProfile pub

### DIFF
--- a/srtp/src/protection_profile.rs
+++ b/srtp/src/protection_profile.rs
@@ -8,27 +8,27 @@ pub enum ProtectionProfile {
 }
 
 impl ProtectionProfile {
-    pub(crate) fn key_len(&self) -> usize {
+    pub fn key_len(&self) -> usize {
         match *self {
             ProtectionProfile::Aes128CmHmacSha1_80 | ProtectionProfile::AeadAes128Gcm => 16,
         }
     }
 
-    pub(crate) fn salt_len(&self) -> usize {
+    pub fn salt_len(&self) -> usize {
         match *self {
             ProtectionProfile::Aes128CmHmacSha1_80 => 14,
             ProtectionProfile::AeadAes128Gcm => 12,
         }
     }
 
-    pub(crate) fn auth_tag_len(&self) -> usize {
+    pub fn auth_tag_len(&self) -> usize {
         match *self {
             ProtectionProfile::Aes128CmHmacSha1_80 => 10, //CIPHER_AES_CM_HMAC_SHA1AUTH_TAG_LEN,
             ProtectionProfile::AeadAes128Gcm => 16,       //CIPHER_AEAD_AES_GCM_AUTH_TAG_LEN,
         }
     }
 
-    pub(crate) fn auth_key_len(&self) -> usize {
+    pub fn auth_key_len(&self) -> usize {
         match *self {
             ProtectionProfile::Aes128CmHmacSha1_80 => 20,
             ProtectionProfile::AeadAes128Gcm => 0,


### PR DESCRIPTION
I was looking at using the srtp code here in some code I'm playing with, but it's slightly awkward to use on its own (without the dtls code from webrtc-rs as well)--Is there any harm in making these methods public? It would make it easier to consume webrtc-rs/srtp as a standalone lib.  Specifically, I'd like to access them to write code for extracting keys from keying material.

EDIT: Making the `SessionKeys` type pub would also be useful.