### PR TITLE
Add getter methods for mid and paused in TrackLocalContext

### DIFF
--- a/webrtc/src/track/track_local/mod.rs
+++ b/webrtc/src/track/track_local/mod.rs
@@ -86,6 +86,16 @@ impl TrackLocalContext {
     pub fn id(&self) -> String {
         self.id.clone()
     }
+
+    /// mid returns the id of media associated with the RTP stream
+    pub fn mid(&self) -> Option<SmolStr> {
+        self.mid.clone()
+    }
+
+    /// paused returns a boolean indicating whether the track is currently paused
+    pub fn paused(&self) -> Arc<AtomicBool> {
+        self.paused.clone()
+    }
 }
 /// TrackLocal is an interface that controls how the user can send media
 /// The user can provide their own TrackLocal implementations, or use


### PR DESCRIPTION
Dear maintainers,
Thank you for your efforts in maintaining this project.

I have added two getter methods to retrieve the `mid` and `paused` fields from the `TrackLocalContext` struct.

In my project, I am implementing a custom `TrackLocal` similar to `TrackLocalStaticRTP`. The bind method provides a `TrackLocalContext`, but currently, I am unable to access all its fields because they are marked as `pub(crate)`.
https://github.com/webrtc-rs/webrtc/blob/de46a53cd6ccac2c7aee515265adce47b2a4621f/webrtc/src/track/track_local/track_local_static_rtp.rs#L177

To address this, I have introduced getter methods for the `mid` and `paused` fields, ensuring that these values can be accessed outside the crate while maintaining encapsulation.

I hope this change aligns with the project's design principles and proves helpful for others with similar use cases. Please let me know if there are any concerns or adjustments needed.

Thank you for considering this contribution.