### PR TITLE
turn: use ok_or() to simplify command_tx

### DIFF
--- a/turn/src/server/mod.rs
+++ b/turn/src/server/mod.rs
@@ -83,19 +83,16 @@ impl Server {
     pub async fn delete_allocations_by_username(&self, username: String) -> Result<()> {
         let tx = {
             let command_tx = self.command_tx.lock().await;
-            command_tx.clone()
+            command_tx.clone().ok_or(Error::ErrClosed)?
         };
-        if let Some(tx) = tx {
-            let (closed_tx, closed_rx) = mpsc::channel(1);
-            tx.send(Command::DeleteAllocations(username, Arc::new(closed_rx)))
-                .map_err(|_| Error::ErrClosed)?;
 
-            closed_tx.closed().await;
+        let (closed_tx, closed_rx) = mpsc::channel(1);
+        tx.send(Command::DeleteAllocations(username, Arc::new(closed_rx)))
+            .map_err(|_| Error::ErrClosed)?;
 
-            Ok(())
-        } else {
-            Err(Error::ErrClosed)
-        }
+        closed_tx.closed().await;
+
+        Ok(())
     }
 
     /// Get information of [`Allocation`][`Allocation`]s by specified [`FiveTuple`]s.
@@ -121,23 +118,20 @@ impl Server {
 
         let tx = {
             let command_tx = self.command_tx.lock().await;
-            command_tx.clone()
+            command_tx.clone().ok_or(Error::ErrClosed)?
         };
-        if let Some(tx) = tx {
-            let (infos_tx, mut infos_rx) = mpsc::channel(1);
-            tx.send(Command::GetAllocationsInfo(five_tuples, infos_tx))
-                .map_err(|_| Error::ErrClosed)?;
 
-            let mut info: HashMap<FiveTuple, AllocationInfo> = HashMap::new();
+        let (infos_tx, mut infos_rx) = mpsc::channel(1);
+        tx.send(Command::GetAllocationsInfo(five_tuples, infos_tx))
+            .map_err(|_| Error::ErrClosed)?;
 
-            for _ in 0..tx.receiver_count() {
-                info.extend(infos_rx.recv().await.ok_or(Error::ErrClosed)?);
-            }
+        let mut info: HashMap<FiveTuple, AllocationInfo> = HashMap::new();
 
-            Ok(info)
-        } else {
-            Err(Error::ErrClosed)
+        for _ in 0..tx.receiver_count() {
+            info.extend(infos_rx.recv().await.ok_or(Error::ErrClosed)?);
         }
+
+        Ok(info)
     }
 
     async fn read_loop(


### PR DESCRIPTION
use `command_tx.clone().ok_or(Error::ErrClosed)?` to replace `if let Some(..) { ... } else { return Err(Error::ErrClosed) }`