### PR TITLE
refactor(ice): replace magic numbers with named constants for STUN/TURN ports

### DIFF
--- a/ice/src/url/mod.rs
+++ b/ice/src/url/mod.rs
@@ -5,6 +5,8 @@ use std::borrow::Cow;
 use std::convert::From;
 use std::fmt;
 
+use stun::{DEFAULT_PORT, DEFAULT_TLS_PORT};
+
 use crate::error::*;
 
 /// The type of server used in the ice.URL structure.
@@ -166,9 +168,9 @@ impl Url {
         let port = if let Some(port) = raw_parts.port() {
             port
         } else if scheme == SchemeType::Stun || scheme == SchemeType::Turn {
-            3478
+            DEFAULT_PORT
         } else {
-            5349
+            DEFAULT_TLS_PORT
         };
 
         let mut q_args = raw_parts.query_pairs();


### PR DESCRIPTION
Replace hardcoded port numbers 3478 and 5349 with DEFAULT_PORT and 
DEFAULT_TLS_PORT constants from the stun module to improve code 
readability and maintainability.

- Add import for stun::{DEFAULT_PORT, DEFAULT_TLS_PORT}
- Replace 3478 with DEFAULT_PORT for STUN/TURN protocols
- Replace 5349 with DEFAULT_TLS_PORT for STUNS/TURNS protocols