### PR TITLE
turn: add feature async-auth

### DIFF
--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -47,6 +47,7 @@ criterion = "0.5"
 
 [features]
 metrics = []
+async-auth = []
 
 [[bench]]
 name = "bench"

--- a/turn/src/auth/mod.rs
+++ b/turn/src/auth/mod.rs
@@ -4,6 +4,8 @@ mod auth_test;
 use std::net::SocketAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "async-auth")]
+use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use md5::{Digest, Md5};
@@ -11,8 +13,20 @@ use ring::hmac;
 
 use crate::error::*;
 
+#[cfg(not(feature = "async-auth"))]
 pub trait AuthHandler {
     fn auth_handle(&self, username: &str, realm: &str, src_addr: SocketAddr) -> Result<Vec<u8>>;
+}
+
+#[cfg(feature = "async-auth")]
+#[async_trait]
+pub trait AuthHandler {
+    async fn auth_handle(
+        &self,
+        username: &str,
+        realm: &str,
+        src_addr: SocketAddr,
+    ) -> Result<Vec<u8>>;
 }
 
 /// `generate_long_term_credentials()` can be used to create credentials valid for `duration` time/


### PR DESCRIPTION
Add optional async authentication support for TURN server

This PR adds an `async-auth` feature flag that enables asynchronous authentication for TURN servers. When enabled, the `AuthHandler` trait's `auth_handle` method becomes asynchronous, allowing authentication logic to perform non-blocking operations like database queries.

Resolves #270 