### PR TITLE
Remove unused ErrTurnCredentials as it is no longer used. It was used…

### DIFF
--- a/webrtc/src/error.rs
+++ b/webrtc/src/error.rs
@@ -40,11 +40,6 @@ pub enum Error {
     #[error("turn server credentials required")]
     ErrNoTurnCredentials,
 
-    /// ErrTurnCredentials indicates that provided TURN credentials are partial
-    /// or malformed.
-    #[error("invalid turn server credentials")]
-    ErrTurnCredentials,
-
     /// ErrExistingTrack indicates that a track already exists.
     #[error("track already exists")]
     ErrExistingTrack,


### PR DESCRIPTION
… when CredentialType was an option, but it is now deprecated. Ref: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#credentialtype