### PR TITLE
Fix grcov use profile-generate to replace outdated -Zprofile options

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -50,8 +50,8 @@ jobs:
           args: --all --no-fail-fast ${{ matrix.cargo_flags }}
         env:
           CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Cdebug-assertions=off'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Cdebug-assertions=off'
+          RUSTFLAGS: '-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Cdebug-assertions=off -Cprofile-generate=target/debug'
+          RUSTDOCFLAGS: '-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Cdebug-assertions=off -Cprofile-generate=target/debug'
 
       - name: Generate coverage data
         id: grcov


### PR DESCRIPTION
Related to [mozilla/grcov#1240](https://github.com/mozilla/grcov/issues/1240)

I start this PR to fix the main branch's CI failure, but find out that we need to use profile-generate to replace outdated -Zprofile options.
 
Reference: https://doc.rust-lang.org/rustc/profile-guided-optimization.html for more information.
Reference: https://github.com/mozilla/sccache/pull/2282