### PR TITLE
AV1: Correctly parse 5-byte leb128 size value

### DIFF
--- a/rtp/src/codecs/av1/av1_test.rs
+++ b/rtp/src/codecs/av1/av1_test.rs
@@ -1,8 +1,8 @@
+use crate::codecs::av1::leb128::read_leb128;
 use crate::codecs::av1::obu::{
     OBU_HAS_EXTENSION_BIT, OBU_TYPE_FRAME, OBU_TYPE_FRAME_HEADER, OBU_TYPE_METADATA,
     OBU_TYPE_SEQUENCE_HEADER, OBU_TYPE_TEMPORAL_DELIMITER, OBU_TYPE_TILE_GROUP, OBU_TYPE_TILE_LIST,
 };
-use crate::codecs::av1::leb128::read_leb128;
 use crate::error::Result;
 
 use super::*;
@@ -453,7 +453,6 @@ fn test_split_two_obus_into_two_packets() -> Result<()> {
     );
     Ok(())
 }
-
 
 #[test]
 fn read_leb128_0() {

--- a/rtp/src/codecs/av1/av1_test.rs
+++ b/rtp/src/codecs/av1/av1_test.rs
@@ -2,6 +2,7 @@ use crate::codecs::av1::obu::{
     OBU_HAS_EXTENSION_BIT, OBU_TYPE_FRAME, OBU_TYPE_FRAME_HEADER, OBU_TYPE_METADATA,
     OBU_TYPE_SEQUENCE_HEADER, OBU_TYPE_TEMPORAL_DELIMITER, OBU_TYPE_TILE_GROUP, OBU_TYPE_TILE_LIST,
 };
+use crate::codecs::av1::leb128::read_leb128;
 use crate::error::Result;
 
 use super::*;
@@ -451,4 +452,21 @@ fn test_split_two_obus_into_two_packets() -> Result<()> {
         ]
     );
     Ok(())
+}
+
+
+#[test]
+fn read_leb128_0() {
+    let bytes = vec![0u8];
+    let (payload_size, leb128_size) = read_leb128(&(bytes.into()));
+    assert_eq!(payload_size, 0);
+    assert_eq!(leb128_size, 1);
+}
+
+#[test]
+fn read_leb128_5_byte() {
+    let bytes = vec![0xC3, 0x80, 0x81, 0x80, 0x00];
+    let (payload_size, leb128_size) = read_leb128(&(bytes.into()));
+    assert_eq!(leb128_size, 5);
+    assert_eq!(payload_size, 16451);
 }

--- a/rtp/src/codecs/av1/leb128.rs
+++ b/rtp/src/codecs/av1/leb128.rs
@@ -14,13 +14,13 @@ pub fn encode_leb128(mut val: u32) -> u32 {
     }
 }
 
-pub fn decode_leb128(mut val: u32) -> u32 {
+pub fn decode_leb128(mut val: u64) -> u32 {
     let mut b = 0;
     loop {
         b |= val & 0b_0111_1111;
         val >>= 8;
         if val == 0 {
-            return b;
+	    return b as u32;            
         }
         b <<= 7;
     }
@@ -29,7 +29,7 @@ pub fn decode_leb128(mut val: u32) -> u32 {
 pub fn read_leb128(bytes: &Bytes) -> (u32, usize) {
     let mut encoded = 0;
     for i in 0..bytes.len() {
-        encoded |= bytes[i] as u32;
+        encoded |= bytes[i] as u64;
         if bytes[i] & 0b_1000_0000 == 0 {
             return (decode_leb128(encoded), i + 1);
         }

--- a/rtp/src/codecs/av1/leb128.rs
+++ b/rtp/src/codecs/av1/leb128.rs
@@ -20,7 +20,7 @@ pub fn decode_leb128(mut val: u64) -> u32 {
         b |= val & 0b_0111_1111;
         val >>= 8;
         if val == 0 {
-	    return b as u32;            
+            return b as u32;
         }
         b <<= 7;
     }


### PR DESCRIPTION
The parsing of leb128 size value a 2-pass approach rather than following the pseudocode in the AV1 spec, presumably for performance reasons. However while the maximum permitted value is indeed 32 bits, the input bytes accumulated in a `u32` are packed 7 bits per byte, thus losing relevant bits from the first byte for 5-byte values. (I believe the leb128 value can be up to 8 bytes with leading zeroes but perhaps that case was fine).

I imagine this doesn't come up where the the only large OBU in a binary presented to webrtc-rs has the size omitted, we hit this with an encoder which sets the size on every OBU.