### PR TITLE
#426 - add optional loopback support

### DIFF
--- a/ice/src/agent/agent_config.rs
+++ b/ice/src/agent/agent_config.rs
@@ -152,6 +152,9 @@ pub struct AgentConfig {
     /// Controls if self-signed certificates are accepted when connecting to TURN servers via TLS or
     /// DTLS.
     pub insecure_skip_verify: bool,
+
+    /// Include loopback addresses in the candidate list.
+    pub include_loopback: bool,
 }
 
 impl AgentConfig {

--- a/ice/src/agent/agent_gather_test.rs
+++ b/ice/src/agent/agent_gather_test.rs
@@ -24,6 +24,7 @@ async fn test_vnet_gather_no_local_ip_address() -> Result<()> {
         &a.interface_filter,
         &a.ip_filter,
         &[NetworkType::Udp4],
+        false,
     )
     .await;
     assert!(local_ips.is_empty(), "should return no local IP");
@@ -51,8 +52,14 @@ async fn test_vnet_gather_dynamic_ip_address() -> Result<()> {
     })
     .await?;
 
-    let local_ips =
-        local_interfaces(&nw, &a.interface_filter, &a.ip_filter, &[NetworkType::Udp4]).await;
+    let local_ips = local_interfaces(
+        &nw,
+        &a.interface_filter,
+        &a.ip_filter,
+        &[NetworkType::Udp4],
+        false,
+    )
+    .await;
     assert!(!local_ips.is_empty(), "should have one local IP");
 
     for ip in &local_ips {
@@ -85,8 +92,14 @@ async fn test_vnet_gather_listen_udp() -> Result<()> {
     })
     .await?;
 
-    let local_ips =
-        local_interfaces(&nw, &a.interface_filter, &a.ip_filter, &[NetworkType::Udp4]).await;
+    let local_ips = local_interfaces(
+        &nw,
+        &a.interface_filter,
+        &a.ip_filter,
+        &[NetworkType::Udp4],
+        false,
+    )
+    .await;
     assert!(!local_ips.is_empty(), "should have one local IP");
 
     for ip in local_ips {
@@ -340,8 +353,14 @@ async fn test_vnet_gather_with_interface_filter() -> Result<()> {
         })
         .await?;
 
-        let local_ips =
-            local_interfaces(&nw, &a.interface_filter, &a.ip_filter, &[NetworkType::Udp4]).await;
+        let local_ips = local_interfaces(
+            &nw,
+            &a.interface_filter,
+            &a.ip_filter,
+            &[NetworkType::Udp4],
+            false,
+        )
+        .await;
         assert!(
             local_ips.is_empty(),
             "InterfaceFilter should have excluded everything"
@@ -361,8 +380,14 @@ async fn test_vnet_gather_with_interface_filter() -> Result<()> {
         })
         .await?;
 
