### PR TITLE
peer_connection: sdp: Fix BUNDLE group matching

### DIFF
--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -829,6 +829,7 @@ impl PeerConnectionInternal {
                 .and_then(|d| d.parsed.as_ref())
                 .and_then(|d| d.attribute(ATTR_KEY_GROUP))
                 .map(ToOwned::to_owned)
+                .or(Some(String::new()))
         };
 
         let dtls_fingerprints = if let Some(cert) = self.dtls_transport.certificates.first() {


### PR DESCRIPTION
A minor bug in my last PR allowed an empty BUNDLE group attribute from offer to add all unmatched results into answer. The correct answer should not have any BUNDLE group either of course.