### PR TITLE
turn: Add relay_addr to AllocationInfo

### DIFF
--- a/turn/src/allocation/allocation_manager.rs
+++ b/turn/src/allocation/allocation_manager.rs
@@ -63,6 +63,7 @@ impl Manager {
                     AllocationInfo::new(
                         *five_tuple,
                         alloc.username.text.clone(),
+                        alloc.relay_addr,
                         #[cfg(feature = "metrics")]
                         alloc.relayed_bytes.load(Ordering::Acquire),
                     ),

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -45,6 +45,9 @@ pub struct AllocationInfo {
     /// Username of this [`Allocation`].
     pub username: String,
 
+    /// Relay address of this [`Allocation`].
+    pub relay_addr: SocketAddr,
+
     /// Relayed bytes with this [`Allocation`].
     #[cfg(feature = "metrics")]
     pub relayed_bytes: usize,
@@ -55,11 +58,13 @@ impl AllocationInfo {
     pub fn new(
         five_tuple: FiveTuple,
         username: String,
+        relay_addr: SocketAddr,
         #[cfg(feature = "metrics")] relayed_bytes: usize,
     ) -> Self {
         Self {
             five_tuple,
             username,
+            relay_addr,
             #[cfg(feature = "metrics")]
             relayed_bytes,
         }
@@ -255,6 +260,7 @@ impl Allocation {
                 .send(AllocationInfo {
                     five_tuple: self.five_tuple,
                     username: self.username.text.clone(),
+                    relay_addr: self.relay_addr,
                     #[cfg(feature = "metrics")]
                     relayed_bytes: self.relayed_bytes.load(Ordering::Acquire),
                 })


### PR DESCRIPTION
The relay address is an essential part of a turn allocation, but as far as I can tell there's currently no way to get it when using `turn::server::Server`.

This may technically be a breaking change since `AllocationInfo::new` is public. Let me know if that's a problem and I can make the field an `Option` and keep the original constructor.