### PR TITLE
Implement ChaCha20_Poly1305 cipher suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +534,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1954,6 +1979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3027,7 @@ dependencies = [
  "byteorder",
  "cbc",
  "ccm",
+ "chacha20poly1305",
  "chrono",
  "clap 3.2.25",
  "der-parser",

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -52,6 +52,7 @@ log = "0.4"
 thiserror = "1"
 pem = { version = "3", optional = true }
 portable-atomic = "1.6"
+chacha20poly1305 = "0.10.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/dtls/examples/dial/selfsign/dial_selfsign.rs
+++ b/dtls/examples/dial/selfsign/dial_selfsign.rs
@@ -46,6 +46,12 @@ async fn main() -> Result<(), Error> {
                 .default_value("127.0.0.1:4444")
                 .long("server")
                 .help("DTLS Server name."),
+        )
+        .arg(
+            Arg::with_name("ciphersuite")
+                .takes_value(true)
+                .long("ciphersuite")
+                .help("Force a single ciphersuite."),
         );
 
     let matches = app.clone().get_matches();
@@ -68,6 +74,11 @@ async fn main() -> Result<(), Error> {
         certificates: vec![certificate],
         insecure_skip_verify: true,
         extended_master_secret: ExtendedMasterSecretType::Require,
+        cipher_suites: if matches.is_present("ciphersuite") {
+            vec![matches.value_of("ciphersuite").unwrap().into()]
+        } else {
+            vec![]
+        },
         ..Default::default()
     };
     let dtls_conn: Arc<dyn Conn + Send + Sync> =

--- a/dtls/src/cipher_suite/cipher_suite_chacha20_poly1305_sha256.rs
+++ b/dtls/src/cipher_suite/cipher_suite_chacha20_poly1305_sha256.rs
@@ -1,0 +1,116 @@
+use super::*;
+use crate::crypto::crypto_chacha20::*;
+use crate::prf::*;
+
+#[derive(Clone)]
+pub struct CipherSuiteChaCha20Poly1305Sha256 {
+    rsa: bool,
+    cipher: Option<CryptoChaCha20>,
+}
+
+impl CipherSuiteChaCha20Poly1305Sha256 {
+    const PRF_MAC_LEN: usize = 0;
+    const PRF_KEY_LEN: usize = 32;
+    const PRF_IV_LEN: usize = 12;
+
+    pub fn new(rsa: bool) -> Self {
+        CipherSuiteChaCha20Poly1305Sha256 {
+            rsa: rsa,
+            cipher: None,
+        }
+    }
+}
+
+impl CipherSuite for CipherSuiteChaCha20Poly1305Sha256 {
+    fn to_string(&self) -> String {
+        if self.rsa {
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256".to_owned()
+        } else {
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256".to_owned()
+        }
+    }
+
+    fn id(&self) -> CipherSuiteId {
+        if self.rsa {
+            CipherSuiteId::Tls_Ecdhe_Rsa_With_ChaCha20_Poly1305_Sha256
+        } else {
+            CipherSuiteId::Tls_Ecdhe_Ecdsa_With_ChaCha20_Poly1305_Sha256
+        }
+    }
+
+    fn certificate_type(&self) -> ClientCertificateType {
+        if self.rsa {
+            ClientCertificateType::RsaSign
+        } else {
+            ClientCertificateType::EcdsaSign
+        }
+    }
+
+    fn hash_func(&self) -> CipherSuiteHash {
+        CipherSuiteHash::Sha256
+    }
+
+    fn is_psk(&self) -> bool {
+        false
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.cipher.is_some()
+    }
+
+    fn init(
+        &mut self,
+        master_secret: &[u8],
+        client_random: &[u8],
+        server_random: &[u8],
+        is_client: bool,
+    ) -> Result<()> {
+        let keys = prf_encryption_keys(
+            master_secret,
+            client_random,
+            server_random,
+            CipherSuiteChaCha20Poly1305Sha256::PRF_MAC_LEN,
+            CipherSuiteChaCha20Poly1305Sha256::PRF_KEY_LEN,
+            CipherSuiteChaCha20Poly1305Sha256::PRF_IV_LEN,
+            self.hash_func(),
+        )?;
+
+        if is_client {
+            self.cipher = Some(CryptoChaCha20::new(
+                &keys.client_write_key,
+                &keys.client_write_iv,
+                &keys.server_write_key,
+                &keys.server_write_iv,
+            ));
+        } else {
+            self.cipher = Some(CryptoChaCha20::new(
+                &keys.server_write_key,
+                &keys.server_write_iv,
+                &keys.client_write_key,
+                &keys.client_write_iv,
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
+        if let Some(cg) = &self.cipher {
+            cg.encrypt(pkt_rlh, raw)
+        } else {
+            Err(Error::Other(
+                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+            ))
+        }
+    }
+
+    fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
+        if let Some(cg) = &self.cipher {
+            cg.decrypt(input)
+        } else {
+            Err(Error::Other(
+                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+            ))
+        }
+    }
+}

--- a/dtls/src/cipher_suite/mod.rs
+++ b/dtls/src/cipher_suite/mod.rs
@@ -101,6 +101,33 @@ impl From<u16> for CipherSuiteId {
     }
 }
 
+impl From<&str> for CipherSuiteId {
+    fn from(val: &str) -> Self {
+        match val {
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CCM" => CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Ccm,
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8" => {
+                CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Ccm_8
+            }
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" => {
+                CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256
+            }
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" => {
+                CipherSuiteId::Tls_Ecdhe_Rsa_With_Aes_128_Gcm_Sha256
+            }
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" => {
+                CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_256_Cbc_Sha
+            }
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" => {
+                CipherSuiteId::Tls_Ecdhe_Rsa_With_Aes_256_Cbc_Sha
+            }
+            "TLS_PSK_WITH_AES_128_CCM" => CipherSuiteId::Tls_Psk_With_Aes_128_Ccm,
+            "TLS_PSK_WITH_AES_128_CCM_8" => CipherSuiteId::Tls_Psk_With_Aes_128_Ccm_8,
+            "TLS_PSK_WITH_AES_128_GCM_SHA256" => CipherSuiteId::Tls_Psk_With_Aes_128_Gcm_Sha256,
+            _ => CipherSuiteId::Unsupported,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum CipherSuiteHash {
     Sha256,

--- a/dtls/src/cipher_suite/mod.rs
+++ b/dtls/src/cipher_suite/mod.rs
@@ -231,17 +231,16 @@ pub fn cipher_suite_for_id(id: CipherSuiteId) -> Result<Box<dyn CipherSuite + Se
 // CipherSuites we support in order of preference
 pub(crate) fn default_cipher_suites() -> Vec<Box<dyn CipherSuite + Send + Sync>> {
     vec![
-        Box::new(CipherSuiteChaCha20Poly1305Sha256::new(false)),
         Box::new(CipherSuiteAes128GcmSha256::new(false)),
         Box::new(CipherSuiteAes256CbcSha::new(false)),
         Box::new(CipherSuiteAes128GcmSha256::new(true)),
         Box::new(CipherSuiteAes256CbcSha::new(true)),
+        Box::new(CipherSuiteChaCha20Poly1305Sha256::new(false)),
     ]
 }
 
 fn all_cipher_suites() -> Vec<Box<dyn CipherSuite + Send + Sync>> {
     vec![
-        Box::new(CipherSuiteChaCha20Poly1305Sha256::new(false)),
         Box::new(new_cipher_suite_tls_ecdhe_ecdsa_with_aes_128_ccm()),
         Box::new(new_cipher_suite_tls_ecdhe_ecdsa_with_aes_128_ccm8()),
         Box::new(CipherSuiteAes128GcmSha256::new(false)),
@@ -251,6 +250,8 @@ fn all_cipher_suites() -> Vec<Box<dyn CipherSuite + Send + Sync>> {
         Box::new(new_cipher_suite_tls_psk_with_aes_128_ccm()),
         Box::new(new_cipher_suite_tls_psk_with_aes_128_ccm8()),
         Box::<CipherSuiteTlsPskWithAes128GcmSha256>::default(),
+        Box::new(CipherSuiteChaCha20Poly1305Sha256::new(false)),
+        Box::new(CipherSuiteChaCha20Poly1305Sha256::new(true)),
     ]
 }
 

--- a/dtls/src/crypto/crypto_chacha20.rs
+++ b/dtls/src/crypto/crypto_chacha20.rs
@@ -1,0 +1,123 @@
+use std::io::Cursor;
+
+use chacha20poly1305::aead::generic_array::GenericArray;
+use chacha20poly1305::aead::AeadInPlace;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
+
+use super::*;
+use crate::content::*;
+use crate::error::*;
+use crate::record_layer::record_layer_header::*; // what about Aes256Gcm?
+
+const CRYPTO_CHACHA20_TAG_LENGTH: usize = 16;
+const CRYPTO_CHACHA20_NONCE_LENGTH: usize = 12;
+
+// State needed to handle encrypted input/output
+#[derive(Clone)]
+pub struct CryptoChaCha20 {
+    local_cc: ChaCha20Poly1305,
+    remote_cc: ChaCha20Poly1305,
+    local_key: Vec<u8>,
+    remote_key: Vec<u8>,
+    local_write_iv: Vec<u8>,
+    remote_write_iv: Vec<u8>,
+}
+
+fn noncegen(nonce: &mut [u8], epoch: u16, seqnum: u64) {
+    let epoch: u64 = epoch.into();
+    let seqnum = (seqnum & 0xFFFFFFFFFFFF) | (epoch << 48);
+    for i in 0..8 {
+        nonce[i + 4] ^= ((seqnum >> (8 * (7 - i))) & 0xFF) as u8;
+    }
+}
+
+impl CryptoChaCha20 {
+    pub fn new(
+        local_key: &[u8],
+        local_write_iv: &[u8],
+        remote_key: &[u8],
+        remote_write_iv: &[u8],
+    ) -> Self {
+        let key = GenericArray::from_slice(local_key);
+        let local_cc = ChaCha20Poly1305::new(key);
+
+        let key = GenericArray::from_slice(remote_key);
+        let remote_cc = ChaCha20Poly1305::new(key);
+
+        CryptoChaCha20 {
+            local_cc,
+            local_write_iv: local_write_iv.to_vec(),
+            remote_cc,
+            local_key: local_key.to_vec(),
+            remote_key: remote_key.to_vec(),
+            remote_write_iv: remote_write_iv.to_vec(),
+        }
+    }
+
+    pub fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
+        let payload = &raw[RECORD_LAYER_HEADER_SIZE..];
+        let raw = &raw[..RECORD_LAYER_HEADER_SIZE];
+
+        let mut nonce = vec![0u8; CRYPTO_CHACHA20_NONCE_LENGTH];
+        nonce[..CRYPTO_CHACHA20_NONCE_LENGTH]
+            .copy_from_slice(&self.local_write_iv[..CRYPTO_CHACHA20_NONCE_LENGTH]);
+
+        noncegen(&mut nonce[..], pkt_rlh.epoch, pkt_rlh.sequence_number);
+        let nonce = GenericArray::from_slice(&nonce);
+
+        let additional_data = generate_aead_additional_data(pkt_rlh, payload.len());
+
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.extend_from_slice(payload);
+
+        let tag = self
+            .local_cc
+            .encrypt_in_place_detached(nonce, &additional_data, &mut buffer)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let mut r = Vec::with_capacity(raw.len() + buffer.len() + tag.len());
+        r.extend_from_slice(raw);
+        r.extend_from_slice(&buffer);
+        r.extend_from_slice(&tag);
+
+        // Update recordLayer size to include explicit nonce
+        let r_len = (r.len() - RECORD_LAYER_HEADER_SIZE) as u16;
+        r[RECORD_LAYER_HEADER_SIZE - 2..RECORD_LAYER_HEADER_SIZE]
+            .copy_from_slice(&r_len.to_be_bytes());
+
+        Ok(r)
+    }
+
+    pub fn decrypt(&self, r: &[u8]) -> Result<Vec<u8>> {
+        let mut reader = Cursor::new(r);
+        let h = RecordLayerHeader::unmarshal(&mut reader)?;
+        if h.content_type == ContentType::ChangeCipherSpec {
+            // Nothing to encrypt with ChangeCipherSpec
+            return Ok(r.to_vec());
+        }
+
+        let mut nonce = vec![];
+        nonce.extend_from_slice(&self.remote_write_iv[..]);
+
+        noncegen(&mut nonce[..], h.epoch, h.sequence_number);
+        let nonce = GenericArray::from_slice(&nonce);
+
+        let out = &r[RECORD_LAYER_HEADER_SIZE..];
+
+        let additional_data =
+            generate_aead_additional_data(&h, out.len() - CRYPTO_CHACHA20_TAG_LENGTH);
+
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.extend_from_slice(out);
+
+        self.remote_cc
+            .decrypt_in_place(nonce, &additional_data, &mut buffer)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let mut d = Vec::with_capacity(RECORD_LAYER_HEADER_SIZE + buffer.len());
+        d.extend_from_slice(&r[..RECORD_LAYER_HEADER_SIZE]);
+        d.extend_from_slice(&buffer);
+
+        Ok(d)
+    }
+}

--- a/dtls/src/crypto/mod.rs
+++ b/dtls/src/crypto/mod.rs
@@ -3,6 +3,7 @@ mod crypto_test;
 
 pub mod crypto_cbc;
 pub mod crypto_ccm;
+pub mod crypto_chacha20;
 pub mod crypto_gcm;
 pub mod padding;
 


### PR DESCRIPTION
This is a cipher suite supported by Chrome, and preferred on some low-end processors. I've also added an argument to the dial_selfsign example, which forces a cipher suite, and used that argument to test against the DTLS implementation in OpenSSL. Any feedback is appreciated, thank you!

Fixes #674 