### PR TITLE
dtls: refactor cipher suite error handling with ok_or()

### DIFF
--- a/dtls/src/cipher_suite/cipher_suite_aes_128_ccm.rs
+++ b/dtls/src/cipher_suite/cipher_suite_aes_128_ccm.rs
@@ -97,22 +97,16 @@ impl CipherSuite for CipherSuiteAes128Ccm {
     }
 
     fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
-        if let Some(ccm) = &self.ccm {
-            ccm.encrypt(pkt_rlh, raw)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
-            ))
-        }
+        let ccm = self.ccm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+        ))?;
+        ccm.encrypt(pkt_rlh, raw)
     }
 
     fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
-        if let Some(ccm) = &self.ccm {
-            ccm.decrypt(input)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
-            ))
-        }
+        let ccm = self.ccm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+        ))?;
+        ccm.decrypt(input)
     }
 }

--- a/dtls/src/cipher_suite/cipher_suite_aes_128_gcm_sha256.rs
+++ b/dtls/src/cipher_suite/cipher_suite_aes_128_gcm_sha256.rs
@@ -92,22 +92,16 @@ impl CipherSuite for CipherSuiteAes128GcmSha256 {
     }
 
     fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.gcm {
-            cg.encrypt(pkt_rlh, raw)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
-            ))
-        }
+        let cg = self.gcm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+        ))?;
+        cg.encrypt(pkt_rlh, raw)
     }
 
     fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.gcm {
-            cg.decrypt(input)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
-            ))
-        }
+        let cg = self.gcm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+        ))?;
+        cg.decrypt(input)
     }
 }

--- a/dtls/src/cipher_suite/cipher_suite_aes_256_cbc_sha.rs
+++ b/dtls/src/cipher_suite/cipher_suite_aes_256_cbc_sha.rs
@@ -92,22 +92,16 @@ impl CipherSuite for CipherSuiteAes256CbcSha {
     }
 
     fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.cbc {
-            cg.encrypt(pkt_rlh, raw)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
-            ))
-        }
+        let cg = self.cbc.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+        ))?;
+        cg.encrypt(pkt_rlh, raw)
     }
 
     fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.cbc {
-            cg.decrypt(input)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
-            ))
-        }
+        let cg = self.cbc.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+        ))?;
+        cg.decrypt(input)
     }
 }

--- a/dtls/src/cipher_suite/cipher_suite_chacha20_poly1305_sha256.rs
+++ b/dtls/src/cipher_suite/cipher_suite_chacha20_poly1305_sha256.rs
@@ -92,22 +92,16 @@ impl CipherSuite for CipherSuiteChaCha20Poly1305Sha256 {
     }
 
     fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.cipher {
-            cg.encrypt(pkt_rlh, raw)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
-            ))
-        }
+        let cg = self.cipher.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+        ))?;
+        cg.encrypt(pkt_rlh, raw)
     }
 
     fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.cipher {
-            cg.decrypt(input)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
-            ))
-        }
+        let cg = self.cipher.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+        ))?;
+        cg.decrypt(input)
     }
 }

--- a/dtls/src/cipher_suite/cipher_suite_tls_psk_with_aes_128_gcm_sha256.rs
+++ b/dtls/src/cipher_suite/cipher_suite_tls_psk_with_aes_128_gcm_sha256.rs
@@ -75,22 +75,16 @@ impl CipherSuite for CipherSuiteTlsPskWithAes128GcmSha256 {
     }
 
     fn encrypt(&self, pkt_rlh: &RecordLayerHeader, raw: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.gcm {
-            cg.encrypt(pkt_rlh, raw)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to encrypt".to_owned(),
-            ))
-        }
+        let cg = self.gcm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to encrypt".to_owned(),
+        ))?;
+        cg.encrypt(pkt_rlh, raw)
     }
 
     fn decrypt(&self, input: &[u8]) -> Result<Vec<u8>> {
-        if let Some(cg) = &self.gcm {
-            cg.decrypt(input)
-        } else {
-            Err(Error::Other(
-                "CipherSuite has not been initialized, unable to decrypt".to_owned(),
-            ))
-        }
+        let cg = self.gcm.as_ref().ok_or(Error::Other(
+            "CipherSuite has not been initialized, unable to decrypt".to_owned(),
+        ))?;
+        cg.decrypt(input)
     }
 }


### PR DESCRIPTION
Replace verbose if-let-else patterns with concise ok_or() calls
for better code readability and consistency across all cipher
suite implementations.

Changes:
- CipherSuiteAes128Ccm: simplify encrypt/decrypt methods
- CipherSuiteAes128GcmSha256: simplify encrypt/decrypt methods
- CipherSuiteAes256CbcSha: simplify encrypt/decrypt methods
- CipherSuiteChaCha20Poly1305Sha256: simplify encrypt/decrypt methods
- CipherSuiteTlsPskWithAes128GcmSha256: simplify encrypt/decrypt methods