-        let local_ips =
-            local_interfaces(&nw, &a.interface_filter, &a.ip_filter, &[NetworkType::Udp4]).await;
+        let local_ips = local_interfaces(
+            &nw,
+            &a.interface_filter,
+            &a.ip_filter,
+            &[NetworkType::Udp4],
+            false,
+        )
+        .await;
         assert_eq!(
             local_ips.len(),
             1,

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -104,6 +104,7 @@ pub struct Agent {
 
     pub(crate) udp_network: UDPNetwork,
     pub(crate) interface_filter: Arc<Option<InterfaceFilterFn>>,
+    pub(crate) include_loopback: bool,
     pub(crate) ip_filter: Arc<Option<IpFilterFn>>,
     pub(crate) mdns_mode: MulticastDnsMode,
     pub(crate) mdns_name: String,
@@ -200,6 +201,7 @@ impl Agent {
             udp_network: config.udp_network,
             internal: Arc::new(ai),
             interface_filter: Arc::clone(&config.interface_filter),
+            include_loopback: config.include_loopback,
             ip_filter: Arc::clone(&config.ip_filter),
             mdns_mode,
             mdns_name,
@@ -465,6 +467,7 @@ impl Agent {
             agent_internal: Arc::clone(&self.internal),
             gathering_state: Arc::clone(&self.gathering_state),
             chan_candidate_tx: Arc::clone(&self.internal.chan_candidate_tx),
+            include_loopback: self.include_loopback,
         };
         tokio::spawn(async move {
             Self::gather_candidates_internal(params).await;

--- a/ice/src/util/mod.rs
+++ b/ice/src/util/mod.rs
@@ -99,6 +99,7 @@ pub async fn local_interfaces(
     interface_filter: &Option<InterfaceFilterFn>,
     ip_filter: &Option<IpFilterFn>,
     network_types: &[NetworkType],
+    include_loopback: bool,
 ) -> HashSet<IpAddr> {
     let mut ips = HashSet::new();
     let interfaces = vnet.get_interfaces().await;
@@ -123,7 +124,7 @@ pub async fn local_interfaces(
         for ipnet in iface.addrs() {
             let ipaddr = ipnet.addr();
 
-            if !ipaddr.is_loopback()
+            if (!ipaddr.is_loopback() || include_loopback)
                 && ((ipv4requested && ipaddr.is_ipv4()) || (ipv6requested && ipaddr.is_ipv6()))
                 && ip_filter
                     .as_ref()

--- a/ice/src/util/util_test.rs
+++ b/ice/src/util/util_test.rs
@@ -4,7 +4,31 @@ use super::*;
 async fn test_local_interfaces() -> Result<()> {
     let vnet = Arc::new(Net::new(None));
     let interfaces = vnet.get_interfaces().await;
-    let ips = local_interfaces(&vnet, &None, &None, &[NetworkType::Udp4, NetworkType::Udp6]).await;
-    log::info!("interfaces: {:?}, ips: {:?}", interfaces, ips);
+    let ips = local_interfaces(
+        &vnet,
+        &None,
+        &None,
+        &[NetworkType::Udp4, NetworkType::Udp6],
+        false,
+    )
+    .await;
+
+    let ips_with_loopback = local_interfaces(
+        &vnet,
+        &None,
+        &None,
+        &[NetworkType::Udp4, NetworkType::Udp6],
+        true,
+    )
+    .await;
+    assert!(ips_with_loopback.is_superset(&ips));
+    assert!(!ips.iter().any(|ip| ip.is_loopback()));
+    assert!(ips_with_loopback.iter().any(|ip| ip.is_loopback()));
+    log::info!(
+        "interfaces: {:?}, ips: {:?}, ips_with_loopback: {:?}",
+        interfaces,
+        ips,
+        ips_with_loopback
+    );
     Ok(())
 }

--- a/webrtc/src/api/setting_engine/mod.rs
+++ b/webrtc/src/api/setting_engine/mod.rs
@@ -44,6 +44,7 @@ pub struct Candidates {
     pub multicast_dns_host_name: String,
     pub username_fragment: String,
     pub password: String,
+    pub include_loopback_candidate: bool,
 }
 
 #[derive(Default, Clone)]
@@ -277,6 +278,15 @@ impl SettingEngine {
     /// disable_srtcp_replay_protection disables srtcp replay protection.
     pub fn disable_srtcp_replay_protection(&mut self, is_disabled: bool) {
         self.disable_srtcp_replay_protection = is_disabled;
+    }
+
+    /// set_include_loopback_candidate enables webrtc-rs to gather loopback candidates, it is
+    /// useful for, e.g., some VMs that have public IP mapped to loopback interface.
+    /// Note that allowing loopback candidates to be gathered is technically inconsistent with the
+    /// webRTC spec (see https://www.rfc-editor.org/rfc/rfc8445#section-5.1.1.1). This option is
+    /// therefore disabled by default, and should be used with caution.
+    pub fn set_include_loopback_candidate(&mut self, allow_loopback: bool) {
+        self.candidates.include_loopback_candidate = allow_loopback;
     }
 
     /// set_sdp_media_level_fingerprints configures the logic for dtls_transport Fingerprint insertion

--- a/webrtc/src/ice_transport/ice_gatherer.rs
+++ b/webrtc/src/ice_transport/ice_gatherer.rs
@@ -122,6 +122,7 @@ impl RTCIceGatherer {
             ip_filter: self.setting_engine.candidates.ip_filter.clone(),
             nat_1to1_ips: self.setting_engine.candidates.nat_1to1_ips.clone(),
             nat_1to1_ip_candidate_type: nat_1to1_cand_type,
+            include_loopback: self.setting_engine.candidates.include_loopback_candidate,
             net: self.setting_engine.vnet.clone(),
             multicast_dns_mode: mdns_mode,
             multicast_dns_host_name: self


### PR DESCRIPTION
Provides optional support for gathering loopback IPs as ICE candidates. Addresses #426.

Modeled on pion commit https://github.com/pion/ice/pull/497