### PR TITLE
Don't send receiver reports for SSRC during simulcast probe

### DIFF
--- a/interceptor/src/lib.rs
+++ b/interceptor/src/lib.rs
@@ -24,6 +24,9 @@ pub mod twcc;
 
 pub use error::Error;
 
+/// Attribute indicating the stream is probing incoming packets.
+pub const ATTR_READ_PROBE: usize = 2295978936;
+
 /// Attributes are a generic key/value store used by interceptors
 pub type Attributes = HashMap<usize, usize>;
 

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -14,7 +14,6 @@ use portable_atomic::{AtomicBool, AtomicU8};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use tokio::sync::{Mutex, OnceCell};
-use util::Unmarshal;
 
 use crate::api::media_engine::MediaEngine;
 use crate::error::{Error, Result};
@@ -527,33 +526,30 @@ pub(crate) async fn satisfy_type_and_direction(
 /// handle_unknown_rtp_packet consumes a single RTP Packet and returns information that is helpful
 /// for demuxing and handling an unknown SSRC (usually for Simulcast)
 pub(crate) fn handle_unknown_rtp_packet(
-    buf: &[u8],
+    header: &rtp::header::Header,
     mid_extension_id: u8,
     sid_extension_id: u8,
     rsid_extension_id: u8,
 ) -> Result<(String, String, String, PayloadType)> {
-    let mut reader = buf;
-    let rp = rtp::packet::Packet::unmarshal(&mut reader)?;
-
-    if !rp.header.extension {
+    if !header.extension {
         return Ok((String::new(), String::new(), String::new(), 0));
     }
 
-    let payload_type = rp.header.payload_type;
+    let payload_type = header.payload_type;
 
-    let mid = if let Some(payload) = rp.header.get_extension(mid_extension_id) {
+    let mid = if let Some(payload) = header.get_extension(mid_extension_id) {
         String::from_utf8(payload.to_vec())?
     } else {
         String::new()
     };
 
-    let rid = if let Some(payload) = rp.header.get_extension(sid_extension_id) {
+    let rid = if let Some(payload) = header.get_extension(sid_extension_id) {
         String::from_utf8(payload.to_vec())?
     } else {
         String::new()
     };
 
-    let srid = if let Some(payload) = rp.header.get_extension(rsid_extension_id) {
+    let srid = if let Some(payload) = header.get_extension(rsid_extension_id) {
         String::from_utf8(payload.to_vec())?
     } else {
         String::new()


### PR DESCRIPTION
libwebrtc will stop sending SDES headers after the first receiver report on an SSRC[^1]. This breaks simulcast probing if the receiver report is sent before probing is completed. This change delays receiver reports for probing SSRCs until the first non-probe packet is received.

I didn't find any easy way to get this information into the interceptor, so I opted for using attributes. Let me know if you prefer some other means.

[^1]: https://github.com/webrtc-sdk/webrtc/blob/0ae5688d4d490274ea47fee3f87f622ef3f13113/modules/rtp_rtcp/source/rtp_sender.cc#L509