### PR TITLE
stun: use format! macro instead of string concatenation in Uri display

### DIFF
--- a/stun/src/uri.rs
+++ b/stun/src/uri.rs
@@ -21,7 +21,7 @@ pub struct Uri {
 impl fmt::Display for Uri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let host = if self.host.contains("::") {
-            "[".to_owned() + self.host.as_str() + "]"
+            format!("[{}]", self.host)
         } else {
             self.host.clone()
         };


### PR DESCRIPTION
Replace manual string concatenation with format! macro for IPv6 host formatting in Uri::fmt implementation for better readability and performance.