### PR TITLE
Change MIME_TYPE_HEVC from video/HEVC to video/H265 (#141)

### DIFF
--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -28,9 +28,9 @@ use crate::stats::StatsReportType::Codec;
 /// MIME_TYPE_H264 H264 MIME type.
 /// Note: Matching should be case insensitive.
 pub const MIME_TYPE_H264: &str = "video/H264";
-/// MIME_TYPE_HEVC HEVC MIME type.
+/// MIME_TYPE_HEVC HEVC/H265 MIME type.
 /// Note: Matching should be case insensitive.
-pub const MIME_TYPE_HEVC: &str = "video/HEVC";
+pub const MIME_TYPE_HEVC: &str = "video/H265";
 /// MIME_TYPE_OPUS Opus MIME type
 /// Note: Matching should be case insensitive.
 pub const MIME_TYPE_OPUS: &str = "audio/opus";


### PR DESCRIPTION
This is the actual mime type for HEVC/H265 defined by
https://www.iana.org/assignments/media-types/video/H265 as well as
https://datatracker.ietf.org/doc/html/rfc7798#section-7.2.1

With this change, HEVC/H265 can be negotiated for WebRTC with Safari and Chrome browsers.

Note that this might break for users who rely on the current `video/HEVC` value.
Alternatively, we could leave `MIME_TYPE_HEVC` as is (maybe with a `deprecated` flag?) and add `MIME_TYPE_H265` separately.