### PR TITLE
webrtc: Add support for unordered unreliable data channels

### DIFF
--- a/webrtc/src/data_channel/data_channel_parameters.rs
+++ b/webrtc/src/data_channel/data_channel_parameters.rs
@@ -6,7 +6,7 @@ pub struct DataChannelParameters {
     pub label: String,
     pub protocol: String,
     pub ordered: bool,
-    pub max_packet_life_time: u16,
-    pub max_retransmits: u16,
+    pub max_packet_life_time: Option<u16>,
+    pub max_retransmits: Option<u16>,
     pub negotiated: Option<u16>,
 }

--- a/webrtc/src/data_channel/mod.rs
+++ b/webrtc/src/data_channel/mod.rs
@@ -60,8 +60,8 @@ pub struct RTCDataChannel {
     pub(crate) stats_id: String,
     pub(crate) label: String,
     pub(crate) ordered: bool,
-    pub(crate) max_packet_lifetime: u16,
-    pub(crate) max_retransmits: u16,
+    pub(crate) max_packet_lifetime: Option<u16>,
+    pub(crate) max_retransmits: Option<u16>,
     pub(crate) protocol: String,
     pub(crate) negotiated: bool,
     pub(crate) id: AtomicU16,
@@ -137,26 +137,32 @@ impl RTCDataChannel {
             let channel_type;
             let reliability_parameter;
 
-            if self.max_packet_lifetime == 0 && self.max_retransmits == 0 {
-                reliability_parameter = 0u32;
-                if self.ordered {
-                    channel_type = ChannelType::Reliable;
-                } else {
-                    channel_type = ChannelType::ReliableUnordered;
+            match (self.max_retransmits, self.max_packet_lifetime) {
+                (None, None) => {
+                    reliability_parameter = 0u32;
+                    if self.ordered {
+                        channel_type = ChannelType::Reliable;
+                    } else {
+                        channel_type = ChannelType::ReliableUnordered;
+                    }
                 }
-            } else if self.max_retransmits != 0 {
-                reliability_parameter = self.max_retransmits as u32;
-                if self.ordered {
-                    channel_type = ChannelType::PartialReliableRexmit;
-                } else {
-                    channel_type = ChannelType::PartialReliableRexmitUnordered;
+
+                (Some(max_retransmits), _) => {
+                    reliability_parameter = max_retransmits as u32;
+                    if self.ordered {
+                        channel_type = ChannelType::PartialReliableRexmit;
+                    } else {
+                        channel_type = ChannelType::PartialReliableRexmitUnordered;
+                    }
                 }
-            } else {
-                reliability_parameter = self.max_packet_lifetime as u32;
-                if self.ordered {
-                    channel_type = ChannelType::PartialReliableTimed;
-                } else {
-                    channel_type = ChannelType::PartialReliableTimedUnordered;
+
+                (None, Some(max_packet_lifetime)) => {
+                    reliability_parameter = max_packet_lifetime as u32;
+                    if self.ordered {
+                        channel_type = ChannelType::PartialReliableTimed;
+                    } else {
+                        channel_type = ChannelType::PartialReliableTimedUnordered;
+                    }
                 }
             }
 
@@ -454,13 +460,13 @@ impl RTCDataChannel {
 
     /// max_packet_lifetime represents the length of the time window (msec) during
     /// which transmissions and retransmissions may occur in unreliable mode.
-    pub fn max_packet_lifetime(&self) -> u16 {
+    pub fn max_packet_lifetime(&self) -> Option<u16> {
         self.max_packet_lifetime
     }
 
     /// max_retransmits represents the maximum number of retransmissions that are
     /// attempted in unreliable mode.
-    pub fn max_retransmits(&self) -> u16 {
+    pub fn max_retransmits(&self) -> Option<u16> {
         self.max_retransmits
     }
 

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -1849,14 +1849,10 @@ impl RTCPeerConnection {
             }
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #7)
-            if let Some(max_packet_life_time) = options.max_packet_life_time {
-                params.max_packet_life_time = max_packet_life_time;
-            }
+            params.max_packet_life_time = options.max_packet_life_time;
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #8)
-            if let Some(max_retransmits) = options.max_retransmits {
-                params.max_retransmits = max_retransmits;
-            }
+            params.max_retransmits = options.max_retransmits;
 
             // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #10)
             if let Some(protocol) = options.protocol {
@@ -1878,7 +1874,7 @@ impl RTCPeerConnection {
         ));
 
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #16)
-        if d.max_packet_lifetime != 0 && d.max_retransmits != 0 {
+        if d.max_packet_lifetime.is_some() && d.max_retransmits.is_some() {
             return Err(Error::ErrRetransmitsOrPacketLifeTime);
         }
 

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -244,8 +244,8 @@ impl RTCSctpTransport {
                 }
             };
 
-            let mut max_retransmits = 0;
-            let mut max_packet_lifetime = 0;
+            let mut max_retransmits = None;
+            let mut max_packet_life_time = None;
             let val = dc.config.reliability_parameter as u16;
             let ordered;
 
@@ -258,19 +258,19 @@ impl RTCSctpTransport {
                 }
                 ChannelType::PartialReliableRexmit => {
                     ordered = true;
-                    max_retransmits = val;
+                    max_retransmits = Some(val);
                 }
                 ChannelType::PartialReliableRexmitUnordered => {
                     ordered = false;
-                    max_retransmits = val;
+                    max_retransmits = Some(val);
                 }
                 ChannelType::PartialReliableTimed => {
                     ordered = true;
-                    max_packet_lifetime = val;
+                    max_packet_life_time = Some(val);
                 }
                 ChannelType::PartialReliableTimedUnordered => {
                     ordered = false;
-                    max_packet_lifetime = val;
+                    max_packet_life_time = Some(val);
                 }
             };
 
@@ -285,7 +285,7 @@ impl RTCSctpTransport {
                     protocol: dc.config.protocol.clone(),
                     negotiated,
                     ordered,
-                    max_packet_life_time: max_packet_lifetime,
+                    max_packet_life_time,
                     max_retransmits,
                 },
                 Arc::clone(&param.setting_engine),


### PR DESCRIPTION
Fixes #371. Most of the change is in `RTCDataChannel::open` to match https://github.com/pion/webrtc/blob/4ef00e6e5f78647305cdd08568d16f49ae6190eb/datachannel.go#L130-L152