### PR TITLE
Fix build warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ members = [
 ]
 resolver = "2"
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [profile.dev]
 opt-level = 0

--- a/constraints/Cargo.toml
+++ b/constraints/Cargo.toml
@@ -20,6 +20,9 @@ env_logger = "0.10"
 lazy_static = "1"
 serde_json = { version = "1", features = ["preserve_order"] }
 
+[lints]
+workspace = true
+
 [features]
 default = ["serde"]
 serde = ["dep:serde", "indexmap/serde"]

--- a/constraints/src/algorithms/select_settings/select_optimal.rs
+++ b/constraints/src/algorithms/select_settings/select_optimal.rs
@@ -10,22 +10,7 @@ where
     for (candidate, fitness_distance) in candidates {
         use std::cmp::Ordering;
 
-        #[cfg(feature = "total_cmp")]
         let ordering = fitness_distance.total_cmp(&optimal_fitness_distance);
-
-        // TODO: remove fallback once MSRV has been bumped to 1.62 or later:
-        #[cfg(not(feature = "total_cmp"))]
-        let ordering = {
-            // See http://doc.rust-lang.org/1.65.0/core/primitive.f64.html#method.total_cmp:
-
-            let mut left = fitness_distance.to_bits() as i64;
-            let mut right = optimal_fitness_distance.to_bits() as i64;
-
-            left ^= (((left >> 63) as u64) >> 1) as i64;
-            right ^= (((right >> 63) as u64) >> 1) as i64;
-
-            left.cmp(&right)
-        };
 
         if ordering == Ordering::Less {
             // Candidate is new optimal, so drop current selection:

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -34,3 +34,6 @@ portable-atomic = "1.6"
 tokio-test = "0.4" # must match the min version of the `tokio` crate above
 env_logger = "0.10"
 chrono = "0.4.28"
+
+[lints]
+workspace = true

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -60,6 +60,9 @@ chrono = "0.4.28"
 clap = "3"
 hub = {path = "examples/hub"}
 
+[lints]
+workspace = true
+
 [features]
 pem = ["dep:pem"]
 

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -51,6 +51,9 @@ lazy_static = "1"
 hyper = { version = "0.14.27", features = ["full"] }
 sha1 = "0.10"
 
+[lints]
+workspace = true
+
 [[example]]
 name = "ping_pong"
 path = "examples/ping_pong.rs"

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -27,3 +27,6 @@ portable-atomic = "1.6"
 [dev-dependencies]
 tokio-test = "0.4"
 chrono = "0.4.28"
+
+[lints]
+workspace = true

--- a/mdns/Cargo.toml
+++ b/mdns/Cargo.toml
@@ -37,6 +37,9 @@ env_logger = "0.10"
 chrono = "0.4.28"
 clap = "3"
 
+[lints]
+workspace = true
+
 [[example]]
 name = "mdns_query"
 path = "examples/mdns_query.rs"

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -21,6 +21,9 @@ rand = "0.8"
 criterion = { version = "0.5", features = ["html_reports"] }
 nearly_eq = "0.2"
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "audio_buffer"
 harness = false

--- a/rtcp/Cargo.toml
+++ b/rtcp/Cargo.toml
@@ -14,3 +14,6 @@ util = { version = "0.9.0", path = "../util", package = "webrtc-util", default-f
 
 bytes = "1"
 thiserror = "1"
+
+[lints]
+workspace = true

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -24,6 +24,9 @@ memchr = "2.1.1"
 chrono = "0.4.28"
 criterion = "0.5"
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "packet_bench"
 harness = false

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -40,6 +40,9 @@ env_logger = "0.10"
 chrono = "0.4.28"
 clap = "3"
 
+[lints]
+workspace = true
+
 [[example]]
 name = "ping"
 path = "examples/ping.rs"

--- a/sdp/Cargo.toml
+++ b/sdp/Cargo.toml
@@ -18,6 +18,9 @@ substring = "1"
 [dev-dependencies]
 criterion = "0.5"
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "bench"
 harness = false

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -52,6 +52,9 @@ criterion = { version = "0.5", features = ["async_futures"] }
 tokio-test = "0.4"
 lazy_static = "1"
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "srtp_bench"
 harness = false

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -43,6 +43,8 @@ tokio-test = "0.4"
 clap = "3"
 criterion = "0.5"
 
+[lints]
+workspace = true
 
 [[bench]]
 name = "bench"

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -44,6 +44,9 @@ hex = "0.4"
 clap = "3"
 criterion = "0.5"
 
+[lints]
+workspace = true
+
 [features]
 metrics = []
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -61,6 +61,9 @@ chrono = "0.4.28"
 criterion = { version = "0.5", features = ["async_futures"] }
 async-global-executor = "2"
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "bench"
 harness = false

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -65,6 +65,9 @@ portable-atomic = "1.6"
 tokio-test = "0.4"
 env_logger = "0.10"
 
+[lints]
+workspace = true
+
 [features]
 pem = ["dep:pem", "dtls/pem"]
 openssl = ["srtp/openssl"]


### PR DESCRIPTION
* `cfg(fuzzing)` no longer trips up `unexpected_cfgs`
* Remove the check for `feature = "total_cmp"` since the feature no longer exists