### PR TITLE
Handle replay after wrapping in replaydetector

### DIFF
--- a/util/src/replay_detector/mod.rs
+++ b/util/src/replay_detector/mod.rs
@@ -160,9 +160,10 @@ impl ReplayDetector for WrappedSlidingWindowDetector {
             // Update the head of the window.
             self.mask.lsh((-diff) as usize);
             self.latest_seq = self.seq;
+            self.mask.set_bit(0);
+        } else {
+            self.mask.set_bit(diff as usize);
         }
-        self.mask
-            .set_bit((self.latest_seq as isize - self.seq as isize) as usize);
     }
 }
 

--- a/util/src/replay_detector/replay_detector_test.rs
+++ b/util/src/replay_detector/replay_detector_test.rs
@@ -248,6 +248,15 @@ fn test_replay_detector() {
                 0xFFFD, 0xFFFC, 0x0002, 0xFFFE, 0x0000, 0x0001, 0xFFFF, 0x0003,
             ],
         ),
+        (
+            "RepeatedReorderedAfterWrap",
+            4,
+            0xFFFF,
+            vec![0x0, 0xFFFF, 0xFFFF],
+            vec![true, true, true],
+            vec![0x0, 0xFFFF],
+            vec![0x0, 0xFFFF],
+        ),
     ];
 
     for (name, windows_size, max_seq, input, valid, expected, mut expected_wrap) in tests {


### PR DESCRIPTION
Fixes `WrappedSlidingWindowDetector::accept` to update mask correctly when the sequence number wraps between `seq` and `latest_seq`.

Ported from https://github.com/pion/transport/pull/337.