### PR TITLE
Add spec links to public items

### DIFF
--- a/dtls/src/alert/mod.rs
+++ b/dtls/src/alert/mod.rs
@@ -144,7 +144,11 @@ impl From<u8> for AlertDescription {
 // preventing the failed session from being used to establish new
 // connections.  Like other messages, alert messages are encrypted and
 // compressed, as specified by the current connection state.
-// https://tools.ietf.org/html/rfc5246#section-7.2
+/// ## Specifications
+///
+/// * [RFC 5246 §7.2]
+///
+/// [RFC 5246 §7.2]: https://tools.ietf.org/html/rfc5246#section-7.2
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Alert {
     pub(crate) alert_level: AlertLevel,

--- a/dtls/src/application_data.rs
+++ b/dtls/src/application_data.rs
@@ -7,7 +7,11 @@ use crate::error::Result;
 // fragmented, compressed, and encrypted based on the current connection
 // state.  The messages are treated as transparent data to the record
 // layer.
-// https://tools.ietf.org/html/rfc5246#section-10
+/// ## Specifications
+///
+/// * [RFC 5246 §10]
+///
+/// [RFC 5246 §10]: https://tools.ietf.org/html/rfc5246#section-10
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ApplicationData {
     pub data: Vec<u8>,

--- a/dtls/src/change_cipher_spec/mod.rs
+++ b/dtls/src/change_cipher_spec/mod.rs
@@ -12,7 +12,11 @@ use super::error::*;
 // ciphering strategies.  The protocol consists of a single message,
 // which is encrypted and compressed under the current (not the pending)
 // connection state.  The message consists of a single byte of value 1.
-// https://tools.ietf.org/html/rfc5246#section-7.1
+/// ## Specifications
+///
+/// * [RFC 5246 §7.1]
+///
+/// [RFC 5246 §7.1]: https://tools.ietf.org/html/rfc5246#section-7.1
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ChangeCipherSpec;
 

--- a/dtls/src/content.rs
+++ b/dtls/src/content.rs
@@ -6,7 +6,11 @@ use super::change_cipher_spec::*;
 use super::handshake::*;
 use crate::error::*;
 
-// https://tools.ietf.org/html/rfc4346#section-6.2.1
+/// ## Specifications
+///
+/// * [RFC 4346 §6.2.1]
+///
+/// [RFC 4346 §6.2.1]: https://tools.ietf.org/html/rfc4346#section-6.2.1
 #[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ContentType {
     ChangeCipherSpec = 20,

--- a/dtls/src/extension/extension_supported_elliptic_curves.rs
+++ b/dtls/src/extension/extension_supported_elliptic_curves.rs
@@ -6,7 +6,11 @@ use crate::curve::named_curve::*;
 
 const EXTENSION_SUPPORTED_GROUPS_HEADER_SIZE: usize = 6;
 
-// https://tools.ietf.org/html/rfc8422#section-5.1.1
+/// ## Specifications
+///
+/// * [RFC 8422 §5.1.1]
+///
+/// [RFC 8422 §5.1.1]: https://tools.ietf.org/html/rfc8422#section-5.1.1
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionSupportedEllipticCurves {
     pub elliptic_curves: Vec<NamedCurve>,

--- a/dtls/src/extension/extension_supported_point_formats.rs
+++ b/dtls/src/extension/extension_supported_point_formats.rs
@@ -9,7 +9,11 @@ pub type EllipticCurvePointFormat = u8;
 
 pub const ELLIPTIC_CURVE_POINT_FORMAT_UNCOMPRESSED: EllipticCurvePointFormat = 0;
 
-// https://tools.ietf.org/html/rfc4492#section-5.1.2
+/// ## Specifications
+///
+/// * [RFC 4492 §5.1.2]
+///
+/// [RFC 4492 §5.1.2]: https://tools.ietf.org/html/rfc4492#section-5.1.2
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionSupportedPointFormats {
     pub(crate) point_formats: Vec<EllipticCurvePointFormat>,

--- a/dtls/src/extension/extension_supported_signature_algorithms.rs
+++ b/dtls/src/extension/extension_supported_signature_algorithms.rs
@@ -6,7 +6,11 @@ use crate::signature_hash_algorithm::*;
 
 const EXTENSION_SUPPORTED_SIGNATURE_ALGORITHMS_HEADER_SIZE: usize = 6;
 
-// https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+/// ## Specifications
+///
+/// * [RFC 5246 §7.4.1.4.1]
+///
+/// [RFC 5246 §7.4.1.4.1]: https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionSupportedSignatureAlgorithms {
     pub(crate) signature_hash_algorithms: Vec<SignatureHashAlgorithm>,

--- a/dtls/src/extension/extension_use_extended_master_secret.rs
+++ b/dtls/src/extension/extension_use_extended_master_secret.rs
@@ -5,7 +5,11 @@ use super::*;
 
 const EXTENSION_USE_EXTENDED_MASTER_SECRET_HEADER_SIZE: usize = 4;
 
-// https://tools.ietf.org/html/rfc8422
+/// ## Specifications
+///
+/// * [RFC 8422]
+///
+/// [RFC 8422]: https://tools.ietf.org/html/rfc8422
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionUseExtendedMasterSecret {
     pub(crate) supported: bool,

--- a/dtls/src/extension/extension_use_srtp.rs
+++ b/dtls/src/extension/extension_use_srtp.rs
@@ -4,7 +4,11 @@ mod extension_use_srtp_test;
 use super::*;
 
 // SRTPProtectionProfile defines the parameters and options that are in effect for the SRTP processing
-// https://tools.ietf.org/html/rfc5764#section-4.1.2
+/// ## Specifications
+///
+/// * [RFC 5764 §4.1.2]
+///
+/// [RFC 5764 §4.1.2]: https://tools.ietf.org/html/rfc5764#section-4.1.2
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SrtpProtectionProfile {
@@ -29,7 +33,11 @@ impl From<u16> for SrtpProtectionProfile {
 
 const EXTENSION_USE_SRTPHEADER_SIZE: usize = 6;
 
-// https://tools.ietf.org/html/rfc8422
+/// ## Specifications
+///
+/// * [RFC 8422]
+///
+/// [RFC 8422]: https://tools.ietf.org/html/rfc8422
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionUseSrtp {

--- a/dtls/src/extension/renegotiation_info.rs
+++ b/dtls/src/extension/renegotiation_info.rs
@@ -8,7 +8,12 @@ const RENEGOTIATION_INFO_HEADER_SIZE: usize = 5;
 
 /// RenegotiationInfo allows a Client/Server to
 /// communicate their renegotiation support
-/// https://tools.ietf.org/html/rfc5746
+///
+/// ## Specifications
+///
+/// * [RFC 5746]
+///
+/// [RFC 5746]: https://tools.ietf.org/html/rfc5746
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtensionRenegotiationInfo {
     pub(crate) renegotiated_connection: u8,

--- a/dtls/src/handshake/handshake_message_hello_verify_request.rs
+++ b/dtls/src/handshake/handshake_message_hello_verify_request.rs
@@ -22,9 +22,12 @@ use crate::record_layer::record_layer_header::*;
    MAY respond with a HelloVerifyRequest message.  This message contains
    a stateless cookie generated using the technique of [PHOTURIS].  The
    client MUST retransmit the ClientHello with the cookie added.
-
-   https://tools.ietf.org/html/rfc6347#section-4.2.1
 */
+/// ## Specifications
+///
+/// * [RFC 6347 §4.2.1]
+///
+/// [RFC 6347 §4.2.1]: https://tools.ietf.org/html/rfc6347#section-4.2.1
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HandshakeMessageHelloVerifyRequest {
     pub(crate) version: ProtocolVersion,

--- a/dtls/src/handshake/handshake_random.rs
+++ b/dtls/src/handshake/handshake_random.rs
@@ -7,7 +7,11 @@ use rand::Rng;
 pub const RANDOM_BYTES_LENGTH: usize = 28;
 pub const HANDSHAKE_RANDOM_LENGTH: usize = RANDOM_BYTES_LENGTH + 4;
 
-// https://tools.ietf.org/html/rfc4346#section-7.4.1.2
+/// ## Specifications
+///
+/// * [RFC 4346 §7.4.1.2]
+///
+/// [RFC 4346 §7.4.1.2]: https://tools.ietf.org/html/rfc4346#section-7.4.1.2
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HandshakeRandom {
     pub gmt_unix_time: SystemTime,

--- a/dtls/src/handshake/mod.rs
+++ b/dtls/src/handshake/mod.rs
@@ -33,7 +33,11 @@ use handshake_message_server_key_exchange::*;
 use super::content::*;
 use super::error::*;
 
-// https://tools.ietf.org/html/rfc5246#section-7.4
+/// ## Specifications
+///
+/// * [RFC 5246 §7.4]
+///
+/// [RFC 5246 §7.4]: https://tools.ietf.org/html/rfc5246#section-7.4
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum HandshakeType {
     HelloRequest = 0,

--- a/dtls/src/record_layer/mod.rs
+++ b/dtls/src/record_layer/mod.rs
@@ -28,8 +28,12 @@ use crate::handshake::Handshake;
  only change is the inclusion of an explicit sequence number in the
  record.  This sequence number allows the recipient to correctly
  verify the TLS MAC.
- https://tools.ietf.org/html/rfc4347#section-4.1
 */
+/// ## Specifications
+///
+/// * [RFC 4347 §4.1]
+///
+/// [RFC 4347 §4.1]: https://tools.ietf.org/html/rfc4347#section-4.1
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordLayer {
     pub record_layer_header: RecordLayerHeader,

--- a/dtls/src/record_layer/record_layer_header.rs
+++ b/dtls/src/record_layer/record_layer_header.rs
@@ -27,7 +27,11 @@ pub const PROTOCOL_VERSION1_2: ProtocolVersion = ProtocolVersion {
     minor: DTLS1_2MINOR,
 };
 
-// https://tools.ietf.org/html/rfc4346#section-6.2.1
+/// ## Specifications
+///
+/// * [RFC 4346 §6.2.1]
+///
+/// [RFC 4346 §6.2.1]: https://tools.ietf.org/html/rfc4346#section-6.2.1
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub struct ProtocolVersion {
     pub major: u8,

--- a/ice/src/tcp_type/mod.rs
+++ b/ice/src/tcp_type/mod.rs
@@ -3,8 +3,13 @@ mod tcp_type_test;
 
 use std::fmt;
 
-// TCPType is the type of ICE TCP candidate as described in
-// ttps://tools.ietf.org/html/rfc6544#section-4.5
+/// TCPType is the type of ICE TCP candidate
+///
+/// ## Specifications
+///
+/// * [RFC 6544 §4.5]
+///
+/// [RFC 6544 §4.5]: https://tools.ietf.org/html/rfc6544#section-4.5
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TcpType {
     /// The default value. For example UDP candidates do not need this field.

--- a/rtcp/src/payload_feedbacks/receiver_estimated_maximum_bitrate/mod.rs
+++ b/rtcp/src/payload_feedbacks/receiver_estimated_maximum_bitrate/mod.rs
@@ -15,7 +15,12 @@ use crate::util::*;
 type Result<T> = std::result::Result<T, util::Error>;
 
 /// ReceiverEstimatedMaximumBitrate contains the receiver's estimated maximum bitrate.
-/// see: https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03
+///
+/// ## Specifications
+///
+/// * [draft-alvestrand-rmcat-remb-03]
+///
+/// [draft-alvestrand-rmcat-remb-03]: https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct ReceiverEstimatedMaximumBitrate {
     /// SSRC of sender

--- a/rtcp/src/transport_feedbacks/transport_layer_cc/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_cc/mod.rs
@@ -14,7 +14,6 @@ use crate::util::*;
 
 type Result<T> = std::result::Result<T, util::Error>;
 
-/// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#page-5
 /// 0                   1                   2                   3
 /// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -40,9 +39,14 @@ type Result<T> = std::result::Result<T, util::Error>;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |           recv delta          |  recv delta   | zero padding  |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
 // for packet status chunk
 /// type of packet status chunk
+///
+/// ## Specifications
+///
+/// * [draft-holmer-rmcat-transport-wide-cc-extensions-01, page 5]
+///
+/// [draft-holmer-rmcat-transport-wide-cc-extensions-01, page 5]: https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01#page-5
 #[derive(Default, PartialEq, Eq, Debug, Clone)]
 #[repr(u16)]
 pub enum StatusChunkTypeTcc {

--- a/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
+++ b/rtcp/src/transport_feedbacks/transport_layer_nack/mod.rs
@@ -102,8 +102,11 @@ const TLN_LENGTH: usize = 2;
 const NACK_OFFSET: usize = 8;
 
 // The TransportLayerNack packet informs the encoder about the loss of a transport packet
-// IETF RFC 4585, Section 6.2.1
-// https://tools.ietf.org/html/rfc4585#section-6.2.1
+/// ## Specifications
+///
+/// * [RFC 4585 §6.2.1]
+///
+/// [RFC 4585 §6.2.1]: https://tools.ietf.org/html/rfc4585#section-6.2.1
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct TransportLayerNack {
     /// SSRC of sender

--- a/rtp/src/codecs/h265/mod.rs
+++ b/rtp/src/codecs/h265/mod.rs
@@ -244,12 +244,20 @@ const H265NALU_FRAGMENTATION_UNIT_TYPE: u8 = 49;
 const H265NALU_PACI_PACKET_TYPE: u8 = 50;
 
 /// H265NALUHeader is a H265 NAL Unit Header
-/// <https://datatracker.ietf.org/doc/html/rfc7798#section-1.1.4>
+///
+/// ```text
 /// +---------------+---------------+
-///  |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
-///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-///  |F|   Type    |  layer_id  | tid |
-///  +-------------+-----------------+
+/// |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |F|   Type    |  layer_id  | tid|
+/// +-------------+-----------------+
+/// ```
+///
+/// ## Specifications
+///
+/// * [RFC 7798 §1.1.4]
+///
+/// [RFC 7798 §1.1.4]: https://tools.ietf.org/html/rfc7798#section-1.1.4
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct H265NALUHeader(pub u16);
 
@@ -322,7 +330,11 @@ impl H265NALUHeader {
 ///   |                               :...OPTIONAL RTP padding        |
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.1>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.1]
+///
+/// [RFC 7798 §4.4.1]: https://tools.ietf.org/html/rfc7798#section-4.4.1
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265SingleNALUnitPacket {
     /// payload_header is the header of the H265 packet.
@@ -411,7 +423,11 @@ impl H265SingleNALUnitPacket {
 ///   |                               :
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.2]
+///
+/// [RFC 7798 §4.4.2]: https://tools.ietf.org/html/rfc7798#section-4.4.2
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265AggregationUnitFirst {
     donl: Option<u16>,
@@ -451,7 +467,11 @@ impl H265AggregationUnitFirst {
 ///   |                               :
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.2]
+///
+/// [RFC 7798 §4.4.2]: https://tools.ietf.org/html/rfc7798#section-4.4.2
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265AggregationUnit {
     dond: Option<u8>,
@@ -491,7 +511,11 @@ impl H265AggregationUnit {
 ///   |                               :...OPTIONAL RTP padding        |
 ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.2]
+///
+/// [RFC 7798 §4.4.2]: https://tools.ietf.org/html/rfc7798#section-4.4.2
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265AggregationPacket {
     first_unit: Option<H265AggregationUnitFirst>,
@@ -650,7 +674,11 @@ impl H265FragmentationUnitHeader {
 /// |                               :...OPTIONAL RTP padding        |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.3>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.3]
+///
+/// [RFC 7798 §4.4.3]: https://tools.ietf.org/html/rfc7798#section-4.4.3
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265FragmentationUnitPacket {
     /// payload_header is the header of the H265 packet.
@@ -749,7 +777,11 @@ impl H265FragmentationUnitPacket {
 /// |                               :...OPTIONAL RTP padding        |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.4>
+/// ## Specifications
+///
+/// * [RFC 7798 §4.4.4]
+///
+/// [RFC 7798 §4.4.4]: https://tools.ietf.org/html/rfc7798#section-4.4.4
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct H265PACIPacket {
     /// payload_header is the header of the H265 packet.
@@ -878,7 +910,12 @@ impl H265PACIPacket {
 ///
 
 /// H265TSCI is a Temporal Scalability Control Information header extension.
-/// Reference: <https://datatracker.ietf.org/doc/html/rfc7798#section-4.5>
+///
+/// ## Specifications
+///
+/// * [RFC 7798 §4.5]
+///
+/// [RFC 7798 §4.5]: https://tools.ietf.org/html/rfc7798#section-4.5
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct H265TSCI(pub u32);
 

--- a/rtp/src/extension/audio_level_extension/mod.rs
+++ b/rtp/src/extension/audio_level_extension/mod.rs
@@ -11,7 +11,6 @@ use crate::error::Error;
 pub const AUDIO_LEVEL_EXTENSION_SIZE: usize = 1;
 
 /// AudioLevelExtension is a extension payload format described in
-/// https://tools.ietf.org/html/rfc6464
 ///
 /// Implementation based on:
 /// https://chromium.googlesource.com/external/webrtc/+/e2a017725570ead5946a4ca8235af27470ca0df9/webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc#49
@@ -29,6 +28,12 @@ pub const AUDIO_LEVEL_EXTENSION_SIZE: usize = 1;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |      ID       |     len=1     |V|    level    |    0 (pad)    |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+/// ## Specifications
+///
+/// * [RFC 6464]
+///
+/// [RFC 6464]: https://tools.ietf.org/html/rfc6464
 #[derive(PartialEq, Eq, Debug, Default, Copy, Clone, Serialize, Deserialize)]
 pub struct AudioLevelExtension {
     pub level: u8,

--- a/sctp/src/chunk/chunk_init.rs
+++ b/sctp/src/chunk/chunk_init.rs
@@ -129,22 +129,26 @@ impl Chunk for ChunkInit {
         }
     }
 
-    ///https://tools.ietf.org/html/rfc4960#section-3.2.1
+    /// Chunk values of SCTP control chunks consist of a chunk-type-specific
+    /// header of required fields, followed by zero or more parameters.  The
+    /// optional and variable-length parameters contained in a chunk are
+    /// defined in a Type-Length-Value format as shown below.
     ///
-    ///Chunk values of SCTP control chunks consist of a chunk-type-specific
-    ///header of required fields, followed by zero or more parameters.  The
-    ///optional and variable-length parameters contained in a chunk are
-    ///defined in a Type-Length-Value format as shown below.
+    /// 0                   1                   2                   3
+    /// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    /// |          Parameter Type       |       Parameter Length        |
+    /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    /// |                                                               |
+    /// |                       Parameter Value                         |
+    /// |                                                               |
+    /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     ///
-    ///0                   1                   2                   3
-    ///0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    ///|          Parameter Type       |       Parameter Length        |
-    ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    ///|                                                               |
-    ///|                       Parameter Value                         |
-    ///|                                                               |
-    ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    /// ## Specifications
+    ///
+    /// * [RFC 4960 §3.2.1]
+    ///
+    /// [RFC 4960 §3.2.1]: https://tools.ietf.org/html/rfc4960#section-3.2.1
     fn unmarshal(raw: &Bytes) -> Result<Self> {
         let header = ChunkHeader::unmarshal(raw)?;
 

--- a/sctp/src/packet.rs
+++ b/sctp/src/packet.rs
@@ -22,9 +22,10 @@ use crate::chunk::Chunk;
 use crate::error::{Error, Result};
 use crate::util::*;
 
-///Packet represents an SCTP packet, defined in https://tools.ietf.org/html/rfc4960#section-3
-///An SCTP packet is composed of a common header and chunks.  A chunk
-///contains either control information or user data.
+/// Packet represents an SCTP packet
+///
+/// An SCTP packet is composed of a common header and chunks.  A chunk
+/// contains either control information or user data.
 ///
 ///
 ///SCTP Packet Format
@@ -52,6 +53,12 @@ use crate::util::*;
 ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ///|                           Checksum                            |
 ///+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+/// ## Specifications
+///
+/// * [RFC 4960 §3]
+///
+/// [RFC 4960 §3]: https://tools.ietf.org/html/rfc4960#section-3
 #[derive(Default, Debug)]
 pub(crate) struct Packet {
     pub(crate) source_port: u16,

--- a/sdp/src/description/media.rs
+++ b/sdp/src/description/media.rs
@@ -21,7 +21,12 @@ fn ext_map_uri() -> HashMap<isize, &'static str> {
 }
 
 /// MediaDescription represents a media type.
-/// <https://tools.ietf.org/html/rfc4566#section-5.14>
+///
+/// ## Specifications
+///
+/// * [RFC 4566 §5.14]
+///
+/// [RFC 4566 §5.14]: https://tools.ietf.org/html/rfc4566#section-5.14
 #[derive(Debug, Default, Clone)]
 pub struct MediaDescription {
     /// `m=<media> <port>/<number of ports> <proto> <fmt> ...`

--- a/webrtc/src/data_channel/data_channel_init.rs
+++ b/webrtc/src/data_channel/data_channel_init.rs
@@ -1,5 +1,11 @@
 /// DataChannelConfig can be used to configure properties of the underlying
 /// channel such as data reliability.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit
 #[derive(Default, Debug, Clone)]
 pub struct RTCDataChannelInit {
     /// ordered indicates if data is allowed to be delivered out of order. The

--- a/webrtc/src/data_channel/data_channel_state.rs
+++ b/webrtc/src/data_channel/data_channel_state.rs
@@ -3,6 +3,14 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// DataChannelState indicates the state of a data channel.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/readyState
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelstate
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RTCDataChannelState {
     #[serde(rename = "unspecified")]

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -47,6 +47,14 @@ pub type OnCloseHdlrFn =
 /// DataChannel represents a WebRTC DataChannel
 /// The DataChannel interface represents a network channel
 /// which can be used for bidirectional peer-to-peer transfers of arbitrary data
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel
 #[derive(Default)]
 pub struct RTCDataChannel {
     pub(crate) stats_id: String,

--- a/webrtc/src/dtls_transport/dtls_fingerprint.rs
+++ b/webrtc/src/dtls_transport/dtls_fingerprint.rs
@@ -1,7 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 /// DTLSFingerprint specifies the hash function algorithm and certificate
-/// fingerprint as described in <https://tools.ietf.org/html/rfc4572>.
+/// fingerprint as described in [RFC 4572].
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcdtlsfingerprint
+/// [RFC 4572]: https://tools.ietf.org/html/rfc4572
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RTCDtlsFingerprint {
     /// Algorithm specifies one of the the hash function algorithms defined in

--- a/webrtc/src/dtls_transport/dtls_transport_state.rs
+++ b/webrtc/src/dtls_transport/dtls_transport_state.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 
 /// DTLSTransportState indicates the DTLS transport establishment state.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/state
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcdtlstransportstate
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCDtlsTransportState {
     #[default]

--- a/webrtc/src/ice_transport/ice_candidate.rs
+++ b/webrtc/src/ice_transport/ice_candidate.rs
@@ -14,6 +14,14 @@ use crate::ice_transport::ice_candidate_type::RTCIceCandidateType;
 use crate::ice_transport::ice_protocol::RTCIceProtocol;
 
 /// ICECandidate represents a ice candidate
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RTCIceCandidate {
     pub stats_id: String,

--- a/webrtc/src/ice_transport/ice_candidate_pair.rs
+++ b/webrtc/src/ice_transport/ice_candidate_pair.rs
@@ -3,6 +3,12 @@ use std::fmt;
 use crate::ice_transport::ice_candidate::*;
 
 /// ICECandidatePair represents an ICE Candidate pair
+///
+/// ## Specifications
+///
+/// * [MDN]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePair
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCIceCandidatePair {
     stats_id: String,

--- a/webrtc/src/ice_transport/ice_candidate_type.rs
+++ b/webrtc/src/ice_transport/ice_candidate_type.rs
@@ -4,6 +4,14 @@ use ice::candidate::CandidateType;
 use serde::{Deserialize, Serialize};
 
 /// ICECandidateType represents the type of the ICE candidate used.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateStats/candidateType
+/// [W3C]: https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatestats-candidatetype
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RTCIceCandidateType {
     #[default]

--- a/webrtc/src/ice_transport/ice_connection_state.rs
+++ b/webrtc/src/ice_transport/ice_connection_state.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 
 /// RTCIceConnectionState indicates signaling state of the ICE Connection.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-peerconnection-ice-connection-state
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceConnectionState {
     #[default]

--- a/webrtc/src/ice_transport/ice_gatherer_state.rs
+++ b/webrtc/src/ice_transport/ice_gatherer_state.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 
 /// ICEGathererState represents the current state of the ICE gatherer.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcicegathererstate
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceGathererState {
     #[default]

--- a/webrtc/src/ice_transport/ice_gathering_state.rs
+++ b/webrtc/src/ice_transport/ice_gathering_state.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 
 /// ICEGatheringState describes the state of the candidate gathering process.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-peerconnection-ice-gathering-state
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceGatheringState {
     #[default]

--- a/webrtc/src/ice_transport/ice_parameters.rs
+++ b/webrtc/src/ice_transport/ice_parameters.rs
@@ -2,6 +2,14 @@ use serde::{Deserialize, Serialize};
 
 /// ICEParameters includes the ICE username fragment
 /// and password and other ICE-related parameters.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceParameters
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtciceparameters
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RTCIceParameters {
     pub username_fragment: String,

--- a/webrtc/src/ice_transport/ice_protocol.rs
+++ b/webrtc/src/ice_transport/ice_protocol.rs
@@ -4,6 +4,14 @@ use serde::{Deserialize, Serialize};
 
 /// ICEProtocol indicates the transport protocol type that is used in the
 /// ice.URL structure.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/protocol
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtciceprotocol-enum
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RTCIceProtocol {
     #[default]

--- a/webrtc/src/ice_transport/ice_role.rs
+++ b/webrtc/src/ice_transport/ice_role.rs
@@ -2,6 +2,14 @@ use std::fmt;
 
 /// ICERole describes the role ice.Agent is playing in selecting the
 /// preferred the candidate pair.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceTransport/role
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcicerole
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceRole {
     #[default]

--- a/webrtc/src/ice_transport/ice_server.rs
+++ b/webrtc/src/ice_transport/ice_server.rs
@@ -4,6 +4,12 @@ use crate::error::{Error, Result};
 
 /// ICEServer describes a single STUN and TURN server that can be used by
 /// the ICEAgent to establish a connection with a peer.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtciceserver
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RTCIceServer {
     pub urls: Vec<String>,

--- a/webrtc/src/ice_transport/ice_transport_state.rs
+++ b/webrtc/src/ice_transport/ice_transport_state.rs
@@ -3,6 +3,14 @@ use std::fmt;
 use ice::state::ConnectionState;
 
 /// ICETransportState represents the current state of the ICE transport.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceTransport/state
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcicetransportstate
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCIceTransportState {
     #[default]

--- a/webrtc/src/peer_connection/certificate.rs
+++ b/webrtc/src/peer_connection/certificate.rs
@@ -15,6 +15,14 @@ use crate::stats::stats_collector::StatsCollector;
 use crate::stats::{CertificateStats, StatsReportType};
 
 /// Certificate represents a X.509 certificate used to authenticate WebRTC communications.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCCertificate
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtccertificate
 #[derive(Clone, Debug)]
 pub struct RTCCertificate {
     /// DTLS certificate.

--- a/webrtc/src/peer_connection/configuration.rs
+++ b/webrtc/src/peer_connection/configuration.rs
@@ -9,6 +9,12 @@ use crate::peer_connection::policy::rtcp_mux_policy::RTCRtcpMuxPolicy;
 /// Configurations may be set up once and reused across multiple connections.
 /// Configurations are treated as readonly. As long as they are unmodified,
 /// they are safe for concurrent use.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcconfiguration-dictionary
 #[derive(Default, Clone)]
 pub struct RTCConfiguration {
     /// iceservers defines a slice describing servers available to be used by

--- a/webrtc/src/peer_connection/offer_answer_options.rs
+++ b/webrtc/src/peer_connection/offer_answer_options.rs
@@ -9,6 +9,12 @@ pub struct RTCAnswerOptions {
 
 /// OfferOptions structure describes the options used to control the offer
 /// creation process
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dictionary-rtcofferoptions-members
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct RTCOfferOptions {
     /// voice_activity_detection allows the application to provide information

--- a/webrtc/src/peer_connection/peer_connection_state.rs
+++ b/webrtc/src/peer_connection/peer_connection_state.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 
 /// PeerConnectionState indicates the state of the PeerConnection.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-peerconnection-connection-state
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCPeerConnectionState {
     #[default]

--- a/webrtc/src/peer_connection/policy/bundle_policy.rs
+++ b/webrtc/src/peer_connection/policy/bundle_policy.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 /// endpoint is not bundle-aware, and what ICE candidates are gathered. If the
 /// remote endpoint is bundle-aware, all media tracks and data channels are
 /// bundled onto the same transport.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcbundlepolicy-enum
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCBundlePolicy {
     #[default]

--- a/webrtc/src/peer_connection/policy/ice_transport_policy.rs
+++ b/webrtc/src/peer_connection/policy/ice_transport_policy.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Serialize};
 
 /// ICETransportPolicy defines the ICE candidate policy surface the
 /// permitted candidates. Only these candidates are used for connectivity checks.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcicetransportpolicy-enum
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCIceTransportPolicy {
     #[default]

--- a/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
+++ b/webrtc/src/peer_connection/policy/rtcp_mux_policy.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Serialize};
 
 /// RTCPMuxPolicy affects what ICE candidates are gathered to support
 /// non-multiplexed RTCP.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcrtcpmuxpolicy-enum
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCRtcpMuxPolicy {
     #[default]

--- a/webrtc/src/peer_connection/sdp/sdp_type.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_type.rs
@@ -3,6 +3,14 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 /// SDPType describes the type of an SessionDescription.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/type
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-type
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RTCSdpType {
     #[default]

--- a/webrtc/src/peer_connection/sdp/session_description.rs
+++ b/webrtc/src/peer_connection/sdp/session_description.rs
@@ -7,6 +7,14 @@ use super::sdp_type::RTCSdpType;
 use crate::error::Result;
 
 /// SessionDescription is used to expose local and remote session descriptions.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcsessiondescription-class
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RTCSessionDescription {
     #[serde(rename = "type")]

--- a/webrtc/src/peer_connection/signaling_state.rs
+++ b/webrtc/src/peer_connection/signaling_state.rs
@@ -21,6 +21,14 @@ impl fmt::Display for StateChangeOp {
 }
 
 /// SignalingState indicates the signaling state of the offer/answer process.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/signalingState
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-peerconnection-signaling-state
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCSignalingState {
     #[default]

--- a/webrtc/src/rtp_transceiver/rtp_codec.rs
+++ b/webrtc/src/rtp_transceiver/rtp_codec.rs
@@ -50,7 +50,12 @@ impl fmt::Display for RTPCodecType {
 }
 
 /// RTPCodecCapability provides information about codec capabilities.
-/// <https://w3c.github.io/webrtc-pc/#dictionary-rtcrtpcodeccapability-members>
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dictionary-rtcrtpcodeccapability-members
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RTCRtpCodecCapability {
     pub mime_type: String,

--- a/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -391,6 +391,14 @@ impl RTPReceiverInternal {
 }
 
 /// RTPReceiver allows an application to inspect the receipt of a TrackRemote
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcrtpreceiver-interface
 pub struct RTCRtpReceiver {
     receive_mtu: usize,
     kind: RTPCodecType,

--- a/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/mod.rs
@@ -42,6 +42,14 @@ pub(crate) struct TrackEncoding {
 }
 
 /// RTPSender allows an application to control how a given Track is encoded and transmitted to a remote peer
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcrtpsender-interface
 pub struct RTCRtpSender {
     pub(crate) track_encodings: Mutex<Vec<TrackEncoding>>,
 

--- a/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
+++ b/webrtc/src/rtp_transceiver/rtp_transceiver_direction.rs
@@ -1,6 +1,14 @@
 use std::fmt;
 
 /// RTPTransceiverDirection indicates the direction of the RTPTransceiver.
+///
+/// ## Specifications
+///
+/// * [MDN]
+/// * [W3C]
+///
+/// [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/direction
+/// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RTCRtpTransceiverDirection {
     Unspecified,

--- a/webrtc/src/sctp_transport/sctp_transport_state.rs
+++ b/webrtc/src/sctp_transport/sctp_transport_state.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 
 /// SCTPTransportState indicates the state of the SCTP transport.
+///
+/// ## Specifications
+///
+/// * [W3C]
+///
+/// [W3C]: https://w3c.github.io/webrtc-pc/#rtcsctptransportstate
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RTCSctpTransportState {


### PR DESCRIPTION
This adds a `Specifications` section to a bunch of public items, linking to MDN, W3C, and RFCs.

This doesn't cover all public items, but it is a good start, since #55 is still in progress.