### PR TITLE
mdns: allow reuse_port on non-Unix platforms when feature is enabled

### DIFF
--- a/mdns/src/conn/mod.rs
+++ b/mdns/src/conn/mod.rs
@@ -58,8 +58,7 @@ impl DnsConn {
             Some(socket2::Protocol::UDP),
         )?;
 
-        #[cfg(feature = "reuse_port")]
-        #[cfg(target_family = "unix")]
+        #[cfg(all(target_family = "unix", feature = "reuse_port"))]
         socket.set_reuse_port(true)?;
 
         socket.set_reuse_address(true)?;


### PR DESCRIPTION
Change conditional compilation from requiring both unix target family and reuse_port feature to allowing either condition.