### PR TITLE
Fix writer to skip packets with an empty payload

### DIFF
--- a/media/src/io/ivf_writer/ivf_writer_test.rs
+++ b/media/src/io/ivf_writer/ivf_writer_test.rs
@@ -1,7 +1,6 @@
 use std::io::Cursor;
 
 use super::*;
-use crate::error::Error;
 
 #[test]
 fn test_ivf_writer_add_packet_and_close() -> Result<()> {
@@ -117,18 +116,16 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
 
     let add_packet_test_case = vec![
         (
-            "IVFWriter shouldn't be able to write something an empty packet",
+            "IVFWriter should be able to skip something an empty packet",
             "IVFWriter should be able to close the file",
             rtp::packet::Packet::default(),
-            Some(Error::ErrInvalidNilPacket),
             false,
-            0,
+            1,
         ),
         (
             "IVFWriter should be able to write an IVF packet",
             "IVFWriter should be able to close the file",
             valid_packet.clone(),
-            None,
             false,
             1,
         ),
@@ -136,7 +133,6 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
             "IVFWriter should be able to write a Keframe IVF packet",
             "IVFWriter should be able to close the file",
             keyframe_packet,
-            None,
             true,
             2,
         ),
@@ -155,7 +151,7 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
         unused: 0,                // Unused
     };
 
-    for (msg1, _msg2, packet, err, seen_key_frame, count) in add_packet_test_case {
+    for (msg1, _msg2, packet, seen_key_frame, count) in add_packet_test_case {
         let mut writer = IVFWriter::new(Cursor::new(Vec::<u8>::new()), &header)?;
         assert!(
             !writer.seen_key_frame,
@@ -163,12 +159,8 @@ fn test_ivf_writer_add_packet_and_close() -> Result<()> {
         );
         assert_eq!(writer.count, 0, "Writer's packet count should initialize 0");
         let result = writer.write_rtp(&packet);
-        if err.is_some() {
-            assert!(result.is_err(), "{}", msg1);
-            continue;
-        } else {
-            assert!(result.is_ok(), "{}", msg1);
-        }
+
+        assert!(result.is_ok(), "{}", msg1);
 
         assert_eq!(seen_key_frame, writer.seen_key_frame, "{msg1} failed");
         if count == 1 {

--- a/media/src/io/ivf_writer/mod.rs
+++ b/media/src/io/ivf_writer/mod.rs
@@ -57,6 +57,10 @@ impl<W: Write + Seek> IVFWriter<W> {
 impl<W: Write + Seek> Writer for IVFWriter<W> {
     /// write_rtp adds a new packet and writes the appropriate headers for it
     fn write_rtp(&mut self, packet: &rtp::packet::Packet) -> Result<()> {
+        if packet.payload.is_empty() {
+            return Ok(());
+        }
+
         let mut depacketizer: Box<dyn Depacketizer> = if self.is_vp9 {
             Box::<rtp::codecs::vp9::Vp9Packet>::default()
         } else {

--- a/media/src/io/ogg_writer/mod.rs
+++ b/media/src/io/ogg_writer/mod.rs
@@ -169,6 +169,10 @@ impl<W: Write + Seek> OggWriter<W> {
 impl<W: Write + Seek> Writer for OggWriter<W> {
     /// write_rtp adds a new packet and writes the appropriate headers for it
     fn write_rtp(&mut self, packet: &rtp::packet::Packet) -> Result<()> {
+        if packet.payload.is_empty() {
+            return Ok(());
+        }
+
         let mut opus_packet = rtp::codecs::opus::OpusPacket;
         let payload = opus_packet.depacketize(&packet.payload)?;
 

--- a/media/src/io/ogg_writer/ogg_writer_test.rs
+++ b/media/src/io/ogg_writer/ogg_writer_test.rs
@@ -1,7 +1,6 @@
 use std::io::Cursor;
 
 use super::*;
-use crate::error::Error;
 
 #[test]
 fn test_ogg_writer_add_packet_and_close() -> Result<()> {
@@ -36,28 +35,21 @@ fn test_ogg_writer_add_packet_and_close() -> Result<()> {
     // nolint:dupl
     let add_packet_test_case = vec![
         (
-            "OggWriter shouldn't be able to write an empty packet",
+            "OggWriter should be able to skip an empty packet",
             "OggWriter should be able to close the file",
             rtp::packet::Packet::default(),
-            Some(Error::ErrInvalidNilPacket),
         ),
         (
             "OggWriter should be able to write an Opus packet",
             "OggWriter should be able to close the file",
             valid_packet,
-            None,
         ),
     ];
 
-    for (msg1, _msg2, packet, err) in add_packet_test_case {
+    for (msg1, _msg2, packet) in add_packet_test_case {
         let mut writer = OggWriter::new(Cursor::new(Vec::<u8>::new()), 4800, 2)?;
         let result = writer.write_rtp(&packet);
-        if err.is_some() {
-            assert!(result.is_err(), "{}", msg1);
-            continue;
-        } else {
-            assert!(result.is_ok(), "{}", msg1);
-        }
+        assert!(result.is_ok(), "{}", msg1);
         writer.close()?;
     }
 


### PR DESCRIPTION
Fixes #634 

## References

### Similar implementation in webrtc-rs/webrtc

https://github.com/webrtc-rs/webrtc/blob/a97d49e49e694b5d6c6775b153a8d30aa41a268e/media/src/io/h264_writer/mod.rs#L52-L54

### Related PR in pion/webrtc

- https://github.com/pion/webrtc/pull/1995

## Test

1. Open https://jsfiddle.net/vfmcg8rk/1/
1. Copy SDP
1. cargo build --example save-to-disk-h264
1. echo $BROWSER_SDP | ./target/debug/examples/save-to-disk-h264 --video ./output.h264 --audio ./output.ogg
1. Start session 

-> `OggWriter` and `IvfWriter` works continuously