### PR TITLE
Closing mdns agent

### DIFF
--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -349,6 +349,8 @@ impl Agent {
             udp_mux.remove_conn_by_ufrag(&ufrag).await;
         }
 
+        Self::close_multicast_conn(&self.mdns_conn).await;
+
         //FIXME: deadlock here
         self.internal.close().await
     }

--- a/sctp/fuzz/fuzz_targets/packet.rs
+++ b/sctp/fuzz/fuzz_targets/packet.rs
@@ -1,8 +1,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use webrtc_sctp::packet::Packet;
 use bytes::Bytes;
+use webrtc_sctp::packet::Packet;
 
 fuzz_target!(|data: &[u8]| {
     let bytes = Bytes::from(data.to_vec());

--- a/sctp/fuzz/fuzz_targets/param.rs
+++ b/sctp/fuzz/fuzz_targets/param.rs
@@ -1,8 +1,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use webrtc_sctp::param::build_param;
 use bytes::Bytes;
+use webrtc_sctp::param::build_param;
 
 fuzz_target!(|data: &[u8]| {
     let bytes = Bytes::from(data.to_vec());


### PR DESCRIPTION
I use the library with many open/close, and I get mdns storms where the webrtc library searches for other nodes over the network in a very aggressive manner.

This has been proposed by @r-byondlabs, and might very well be the problem: if I open/close many connections, and the mdns-agents are not cleaned up, there might be many requests.

Fixes #616