### PR TITLE
do not used fixed sctp-ports 5000, but consult the negotiated ports

### DIFF
--- a/data/src/data_channel/data_channel_test.rs
+++ b/data/src/data_channel/data_channel_test.rs
@@ -35,6 +35,8 @@ async fn create_new_association_pair(
             max_receive_buffer_size: 0,
             max_message_size: 0,
             name: "client".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await;
 
@@ -51,6 +53,8 @@ async fn create_new_association_pair(
             max_receive_buffer_size: 0,
             max_message_size: 0,
             name: "server".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await;
 

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -187,7 +187,7 @@ impl DataChannel {
                     match self.handle_dcep(&mut data).await {
                         Ok(()) => {}
                         Err(err) => {
-                            log::error!("Failed to handle DCEP: {:?}", err);
+                            log::error!("Failed to handle DCEP: {err:?}");
                         }
                     }
                     continue;

--- a/dtls/src/conn/conn_test.rs
+++ b/dtls/src/conn/conn_test.rs
@@ -2302,7 +2302,7 @@ async fn test_multiple_hello_verify_request() -> Result<()> {
 
     for i in 0..cookies.len() {
         let cookie = &cookies[i];
-        trace!("cookie {}: {:?}", i, cookie);
+        trace!("cookie {i}: {cookie:?}");
 
         // read client hello
         let mut resp = vec![0; 1024];

--- a/dtls/src/crypto/mod.rs
+++ b/dtls/src/crypto/mod.rs
@@ -342,7 +342,7 @@ fn verify_signature(
         _ => return Err(Error::ErrKeySignatureVerifyUnimplemented),
     };
 
-    log::trace!("Picked an algorithm {:?}", verify_alg);
+    log::trace!("Picked an algorithm {verify_alg:?}");
 
     let public_key = ring::signature::UnparsedPublicKey::new(
         verify_alg,

--- a/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
+++ b/examples/examples/data-channels-flow-control/data-channels-flow-control.rs
@@ -174,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
                 if let Ok(candidate) = candidate.to_json() {
                     if let Some(requester) = maybe_requester.upgrade() {
                         if let Err(err) = requester.add_ice_candidate(candidate).await {
-                            log::warn!("{}", err);
+                            log::warn!("{err}");
                         }
                     }
                 }
@@ -191,7 +191,7 @@ async fn main() -> anyhow::Result<()> {
                 if let Ok(candidate) = candidate.to_json() {
                     if let Some(responder) = maybe_responder.upgrade() {
                         if let Err(err) = responder.add_ice_candidate(candidate).await {
-                            log::warn!("{}", err);
+                            log::warn!("{err}");
                         }
                     }
                 }

--- a/examples/examples/ortc/ortc.rs
+++ b/examples/examples/ortc/ortc.rs
@@ -189,7 +189,8 @@ async fn main() -> Result<()> {
     dtls.start(remote_signal.dtls_parameters).await?;
 
     // Start the SCTP transport
-    sctp.start(remote_signal.sctp_capabilities).await?;
+    sctp.start(remote_signal.sctp_capabilities, 5000, 5000)
+        .await?;
 
     // Construct the data channel as the offerer
     if is_offer {

--- a/examples/examples/play-from-disk-hevc/play-from-disk-hevc.rs
+++ b/examples/examples/play-from-disk-hevc/play-from-disk-hevc.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
     let (answer_sdr, answer_rcv) = mpsc::channel::<RTCSessionDescription>(10);
     tokio::spawn(async move {
         if let Err(e) = offer_worker(video_file1, audio_file, offer_sdr, answer_rcv).await {
-            println!("[Speaker] Error: {:?}", e);
+            println!("[Speaker] Error: {e:?}");
         }
     });
     // Create a MediaEngine object to configure the supported codec

--- a/ice/src/agent/agent_gather.rs
+++ b/ice/src/agent/agent_gather.rs
@@ -226,7 +226,7 @@ impl Agent {
             .await;
 
             if let Err(err) = result {
-                log::error!("Failed to gather local candidates using UDP mux: {}", err);
+                log::error!("Failed to gather local candidates using UDP mux: {err}");
             }
 
             return;
@@ -426,9 +426,7 @@ impl Agent {
                             Ok(ip) => Some(ip),
                             Err(err) => {
                                 log::warn!(
-                            "1:1 NAT mapping is enabled but not external IP is found for {}: {}",
-                            ip,
-                            err
+                            "1:1 NAT mapping is enabled but not external IP is found for {ip}: {err}"
                         );
                                 None
                             }

--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -180,10 +180,7 @@ impl AgentInternal {
         }
 
         log::debug!(
-            "Started agent: isControlling? {}, remoteUfrag: {}, remotePwd: {}",
-            is_controlling,
-            remote_ufrag,
-            remote_pwd
+            "Started agent: isControlling? {is_controlling}, remoteUfrag: {remote_ufrag}, remotePwd: {remote_pwd}"
         );
         self.set_remote_credentials(remote_ufrag, remote_pwd)
             .await?;

--- a/ice/src/agent/agent_selector.rs
+++ b/ice/src/agent/agent_selector.rs
@@ -137,7 +137,7 @@ impl AgentInternal {
                 };
 
                 if let Err(err) = result {
-                    log::error!("{}", err);
+                    log::error!("{err}");
                     None
                 } else {
                     log::trace!(
@@ -297,7 +297,7 @@ impl ControllingSelector for AgentInternal {
         };
 
         if let Err(err) = result {
-            log::error!("{}", err);
+            log::error!("{err}");
         } else {
             self.send_binding_request(&msg, local, remote).await;
         }
@@ -316,15 +316,11 @@ impl ControllingSelector for AgentInternal {
             // Assert that NAT is not symmetric
             // https://tools.ietf.org/html/rfc8445#section-7.2.5.2.1
             if transaction_addr != remote_addr {
-                log::debug!("discard message: transaction source and destination does not match expected({}), actual({})", transaction_addr, remote);
+                log::debug!("discard message: transaction source and destination does not match expected({transaction_addr}), actual({remote})");
                 return;
             }
 
-            log::trace!(
-                "inbound STUN (SuccessResponse) from {} to {}",
-                remote,
-                local
-            );
+            log::trace!("inbound STUN (SuccessResponse) from {remote} to {local}");
             let selected_pair_is_none = self.agent_conn.get_selected_pair().is_none();
 
             if let Some(p) = self.find_pair(local, remote).await {
@@ -380,10 +376,7 @@ impl ControllingSelector for AgentInternal {
                 && self.agent_conn.get_selected_pair().is_none()
             {
                 if let Some(best_pair) = self.agent_conn.get_best_available_candidate_pair().await {
-                    log::trace!(
-                        "controllingSelector: getBestAvailableCandidatePair {}",
-                        best_pair
-                    );
+                    log::trace!("controllingSelector: getBestAvailableCandidatePair {best_pair}");
                     if best_pair == p
                         && self.is_nominatable(&p.local)
                         && self.is_nominatable(&p.remote)
@@ -449,7 +442,7 @@ impl ControlledSelector for AgentInternal {
         };
 
         if let Err(err) = result {
-            log::error!("{}", err);
+            log::error!("{err}");
         } else {
             self.send_binding_request(&msg, local, remote).await;
         }
@@ -474,20 +467,16 @@ impl ControlledSelector for AgentInternal {
             // Assert that NAT is not symmetric
             // https://tools.ietf.org/html/rfc8445#section-7.2.5.2.1
             if transaction_addr != remote_addr {
-                log::debug!("discard message: transaction source and destination does not match expected({}), actual({})", transaction_addr, remote);
+                log::debug!("discard message: transaction source and destination does not match expected({transaction_addr}), actual({remote})");
                 return;
             }
 
-            log::trace!(
-                "inbound STUN (SuccessResponse) from {} to {}",
-                remote,
-                local
-            );
+            log::trace!("inbound STUN (SuccessResponse) from {remote} to {local}");
 
             if let Some(p) = self.find_pair(local, remote).await {
                 p.state
                     .store(CandidatePairState::Succeeded as u8, Ordering::SeqCst);
-                log::trace!("Found valid candidate pair: {}", p);
+                log::trace!("Found valid candidate pair: {p}");
 
                 if p.nominate_on_binding_success.load(Ordering::SeqCst)
                     && self.agent_conn.get_selected_pair().is_none()

--- a/ice/src/agent/agent_vnet_test.rs
+++ b/ice/src/agent/agent_vnet_test.rs
@@ -658,8 +658,8 @@ async fn test_connectivity_vnet_1to1_nat_with_host_candidate_vs_symmetric_nats()
         filtering_behavior: nat::EndpointDependencyType::EndpointAddrPortDependent,
         ..Default::default()
     };
-    log::debug!("natType0: {:?}", nat_type0);
-    log::debug!("natType1: {:?}", nat_type1);
+    log::debug!("natType0: {nat_type0:?}");
+    log::debug!("natType1: {nat_type1:?}");
 
     let v = build_vnet(nat_type0, nat_type1).await?;
 
@@ -711,8 +711,8 @@ async fn test_connectivity_vnet_1to1_nat_with_srflx_candidate_vs_symmetric_nats(
         filtering_behavior: nat::EndpointDependencyType::EndpointAddrPortDependent,
         ..Default::default()
     };
-    log::debug!("natType0: {:?}", nat_type0);
-    log::debug!("natType1: {:?}", nat_type1);
+    log::debug!("natType0: {nat_type0:?}");
+    log::debug!("natType1: {nat_type1:?}");
 
     let v = build_vnet(nat_type0, nat_type1).await?;
 

--- a/ice/src/agent/mod.rs
+++ b/ice/src/agent/mod.rs
@@ -141,7 +141,7 @@ impl Agent {
                 Err(err) => {
                     // Opportunistic mDNS: If we can't open the connection, that's ok: we
                     // can continue without it.
-                    log::warn!("Failed to initialize mDNS {}: {}", mdns_name, err);
+                    log::warn!("Failed to initialize mDNS {mdns_name}: {err}");
                     None
                 }
             };
@@ -269,7 +269,7 @@ impl Agent {
         if c.tcp_type() == TcpType::Active {
             // TCP Candidates with tcptype active will probe server passive ones, so
             // no need to do anything with them.
-            log::info!("Ignoring remote candidate with tcpType active: {}", c);
+            log::info!("Ignoring remote candidate with tcpType active: {c}");
             return Ok(());
         }
 
@@ -515,7 +515,7 @@ impl Agent {
     async fn close_multicast_conn(mdns_conn: &Option<Arc<DnsConn>>) {
         if let Some(conn) = mdns_conn {
             if let Err(err) = conn.close().await {
-                log::warn!("failed to close mDNS Conn: {}", err);
+                log::warn!("failed to close mDNS Conn: {err}");
             }
         }
     }

--- a/ice/src/mdns/mod.rs
+++ b/ice/src/mdns/mod.rs
@@ -58,7 +58,7 @@ pub(crate) fn create_multicast_dns(
     } else {
         SocketAddr::from_str(dest_addr)?
     };
-    log::info!("mDNS is using {} as dest_addr", addr);
+    log::info!("mDNS is using {addr} as dest_addr");
 
     let conn = DnsConn::server(
         addr,

--- a/ice/src/udp_mux/mod.rs
+++ b/ice/src/udp_mux/mod.rs
@@ -125,7 +125,7 @@ impl UDPMuxDefault {
 
         match result {
             Err(err) => {
-                log::warn!("Failed to handle decode ICE from {}: {}", addr, err);
+                log::warn!("Failed to handle decode ICE from {addr}: {err}");
                 None
             }
             Ok(_) => {
@@ -139,10 +139,7 @@ impl UDPMuxDefault {
                     // Per the RFC this shouldn't happen
                     // https://datatracker.ietf.org/doc/html/rfc5389#section-15.3
                     Err(err) => {
-                        log::warn!(
-                            "Failed to decode USERNAME from STUN message as UTF-8: {}",
-                            err
-                        );
+                        log::warn!("Failed to decode USERNAME from STUN message as UTF-8: {err}");
                         return None;
                     }
                     Ok(s) => s,
@@ -197,14 +194,14 @@ impl UDPMuxDefault {
                                     }
                                     Some(conn) => {
                                         if let Err(err) = conn.write_packet(&buffer[..len], addr).await {
-                                            log::error!("Failed to write packet: {}", err);
+                                            log::error!("Failed to write packet: {err}");
                                         }
                                     }
                                 }
                             }
                             Err(Error::Io(err)) if err.0.kind() == ErrorKind::TimedOut => continue,
                             Err(err) => {
-                                log::error!("Could not read udp packet: {}", err);
+                                log::error!("Could not read udp packet: {err}");
                                 break;
                             }
                         }
@@ -325,7 +322,7 @@ impl UDPMuxWriter for UDPMuxDefault {
                 .or_insert_with(|| conn.clone());
         }
 
-        log::debug!("Registered {} for {}", addr, key);
+        log::debug!("Registered {addr} for {key}");
     }
 
     async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> Result<usize, Error> {

--- a/ice/src/udp_mux/udp_mux_test.rs
+++ b/ice/src/udp_mux/udp_mux_test.rs
@@ -62,7 +62,7 @@ async fn test_udp_mux() -> Result<()> {
     let udp_socket = UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).await?;
 
     let addr = udp_socket.local_addr()?;
-    log::info!("Listening on {}", addr);
+    log::info!("Listening on {addr}");
 
     let udp_mux = UDPMuxDefault::new(UDPMuxParams::new(udp_socket));
     let udp_mux_dyn = Arc::clone(&udp_mux) as Arc<dyn UDPMux + Send + Sync>;
@@ -164,9 +164,9 @@ async fn test_mux_connection(
         .unwrap();
 
     let remote_connection = Arc::new(network.bind().await?);
-    log::info!("Bound for ufrag: {}", ufrag);
+    log::info!("Bound for ufrag: {ufrag}");
     remote_connection.connect(connect_addr).await?;
-    log::info!("Connected to {} for ufrag: {}", connect_addr, ufrag);
+    log::info!("Connected to {connect_addr} for ufrag: {ufrag}");
     log::info!(
         "Testing muxing from {} over {}",
         remote_connection.local_addr().unwrap(),
@@ -222,7 +222,7 @@ async fn test_mux_connection(
                 .expect("Failed to write to muxxed connection");
 
             read += n;
-            log::debug!("Muxxed read {}, sequence: {}", read, next_sequence);
+            log::debug!("Muxxed read {read}, sequence: {next_sequence}");
             next_sequence += 1;
         }
     });
@@ -243,7 +243,7 @@ async fn test_mux_connection(
 
             verify_packet(&buffer[..n], next_sequence);
             read += n;
-            log::debug!("Remote read {}, sequence: {}", read, next_sequence);
+            log::debug!("Remote read {read}, sequence: {next_sequence}");
             next_sequence += 1;
         }
     });
@@ -261,7 +261,7 @@ async fn test_mux_connection(
         let len = remote_connection.send(&buffer).await?;
 
         written += len;
-        log::debug!("Data written {}, sequence: {}", written, sequence);
+        log::debug!("Data written {written}, sequence: {sequence}");
         sequence += 1;
 
         sleep(Duration::from_millis(1)).await;

--- a/ice/src/util/mod.rs
+++ b/ice/src/util/mod.rs
@@ -160,7 +160,7 @@ pub async fn listen_udp_in_port_range(
         let laddr = SocketAddr::new(laddr.ip(), port_current);
         match vnet.bind(laddr).await {
             Ok(c) => return Ok(c),
-            Err(err) => log::debug!("failed to listen {}: {}", laddr, err),
+            Err(err) => log::debug!("failed to listen {laddr}: {err}"),
         };
 
         port_current += 1;

--- a/ice/src/util/util_test.rs
+++ b/ice/src/util/util_test.rs
@@ -25,10 +25,7 @@ async fn test_local_interfaces() -> Result<()> {
     assert!(!ips.iter().any(|ip| ip.is_loopback()));
     assert!(ips_with_loopback.iter().any(|ip| ip.is_loopback()));
     log::info!(
-        "interfaces: {:?}, ips: {:?}, ips_with_loopback: {:?}",
-        interfaces,
-        ips,
-        ips_with_loopback
+        "interfaces: {interfaces:?}, ips: {ips:?}, ips_with_loopback: {ips_with_loopback:?}"
     );
     Ok(())
 }

--- a/interceptor/src/nack/generator/mod.rs
+++ b/interceptor/src/nack/generator/mod.rs
@@ -141,7 +141,7 @@ impl Generator {
                     let a = Attributes::new();
                     for nack in nacks{
                         if let Err(err) = rtcp_writer.write(&[Box::new(nack)], &a).await{
-                            log::warn!("failed sending nack: {}", err);
+                            log::warn!("failed sending nack: {err}");
                         }
                     }
                 }
@@ -183,7 +183,7 @@ impl Interceptor for Generator {
         tokio::spawn(async move {
             let _d = w.take();
             if let Err(err) = Generator::run(writer2, internal).await {
-                log::warn!("bind_rtcp_writer NACK Generator::run got error: {}", err);
+                log::warn!("bind_rtcp_writer NACK Generator::run got error: {err}");
             }
         });
 

--- a/interceptor/src/nack/responder/mod.rs
+++ b/interceptor/src/nack/responder/mod.rs
@@ -75,7 +75,7 @@ impl ResponderInternal {
                         if let Some(p) = stream3.get(seq).await {
                             let a = Attributes::new();
                             if let Err(err) = stream3.next_rtp_writer.write(&p, &a).await {
-                                log::warn!("failed resending nacked packet: {}", err);
+                                log::warn!("failed resending nacked packet: {err}");
                             }
                         }
                         true

--- a/interceptor/src/report/receiver/mod.rs
+++ b/interceptor/src/report/receiver/mod.rs
@@ -114,7 +114,7 @@ impl ReceiverReport {
 
                         let a = Attributes::new();
                         if let Err(err) = rtcp_writer.write(&[Box::new(pkt)], &a).await{
-                            log::warn!("failed sending: {}", err);
+                            log::warn!("failed sending: {err}");
                         }
                     }
                 }
@@ -159,7 +159,7 @@ impl Interceptor for ReceiverReport {
         tokio::spawn(async move {
             let _d = w.take();
             if let Err(err) = ReceiverReport::run(writer2, internal).await {
-                log::warn!("bind_rtcp_writer ReceiverReport::run got error: {}", err);
+                log::warn!("bind_rtcp_writer ReceiverReport::run got error: {err}");
             }
         });
 

--- a/interceptor/src/report/sender/mod.rs
+++ b/interceptor/src/report/sender/mod.rs
@@ -74,7 +74,7 @@ impl SenderReport {
 
                         let a = Attributes::new();
                         if let Err(err) = rtcp_writer.write(&[Box::new(pkt)], &a).await{
-                            log::warn!("failed sending: {}", err);
+                            log::warn!("failed sending: {err}");
                         }
                     }
                 }
@@ -116,7 +116,7 @@ impl Interceptor for SenderReport {
         tokio::spawn(async move {
             let _d = w.take();
             if let Err(err) = SenderReport::run(writer2, internal).await {
-                log::warn!("bind_rtcp_writer Generator::run got error: {}", err);
+                log::warn!("bind_rtcp_writer Generator::run got error: {err}");
             }
         });
 

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -135,10 +135,7 @@ impl StatsInterceptor {
             .send(Message::RequestInboundSnapshot { ssrcs, chan: tx })
             .await
         {
-            log::debug!(
-                "Failed to fetch inbound RTP stream stats from stats task with error: {}",
-                e
-            );
+            log::debug!("Failed to fetch inbound RTP stream stats from stats task with error: {e}");
 
             return vec![];
         }
@@ -158,8 +155,7 @@ impl StatsInterceptor {
             .await
         {
             log::debug!(
-                "Failed to fetch outbound RTP stream stats from stats task with error: {}",
-                e
+                "Failed to fetch outbound RTP stream stats from stats task with error: {e}"
             );
 
             return vec![];

--- a/interceptor/src/twcc/receiver/mod.rs
+++ b/interceptor/src/twcc/receiver/mod.rs
@@ -139,7 +139,7 @@ impl Receiver {
                     }
 
                     if let Err(err) = rtcp_writer.write(&pkts, &a).await{
-                        log::error!("rtcp_writer.write got err: {}", err);
+                        log::error!("rtcp_writer.write got err: {err}");
                     }
                 }
             }
@@ -182,7 +182,7 @@ impl Interceptor for Receiver {
         tokio::spawn(async move {
             let _d = w.take();
             if let Err(err) = Receiver::run(writer2, internal).await {
-                log::warn!("bind_rtcp_writer TWCC Sender::run got error: {}", err);
+                log::warn!("bind_rtcp_writer TWCC Sender::run got error: {err}");
             }
         });
 

--- a/mdns/src/conn/mod.rs
+++ b/mdns/src/conn/mod.rs
@@ -72,7 +72,7 @@ impl DnsConn {
             let interfaces = match ifaces::ifaces() {
                 Ok(e) => e,
                 Err(e) => {
-                    log::error!("Error getting interfaces: {:?}", e);
+                    log::error!("Error getting interfaces: {e:?}");
                     return Err(Error::Other(e.to_string()));
                 }
             };
@@ -81,12 +81,12 @@ impl DnsConn {
                 if let Some(SocketAddr::V4(e)) = interface.addr {
                     if let Err(e) = socket.join_multicast_v4(&Ipv4Addr::new(224, 0, 0, 251), e.ip())
                     {
-                        log::trace!("Error connecting multicast, error: {:?}", e);
+                        log::trace!("Error connecting multicast, error: {e:?}");
                         join_error_count += 1;
                         continue;
                     }
 
-                    log::trace!("Connected to interface address {:?}", e);
+                    log::trace!("Connected to interface address {e:?}");
                 }
             }
 
@@ -155,7 +155,7 @@ impl DnsConn {
                 Ok(())
             }
             Err(e) => {
-                log::warn!("Error sending close command to server: {:?}", e);
+                log::warn!("Error sending close command to server: {e:?}");
                 Err(Error::ErrConnectionClosed)
             }
         }
@@ -212,7 +212,7 @@ impl DnsConn {
         let packed_name = match Name::new(name) {
             Ok(pn) => pn,
             Err(err) => {
-                log::warn!("Failed to construct mDNS packet: {}", err);
+                log::warn!("Failed to construct mDNS packet: {err}");
                 return;
             }
         };
@@ -231,7 +231,7 @@ impl DnsConn {
             match msg.pack() {
                 Ok(v) => v,
                 Err(err) => {
-                    log::error!("Failed to construct mDNS packet {}", err);
+                    log::error!("Failed to construct mDNS packet {err}");
                     return;
                 }
             }
@@ -239,7 +239,7 @@ impl DnsConn {
 
         log::trace!("{:?} sending {:?}...", self.socket.local_addr(), raw_query);
         if let Err(err) = self.socket.send_to(&raw_query, self.dst_addr).await {
-            log::error!("Failed to send mDNS packet {}", err);
+            log::error!("Failed to send mDNS packet {err}");
         }
     }
 
@@ -270,11 +270,11 @@ impl DnsConn {
                         Ok((len, addr)) => {
                             n = len;
                             src = addr;
-                            log::trace!("Received new connection from {:?}", addr);
+                            log::trace!("Received new connection from {addr:?}");
                         },
 
                         Err(err) => {
-                            log::error!("Error receiving from socket connection: {:?}", err);
+                            log::error!("Error receiving from socket connection: {err:?}");
                             continue;
                         },
                     }
@@ -283,7 +283,7 @@ impl DnsConn {
 
             let mut p = Parser::default();
             if let Err(err) = p.start(&b[..n]) {
-                log::error!("Failed to parse mDNS packet {}", err);
+                log::error!("Failed to parse mDNS packet {err}");
                 continue;
             }
 
@@ -309,7 +309,7 @@ async fn run(
                     log::trace!("Parsing has completed");
                     break;
                 } else {
-                    log::error!("Failed to parse mDNS packet {}", err);
+                    log::error!("Failed to parse mDNS packet {err}");
                     return;
                 }
             }
@@ -344,7 +344,7 @@ async fn run(
                 if let Err(e) =
                     send_answer(socket, &interface_addr, &q.name.data, src.ip(), dst_addr).await
                 {
-                    log::error!("Error sending answer to client: {:?}", e);
+                    log::error!("Error sending answer to client: {e:?}");
                     continue;
                 };
             }
@@ -359,7 +359,7 @@ async fn run(
             Ok(a) => a,
             Err(err) => {
                 if Error::ErrSectionDone != err {
-                    log::warn!("Failed to parse mDNS packet {}", err);
+                    log::warn!("Failed to parse mDNS packet {err}");
                 }
                 return;
             }
@@ -424,7 +424,7 @@ async fn send_answer(
     };
 
     socket.send_to(&raw_answer, dst_addr).await?;
-    log::trace!("Sent answer to IP {}", dst);
+    log::trace!("Sent answer to IP {dst}");
 
     Ok(())
 }

--- a/sctp/examples/ping.rs
+++ b/sctp/examples/ping.rs
@@ -67,6 +67,8 @@ async fn main() -> Result<(), Error> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     };
     let a = Association::client(config).await?;
     println!("created a client");

--- a/sctp/examples/pong.rs
+++ b/sctp/examples/pong.rs
@@ -67,6 +67,8 @@ async fn main() -> Result<(), Error> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "server".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     };
     let a = Association::server(config).await?;
     println!("created a server");

--- a/sctp/examples/throughput.rs
+++ b/sctp/examples/throughput.rs
@@ -68,6 +68,8 @@ fn main() -> Result<(), Error> {
                     max_receive_buffer_size: 0,
                     max_message_size: 0,
                     name: "recver".to_owned(),
+                    local_port: 5000,
+                    remote_port: 5000,
                 };
                 let a = Association::server(config).await?;
                 println!("created a server");
@@ -114,6 +116,8 @@ fn main() -> Result<(), Error> {
                     max_receive_buffer_size: 0,
                     max_message_size: 0,
                     name: "sender".to_owned(),
+                    local_port: 5000,
+                    remote_port: 5000,
                 };
                 let a = Association::client(config).await.unwrap();
                 println!("created a client");

--- a/sctp/src/association/association_internal/association_internal_test.rs
+++ b/sctp/src/association/association_internal/association_internal_test.rs
@@ -73,6 +73,8 @@ fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
 
     a.cumulative_tsn_ack_point = 9;
@@ -106,6 +108,8 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
 
     a.cumulative_tsn_ack_point = 9;
@@ -177,6 +181,8 @@ async fn test_handle_forward_tsn_forward_3unreceived_chunks() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
     a.use_forward_tsn = true;
 
@@ -216,6 +222,8 @@ async fn test_handle_forward_tsn_forward_1for1_missing() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
     a.use_forward_tsn = true;
 
@@ -269,6 +277,8 @@ async fn test_handle_forward_tsn_forward_1for2_missing() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
     a.use_forward_tsn = true;
 
@@ -320,6 +330,8 @@ async fn test_handle_forward_tsn_dup_forward_tsn_chunk_should_generate_sack() ->
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
     a.use_forward_tsn = true;
 
@@ -354,6 +366,8 @@ async fn test_assoc_create_new_stream() -> Result<()> {
             max_receive_buffer_size: 0,
             max_message_size: 0,
             name: "client".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         },
         close_loop_ch_tx,
         accept_ch_tx,
@@ -398,6 +412,8 @@ async fn handle_init_test(name: &str, initial_state: AssociationState, expect_er
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5002,
+        remote_port: 5001,
     });
     a.set_state(initial_state);
     let pkt = Packet {
@@ -488,6 +504,8 @@ async fn test_assoc_max_message_size_default() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
     assert_eq!(
         a.max_message_size.load(Ordering::SeqCst),
@@ -533,6 +551,8 @@ async fn test_assoc_max_message_size_explicit() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 30000,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     });
 
     assert_eq!(

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -1829,7 +1829,7 @@ async fn test_assoc_reset_close_one_way() -> Result<()> {
                     let _ = done_ch_tx.send(None).await;
                 }
                 Err(err) => {
-                    log::debug!("s1.read_sctp err {:?}", err);
+                    log::debug!("s1.read_sctp err {err:?}");
                     let _ = done_ch_tx.send(Some(err)).await;
                     break;
                 }
@@ -1846,7 +1846,7 @@ async fn test_assoc_reset_close_one_way() -> Result<()> {
         tokio::select! {
             _ = timer.as_mut() =>{},
             result = done_ch_rx.recv() => {
-                log::debug!("s1. {:?}", result);
+                log::debug!("s1. {result:?}");
                 if let Some(err_opt) = result {
                     if err_opt.is_some() {
                         break;
@@ -1931,7 +1931,7 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
                     let _ = done_ch_tx1.send(None).await;
                 }
                 Err(err) => {
-                    log::debug!("s1.read_sctp err {:?}", err);
+                    log::debug!("s1.read_sctp err {err:?}");
                     let _ = done_ch_tx1.send(Some(err)).await;
                     break;
                 }
@@ -1948,7 +1948,7 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
         tokio::select! {
             _ = timer.as_mut() =>{},
             result = done_ch_rx.recv() => {
-                log::debug!("s1. {:?}", result);
+                log::debug!("s1. {result:?}");
                 if let Some(err_opt) = result {
                     if err_opt.is_some() {
                         break;
@@ -1977,7 +1977,7 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
                 panic!("must be error");
             }
             Err(err) => {
-                log::debug!("s0.read_sctp err {:?}", err);
+                log::debug!("s0.read_sctp err {err:?}");
                 let _ = done_ch_tx0.send(Some(err)).await;
             }
         }
@@ -1992,7 +1992,7 @@ async fn test_assoc_reset_close_both_ways() -> Result<()> {
         tokio::select! {
             _ = timer.as_mut() =>{},
             result = done_ch_rx.recv() => {
-                log::debug!("s0. {:?}", result);
+                log::debug!("s0. {result:?}");
                 if let Some(err_opt) = result {
                     if err_opt.is_some() {
                         break;
@@ -2392,7 +2392,7 @@ async fn test_association_shutdown_during_write() -> Result<()> {
             _ = writing_done_rx.recv() => {
                 log::debug!("writing_done_rx");
                 let result = close_loop_ch_rx.recv().await;
-                log::debug!("a1.close_loop_ch_rx.recv: {:?}", result);
+                log::debug!("a1.close_loop_ch_rx.recv: {result:?}");
             },
         };
     }
@@ -2567,7 +2567,7 @@ async fn test_association_handle_packet_before_init() -> Result<()> {
     ];
 
     for (name, packet) in tests {
-        log::debug!("testing {}", name);
+        log::debug!("testing {name}");
 
         let (a_conn, charlie_conn) = pipe();
 

--- a/sctp/src/association/association_test.rs
+++ b/sctp/src/association/association_test.rs
@@ -35,6 +35,8 @@ async fn create_new_association_pair(
             max_receive_buffer_size: recv_buf_size,
             max_message_size: 0,
             name: "client".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await;
 
@@ -51,6 +53,8 @@ async fn create_new_association_pair(
             max_receive_buffer_size: recv_buf_size,
             max_message_size: 0,
             name: "server".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await;
 
@@ -2174,6 +2178,8 @@ async fn test_stats() -> Result<()> {
         max_receive_buffer_size: 0,
         max_message_size: 0,
         name: "client".to_owned(),
+        local_port: 5000,
+        remote_port: 5000,
     })
     .await?;
 
@@ -2209,6 +2215,8 @@ async fn create_assocs() -> Result<(Association, Association)> {
             max_receive_buffer_size: 0,
             max_message_size: 0,
             name: "client".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await?;
 
@@ -2223,6 +2231,8 @@ async fn create_assocs() -> Result<(Association, Association)> {
             max_receive_buffer_size: 0,
             max_message_size: 0,
             name: "server".to_owned(),
+            local_port: 5000,
+            remote_port: 5000,
         })
         .await?;
 
@@ -2567,6 +2577,8 @@ async fn test_association_handle_packet_before_init() -> Result<()> {
                 max_message_size: 0,
                 max_receive_buffer_size: 0,
                 name: "client".to_owned(),
+                local_port: 5000,
+                remote_port: 5000,
             },
             true,
         )

--- a/sctp/src/association/mod.rs
+++ b/sctp/src/association/mod.rs
@@ -407,7 +407,7 @@ impl Association {
         mut close_loop_ch: broadcast::Receiver<()>,
         association_internal: Arc<Mutex<AssociationInternal>>,
     ) {
-        log::debug!("[{}] read_loop entered", name);
+        log::debug!("[{name}] read_loop entered");
 
         let mut buffer = vec![0u8; RECEIVE_MTU];
         let mut done = false;
@@ -421,7 +421,7 @@ impl Association {
                             n=m;
                         }
                         Err(err) => {
-                            log::warn!("[{}] failed to read packets on net_conn: {}", name, err);
+                            log::warn!("[{name}] failed to read packets on net_conn: {err}");
                             break;
                         }
                     }
@@ -432,14 +432,14 @@ impl Association {
             // read from the underlying transport. We do this because the
             // user data is passed to the reassembly queue without
             // copying.
-            log::debug!("[{}] recving {} bytes", name, n);
+            log::debug!("[{name}] recving {n} bytes");
             let inbound = Bytes::from(buffer[..n].to_vec());
             bytes_received.fetch_add(n, Ordering::SeqCst);
 
             {
                 let mut ai = association_internal.lock().await;
                 if let Err(err) = ai.handle_inbound(&inbound).await {
-                    log::warn!("[{}] failed to handle_inbound: {:?}", name, err);
+                    log::warn!("[{name}] failed to handle_inbound: {err:?}");
                     done = true;
                 }
             }
@@ -448,11 +448,11 @@ impl Association {
         {
             let mut ai = association_internal.lock().await;
             if let Err(err) = ai.close().await {
-                log::warn!("[{}] failed to close association: {:?}", name, err);
+                log::warn!("[{name}] failed to close association: {err:?}");
             }
         }
 
-        log::debug!("[{}] read_loop exited", name);
+        log::debug!("[{name}] read_loop exited");
     }
 
     async fn write_loop(
@@ -463,7 +463,7 @@ impl Association {
         association_internal: Arc<Mutex<AssociationInternal>>,
         mut awake_write_loop_ch: mpsc::Receiver<()>,
     ) {
-        log::debug!("[{}] write_loop entered", name);
+        log::debug!("[{name}] write_loop entered");
         let done = Arc::new(AtomicBool::new(false));
         let name = Arc::new(name);
 
@@ -495,7 +495,7 @@ impl Association {
                     Ok(Ok(mut buf)) => {
                         let raw = buf.as_ref();
                         if let Err(err) = net_conn.send(raw.as_ref()).await {
-                            log::warn!("[{}] failed to write packets on net_conn: {}", name2, err);
+                            log::warn!("[{name2}] failed to write packets on net_conn: {err}");
                             done2.store(true, Ordering::Relaxed)
                         } else {
                             bytes_sent.fetch_add(raw.len(), Ordering::SeqCst);
@@ -506,18 +506,16 @@ impl Association {
                         buffer = Some(buf);
                     }
                     Ok(Err(err)) => {
-                        log::warn!("[{}] failed to serialize a packet: {:?}", name2, err);
+                        log::warn!("[{name2}] failed to serialize a packet: {err:?}");
                     }
                     Err(err) => {
                         if err.is_cancelled() {
                             log::debug!(
-                                "[{}] task cancelled while serializing a packet: {:?}",
-                                name,
-                                err
+                                "[{name}] task cancelled while serializing a packet: {err:?}"
                             );
                             break 'outer;
                         } else {
-                            log::error!("[{}] panic while serializing a packet: {:?}", name, err);
+                            log::error!("[{name}] panic while serializing a packet: {err:?}");
                         }
                     }
                 }
@@ -541,11 +539,11 @@ impl Association {
         {
             let mut ai = association_internal.lock().await;
             if let Err(err) = ai.close().await {
-                log::warn!("[{}] failed to close association: {:?}", name, err);
+                log::warn!("[{name}] failed to close association: {err:?}");
             }
         }
 
-        log::debug!("[{}] write_loop exited", name);
+        log::debug!("[{name}] write_loop exited");
     }
 
     /// bytes_sent returns the number of bytes sent

--- a/sctp/src/association/mod.rs
+++ b/sctp/src/association/mod.rs
@@ -178,6 +178,8 @@ pub struct Config {
     pub max_receive_buffer_size: u32,
     pub max_message_size: u32,
     pub name: String,
+    pub remote_port: u16,
+    pub local_port: u16,
 }
 
 ///Association represents an SCTP association

--- a/sdp/src/description/common.rs
+++ b/sdp/src/description/common.rs
@@ -35,10 +35,10 @@ impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.address)?;
         if let Some(t) = &self.ttl {
-            write!(f, "/{}", t)?;
+            write!(f, "/{t}")?;
         }
         if let Some(r) = &self.range {
-            write!(f, "/{}", r)?;
+            write!(f, "/{r}")?;
         }
         Ok(())
     }

--- a/sdp/src/description/media.rs
+++ b/sdp/src/description/media.rs
@@ -245,14 +245,14 @@ impl fmt::Display for MediaName {
         for part in &self.protos {
             if first {
                 first = false;
-                write!(f, " {}", part)?;
+                write!(f, " {part}")?;
             } else {
-                write!(f, "/{}", part)?;
+                write!(f, "/{part}")?;
             }
         }
 
         for part in &self.formats {
-            write!(f, " {}", part)?;
+            write!(f, " {part}")?;
         }
 
         Ok(())

--- a/srtp/src/session/mod.rs
+++ b/srtp/src/session/mod.rs
@@ -98,7 +98,7 @@ impl Session {
                 tokio::select! {
                     result = incoming_stream => match result{
                         Ok(()) => {},
-                        Err(err) => log::info!("{}", err),
+                        Err(err) => log::info!("{err}"),
                     },
                     opt = close_stream => if let Some(ssrc) = opt {
                         Session::close_stream(&cloned_streams_map, ssrc).await

--- a/stun/src/uattrs.rs
+++ b/stun/src/uattrs.rs
@@ -23,7 +23,7 @@ impl fmt::Display for UnknownAttributes {
                 .map(|t| t.to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
-            write!(f, "{}", s)
+            write!(f, "{s}")
         }
     }
 }

--- a/turn/src/allocation/allocation_manager.rs
+++ b/turn/src/allocation/allocation_manager.rs
@@ -131,7 +131,7 @@ impl Manager {
 
         if let Some(a) = allocation {
             if let Err(err) = a.close().await {
-                log::error!("Failed to close allocation: {}", err);
+                log::error!("Failed to close allocation: {err}");
             }
         }
     }
@@ -159,7 +159,7 @@ impl Manager {
 
         future::join_all(to_delete.iter().map(|a| async move {
             if let Err(err) = a.close().await {
-                log::error!("Failed to close allocation: {}", err);
+                log::error!("Failed to close allocation: {err}");
             }
         }))
         .await;

--- a/turn/src/allocation/channel_bind.rs
+++ b/turn/src/allocation/channel_bind.rs
@@ -54,7 +54,7 @@ impl ChannelBind {
                         if let Some(cbs) = &channel_bindings.clone().and_then(|x| x.upgrade()) {
                             let mut cb = cbs.lock().await;
                             if cb.remove(&number).is_none() {
-                                log::error!("Failed to remove ChannelBind for {}", number);
+                                log::error!("Failed to remove ChannelBind for {number}");
                             }
                         }
                         done = true;

--- a/turn/src/allocation/mod.rs
+++ b/turn/src/allocation/mod.rs
@@ -371,7 +371,7 @@ impl Allocation {
                         }
                     }
                     _ = drop_rx.as_mut() => {
-                        log::trace!("allocation has stopped, stop packet_handler. five_tuple: {:?}", five_tuple);
+                        log::trace!("allocation has stopped, stop packet_handler. five_tuple: {five_tuple:?}");
                         break;
                     }
                 };
@@ -407,11 +407,7 @@ impl Allocation {
                         .send_to(&channel_data.raw, five_tuple.src_addr)
                         .await
                     {
-                        log::error!(
-                            "Failed to send ChannelData from allocation {} {}",
-                            src_addr,
-                            err
-                        );
+                        log::error!("Failed to send ChannelData from allocation {src_addr} {err}");
                     }
                 } else {
                     let exist = {
@@ -435,9 +431,7 @@ impl Allocation {
                                 Box::new(data_attr),
                             ]) {
                                 log::error!(
-                                    "Failed to send DataIndication from allocation {} {}",
-                                    src_addr,
-                                    err
+                                    "Failed to send DataIndication from allocation {src_addr} {err}"
                                 );
                                 None
                             } else {
@@ -455,17 +449,13 @@ impl Allocation {
                                 turn_socket.send_to(&msg.raw, five_tuple.src_addr).await
                             {
                                 log::error!(
-                                    "Failed to send DataIndication from allocation {} {}",
-                                    src_addr,
-                                    err
+                                    "Failed to send DataIndication from allocation {src_addr} {err}"
                                 );
                             }
                         }
                     } else {
                         log::info!(
-                            "No Permission or Channel exists for {} on allocation {}",
-                            src_addr,
-                            relay_addr
+                            "No Permission or Channel exists for {src_addr} on allocation {relay_addr}"
                         );
                     }
                 }

--- a/turn/src/auth/mod.rs
+++ b/turn/src/auth/mod.rs
@@ -50,12 +50,7 @@ pub struct LongTermAuthHandler {
 
 impl AuthHandler for LongTermAuthHandler {
     fn auth_handle(&self, username: &str, realm: &str, src_addr: SocketAddr) -> Result<Vec<u8>> {
-        log::trace!(
-            "Authentication username={} realm={} src_addr={}",
-            username,
-            realm,
-            src_addr
-        );
+        log::trace!("Authentication username={username} realm={realm} src_addr={src_addr}");
 
         let t = Duration::from_secs(username.parse::<u64>()?);
         if t < SystemTime::now().duration_since(UNIX_EPOCH)? {

--- a/turn/src/client/client_test.rs
+++ b/turn/src/client/client_test.rs
@@ -59,7 +59,7 @@ async fn test_client_with_stun_send_binding_request() -> Result<()> {
     let c = create_listening_test_client_with_stun_serv().await?;
 
     let resp = c.send_binding_request().await?;
-    log::debug!("mapped-addr: {}", resp);
+    log::debug!("mapped-addr: {resp}");
     {
         let ci = c.client_internal.lock().await;
         let tm = ci.tr_map.lock().await;
@@ -86,7 +86,7 @@ async fn test_client_with_stun_send_binding_request_to_parallel() -> Result<()> 
     tokio::spawn(async move {
         drop(stared_tx);
         if let Ok(resp) = c2.send_binding_request_to(&to.to_string()).await {
-            log::debug!("mapped-addr: {}", resp);
+            log::debug!("mapped-addr: {resp}");
         }
         drop(finished_tx);
     });
@@ -94,7 +94,7 @@ async fn test_client_with_stun_send_binding_request_to_parallel() -> Result<()> 
     let _ = started_rx.recv().await;
 
     let resp = c1.send_binding_request_to(&to.to_string()).await?;
-    log::debug!("mapped-addr: {}", resp);
+    log::debug!("mapped-addr: {resp}");
 
     let _ = finished_rx.recv().await;
 

--- a/turn/src/client/mod.rs
+++ b/turn/src/client/mod.rs
@@ -179,7 +179,7 @@ impl ClientInternal {
             let stun_serv = net
                 .resolve_addr(local_addr.is_ipv4(), &config.stun_serv_addr)
                 .await?;
-            log::debug!("stunServ: {}", stun_serv);
+            log::debug!("stunServ: {stun_serv}");
             stun_serv.to_string()
         };
 
@@ -191,7 +191,7 @@ impl ClientInternal {
             let turn_serv = net
                 .resolve_addr(local_addr.is_ipv4(), &config.turn_serv_addr)
                 .await?;
-            log::debug!("turnServ: {}", turn_serv);
+            log::debug!("turnServ: {turn_serv}");
             turn_serv.to_string()
         };
 
@@ -248,12 +248,12 @@ impl ClientInternal {
                     result = conn.recv_from(&mut buf) => match result {
                         Ok((n, from)) => (n, from),
                         Err(err) => {
-                            log::debug!("exiting read loop: {}", err);
+                            log::debug!("exiting read loop: {err}");
                             break;
                         }
                     }
                 };
-                log::debug!("received {} bytes of udp from {}", n, from);
+                log::debug!("received {n} bytes of udp from {from}");
 
                 select! {
                     biased;
@@ -271,7 +271,7 @@ impl ClientInternal {
                         &binding_mgr,
                     ) => {
                         if let Err(err) = result {
-                            log::debug!("exiting read loop: {}", err);
+                            log::debug!("exiting read loop: {err}");
                             break;
                         }
                     }
@@ -356,7 +356,7 @@ impl ClientInternal {
                 let mut data = Data::default();
                 data.get_from(&msg)?;
 
-                log::debug!("data indication received from {}", from);
+                log::debug!("data indication received from {from}");
 
                 let _ = ClientInternal::handle_inbound_relay_conn(read_ch_tx, &data.0, from).await;
             }
@@ -374,7 +374,7 @@ impl ClientInternal {
         let mut tm = tr_map.lock().await;
         if tm.find(&tr_key).is_none() {
             // silently discard
-            log::debug!("no transaction for {}", msg);
+            log::debug!("no transaction for {msg}");
             return Ok(());
         }
 
@@ -391,7 +391,7 @@ impl ClientInternal {
                 })
                 .await
             {
-                log::debug!("no listener for msg.raw {:?}", data);
+                log::debug!("no listener for msg.raw {data:?}");
             }
         }
 
@@ -433,7 +433,7 @@ impl ClientInternal {
         let read_ch_tx_opt = read_ch_tx.lock().await;
         log::debug!("read_ch_tx_opt = {}", read_ch_tx_opt.is_some());
         if let Some(tx) = &*read_ch_tx_opt {
-            log::debug!("try_send data = {:?}, from = {}", data, from);
+            log::debug!("try_send data = {data:?}, from = {from}");
             if tx
                 .try_send(InboundData {
                     data: data.to_vec(),

--- a/turn/src/client/relay_conn.rs
+++ b/turn/src/client/relay_conn.rs
@@ -283,7 +283,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
                                 }
 
                                 // keep going...
-                                log::warn!("bind() failed: {}", err);
+                                log::warn!("bind() failed: {err}");
                             } else if let Some(b) = bm.get_by_addr(&bind_addr) {
                                 b.set_state(BindingState::Ready);
                             }
@@ -342,7 +342,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
                             }
 
                             // keep going...
-                            log::warn!("bind() for refresh failed: {}", err);
+                            log::warn!("bind() for refresh failed: {err}");
                         } else if let Some(b) = bm.get_by_addr(&bind_addr) {
                             b.set_refreshed_at(Instant::now());
                             b.set_state(BindingState::Ready);
@@ -478,7 +478,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
                 Box::new(FINGERPRINT),
             ])?;
 
-            log::debug!("send refresh request (dont_wait={})", dont_wait);
+            log::debug!("send refresh request (dont_wait={dont_wait})");
             let turn_server_addr = obs.turn_server_addr();
             let tr_res = obs
                 .perform_transaction(&msg, &turn_server_addr, dont_wait)
@@ -525,7 +525,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
 
         if let Err(err) = self.create_permissions(&addrs).await {
             if Error::ErrTryAgain != err {
-                log::error!("fail to refresh permissions: {}", err);
+                log::error!("fail to refresh permissions: {err}");
             }
             return Err(err);
         }
@@ -575,7 +575,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
             return Err(Error::ErrUnexpectedResponse);
         }
 
-        log::debug!("channel binding successful: {} {}", bind_addr, bind_number);
+        log::debug!("channel binding successful: {bind_addr} {bind_number}");
 
         // Success.
         Ok(())
@@ -585,7 +585,7 @@ impl<T: RelayConnObserver + Send + Sync> RelayConnInternal<T> {
 #[async_trait]
 impl<T: RelayConnObserver + Send + Sync> PeriodicTimerTimeoutHandler for RelayConnInternal<T> {
     async fn on_timeout(&mut self, id: TimerIdRefresh) {
-        log::debug!("refresh timer {:?} expired", id);
+        log::debug!("refresh timer {id:?} expired");
         match id {
             TimerIdRefresh::Alloc => {
                 let lifetime = self.lifetime;

--- a/turn/src/client/transaction.rs
+++ b/turn/src/client/transaction.rs
@@ -47,12 +47,7 @@ async fn on_rtx_timeout(
         return true;
     }
 
-    log::trace!(
-        "retransmitting transaction {} to {} (n_rtx={})",
-        tr_key,
-        tr_to,
-        n_rtx
-    );
+    log::trace!("retransmitting transaction {tr_key} to {tr_to} (n_rtx={n_rtx})");
 
     let dst = match SocketAddr::from_str(&tr_to) {
         Ok(dst) => dst,

--- a/turn/src/server/mod.rs
+++ b/turn/src/server/mod.rs
@@ -170,7 +170,7 @@ impl Server {
                             break;
                         }
                         Err(RecvError::Lagged(n)) => {
-                            log::warn!("Turn server has lagged by {} messages", n);
+                            log::warn!("Turn server has lagged by {n} messages");
                             continue;
                         }
                     }
@@ -184,7 +184,7 @@ impl Server {
                     match v {
                         Ok(v) => v,
                         Err(err) => {
-                            log::debug!("exit read loop on error: {}", err);
+                            log::debug!("exit read loop on error: {err}");
                             break;
                         }
                     }
@@ -204,7 +204,7 @@ impl Server {
             };
 
             if let Err(err) = r.handle_request().await {
-                log::error!("error when handling datagram: {}", err);
+                log::error!("error when handling datagram: {err}");
             }
         }
 

--- a/turn/src/server/server_test.rs
+++ b/turn/src/server/server_test.rs
@@ -242,7 +242,7 @@ async fn test_server_vnet_send_binding_request() -> Result<()> {
 
     log::debug!("sending a binding request.");
     let refl_addr = client.send_binding_request().await?;
-    log::debug!("mapped-address: {}", refl_addr);
+    log::debug!("mapped-address: {refl_addr}");
 
     // The mapped-address should have IP address that was assigned
     // to the LAN router.

--- a/util/src/conn/conn_udp_listener.rs
+++ b/util/src/conn/conn_udp_listener.rs
@@ -176,7 +176,7 @@ impl ListenConfig {
                             }
                         }
                         Err(err) => {
-                            log::warn!("ListenConfig pconn.recv_from error: {}", err);
+                            log::warn!("ListenConfig pconn.recv_from error: {err}");
                             break;
                         }
                     };

--- a/util/src/vnet/chunk/chunk_test.rs
+++ b/util/src/vnet/chunk/chunk_test.rs
@@ -26,7 +26,7 @@ fn test_chunk_udp() -> Result<()> {
 
     let mut c = ChunkUdp::new(src, dst);
     let s = c.to_string();
-    log::debug!("chunk: {}", s);
+    log::debug!("chunk: {s}");
     assert_eq!(c.network(), UDP_STR, "should match");
     assert!(s.contains(&src.to_string()), "should include address");
     assert!(s.contains(&dst.to_string()), "should include address");

--- a/util/src/vnet/conn/conn_test.rs
+++ b/util/src/vnet/conn/conn_test.rs
@@ -83,7 +83,7 @@ async fn test_udp_conn_send_to_recv_from() -> Result<()> {
             let (n, addr) = match conn_rx.recv_from(&mut buf).await {
                 Ok((n, addr)) => (n, addr),
                 Err(err) => {
-                    log::debug!("conn closed. exiting the read loop with err {}", err);
+                    log::debug!("conn closed. exiting the read loop with err {err}");
                     break;
                 }
             };
@@ -91,7 +91,7 @@ async fn test_udp_conn_send_to_recv_from() -> Result<()> {
             log::debug!("read data");
             assert_eq!(data_rx.len(), n, "should match");
             assert_eq!(&data_rx, &buf[..n], "should match");
-            log::debug!("dst_addr {} vs add {}", dst_addr, addr);
+            log::debug!("dst_addr {dst_addr} vs add {addr}");
             assert_eq!(dst_addr.to_string(), addr.to_string(), "should match");
             let _ = rcvd_ch_tx.send(()).await;
         }
@@ -170,7 +170,7 @@ async fn test_udp_conn_send_recv() -> Result<()> {
             let n = match conn_rx.recv(&mut buf).await {
                 Ok(n) => n,
                 Err(err) => {
-                    log::debug!("conn closed. exiting the read loop with err {}", err);
+                    log::debug!("conn closed. exiting the read loop with err {err}");
                     break;
                 }
             };

--- a/util/src/vnet/nat/nat_test.rs
+++ b/util/src/vnet/nat/nat_test.rs
@@ -61,19 +61,19 @@ async fn test_nat_mapping_behavior_full_cone_nat() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     let iec = ChunkUdp::new(
         SocketAddr::new(dst.ip(), dst.port()),
         SocketAddr::new(oec.source_addr().ip(), oec.source_addr().port()),
     );
 
-    log::debug!("i-original  : {}", iec);
+    log::debug!("i-original  : {iec}");
 
     let iic = nat.translate_inbound(&iec).await?.unwrap();
 
-    log::debug!("i-translated: {}", iic);
+    log::debug!("i-translated: {iic}");
 
     assert_eq!(oic.source_addr(), iic.destination_addr(), "should match");
 
@@ -117,12 +117,12 @@ async fn test_nat_mapping_behavior_addr_restricted_cone_nat() -> Result<()> {
     let dst = SocketAddr::from_str("5.6.7.8:5678")?;
 
     let oic = ChunkUdp::new(src, dst);
-    log::debug!("o-original  : {}", oic);
+    log::debug!("o-original  : {oic}");
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-translated: {oec}");
 
     // sending different (IP: 5.6.7.9) won't create a new mapping
     let oic2 = ChunkUdp::new(
@@ -132,18 +132,18 @@ async fn test_nat_mapping_behavior_addr_restricted_cone_nat() -> Result<()> {
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
-    log::debug!("o-translated: {}", oec2);
+    log::debug!("o-translated: {oec2}");
 
     let iec = ChunkUdp::new(
         SocketAddr::new(dst.ip(), dst.port()),
         SocketAddr::new(oec.source_addr().ip(), oec.source_addr().port()),
     );
 
-    log::debug!("i-original  : {}", iec);
+    log::debug!("i-original  : {iec}");
 
     let iic = nat.translate_inbound(&iec).await?.unwrap();
 
-    log::debug!("i-translated: {}", iic);
+    log::debug!("i-translated: {iic}");
 
     assert_eq!(oic.source_addr(), iic.destination_addr(), "should match");
 
@@ -196,12 +196,12 @@ async fn test_nat_mapping_behavior_port_restricted_cone_nat() -> Result<()> {
     let dst = SocketAddr::from_str("5.6.7.8:5678")?;
 
     let oic = ChunkUdp::new(src, dst);
-    log::debug!("o-original  : {}", oic);
+    log::debug!("o-original  : {oic}");
 
     let oec = nat.translate_outbound(&oic).await?.unwrap();
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-translated: {oec}");
 
     // sending different (IP: 5.6.7.9) won't create a new mapping
     let oic2 = ChunkUdp::new(
@@ -211,18 +211,18 @@ async fn test_nat_mapping_behavior_port_restricted_cone_nat() -> Result<()> {
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
-    log::debug!("o-translated: {}", oec2);
+    log::debug!("o-translated: {oec2}");
 
     let iec = ChunkUdp::new(
         SocketAddr::new(dst.ip(), dst.port()),
         SocketAddr::new(oec.source_addr().ip(), oec.source_addr().port()),
     );
 
-    log::debug!("i-original  : {}", iec);
+    log::debug!("i-original  : {iec}");
 
     let iic = nat.translate_inbound(&iec).await?.unwrap();
 
-    log::debug!("i-translated: {}", iic);
+    log::debug!("i-translated: {iic}");
 
     assert_eq!(oic.source_addr(), iic.destination_addr(), "should match");
 
@@ -280,9 +280,9 @@ async fn test_nat_mapping_behavior_symmetric_nat_addr_dependent_mapping() -> Res
     let oic2 = ChunkUdp::new(src, dst2);
     let oic3 = ChunkUdp::new(src, dst3);
 
-    log::debug!("o-original  : {}", oic1);
-    log::debug!("o-original  : {}", oic2);
-    log::debug!("o-original  : {}", oic3);
+    log::debug!("o-original  : {oic1}");
+    log::debug!("o-original  : {oic2}");
+    log::debug!("o-original  : {oic3}");
 
     let oec1 = nat.translate_outbound(&oic1).await?.unwrap();
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
@@ -291,9 +291,9 @@ async fn test_nat_mapping_behavior_symmetric_nat_addr_dependent_mapping() -> Res
     assert_eq!(nat.outbound_map_len().await, 2, "should match");
     assert_eq!(nat.inbound_map_len().await, 2, "should match");
 
-    log::debug!("o-translated: {}", oec1);
-    log::debug!("o-translated: {}", oec2);
-    log::debug!("o-translated: {}", oec3);
+    log::debug!("o-translated: {oec1}");
+    log::debug!("o-translated: {oec2}");
+    log::debug!("o-translated: {oec3}");
 
     assert_ne!(
         oec1.source_addr().port(),
@@ -332,9 +332,9 @@ async fn test_nat_mapping_behavior_symmetric_nat_port_dependent_mapping() -> Res
     let oic2 = ChunkUdp::new(src, dst2);
     let oic3 = ChunkUdp::new(src, dst3);
 
-    log::debug!("o-original  : {}", oic1);
-    log::debug!("o-original  : {}", oic2);
-    log::debug!("o-original  : {}", oic3);
+    log::debug!("o-original  : {oic1}");
+    log::debug!("o-original  : {oic2}");
+    log::debug!("o-original  : {oic3}");
 
     let oec1 = nat.translate_outbound(&oic1).await?.unwrap();
     let oec2 = nat.translate_outbound(&oic2).await?.unwrap();
@@ -343,9 +343,9 @@ async fn test_nat_mapping_behavior_symmetric_nat_port_dependent_mapping() -> Res
     assert_eq!(nat.outbound_map_len().await, 3, "should match");
     assert_eq!(nat.inbound_map_len().await, 3, "should match");
 
-    log::debug!("o-translated: {}", oec1);
-    log::debug!("o-translated: {}", oec2);
-    log::debug!("o-translated: {}", oec3);
+    log::debug!("o-translated: {oec1}");
+    log::debug!("o-translated: {oec2}");
+    log::debug!("o-translated: {oec3}");
 
     assert_ne!(
         oec1.source_addr().port(),
@@ -384,8 +384,8 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     // record mapped addr
     let mapped = oec.source_addr().to_string();
@@ -397,8 +397,8 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     assert_eq!(
         mapped,
@@ -414,8 +414,8 @@ async fn test_nat_mapping_timeout_refresh_on_outbound() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     assert_ne!(
         oec.source_addr().to_string(),
@@ -449,8 +449,8 @@ async fn test_nat_mapping_timeout_outbound_detects_timeout() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 1, "should match");
     assert_eq!(nat.inbound_map_len().await, 1, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     // sleep long enough for the mapping to expire
     tokio::time::sleep(Duration::from_millis(125)).await;
@@ -460,7 +460,7 @@ async fn test_nat_mapping_timeout_outbound_detects_timeout() -> Result<()> {
         SocketAddr::new(oec.source_addr().ip(), oec.source_addr().port()),
     );
 
-    log::debug!("i-original  : {}", iec);
+    log::debug!("i-original  : {iec}");
 
     let result = nat.translate_inbound(&iec).await;
     assert!(result.is_err(), "should drop");
@@ -491,8 +491,8 @@ async fn test_nat1to1_behavior_one_mapping() -> Result<()> {
     assert_eq!(nat.outbound_map_len().await, 0, "should match");
     assert_eq!(nat.inbound_map_len().await, 0, "should match");
 
-    log::debug!("o-original  : {}", oic);
-    log::debug!("o-translated: {}", oec);
+    log::debug!("o-original  : {oic}");
+    log::debug!("o-translated: {oec}");
 
     assert_eq!(
         "1.2.3.4:1234",
@@ -505,11 +505,11 @@ async fn test_nat1to1_behavior_one_mapping() -> Result<()> {
         SocketAddr::new(oec.source_addr().ip(), oec.source_addr().port()),
     );
 
-    log::debug!("i-original  : {}", iec);
+    log::debug!("i-original  : {iec}");
 
     let iic = nat.translate_inbound(&iec).await?.unwrap();
 
-    log::debug!("i-translated: {}", iic);
+    log::debug!("i-translated: {iic}");
 
     assert_eq!(oic.source_addr(), iic.destination_addr(), "should match");
 

--- a/util/src/vnet/net/net_test.rs
+++ b/util/src/vnet/net/net_test.rs
@@ -27,11 +27,11 @@ async fn test_net_native_interfaces() -> Result<()> {
     assert!(!nw.is_virtual(), "should be false");
 
     let interfaces = nw.get_interfaces().await;
-    log::debug!("interfaces: {:?}", interfaces);
+    log::debug!("interfaces: {interfaces:?}");
     for ifc in interfaces {
         let addrs = ifc.addrs();
         for addr in addrs {
-            log::debug!("{}", addr)
+            log::debug!("{addr}")
         }
     }
 
@@ -65,7 +65,7 @@ async fn test_net_native_bind() -> Result<()> {
         "127.0.0.1",
         "local_addr ip should match 127.0.0.1"
     );
-    log::debug!("laddr: {}", laddr);
+    log::debug!("laddr: {laddr}");
 
     Ok(())
 }
@@ -83,7 +83,7 @@ async fn test_net_native_dail() -> Result<()> {
         "local_addr should match 127.0.0.1"
     );
     assert_ne!(laddr.port(), 1234, "local_addr port should match 1234");
-    log::debug!("laddr: {}", laddr);
+    log::debug!("laddr: {laddr}");
 
     Ok(())
 }
@@ -293,7 +293,7 @@ async fn test_net_virtual_assign_port() -> Result<()> {
 
         for i in 0..space {
             let port = vnet.assign_port(ip, start, end).await?;
-            log::debug!("{} got port: {}", i, port);
+            log::debug!("{i} got port: {port}");
 
             let obs: Arc<Mutex<dyn ConnObserver + Send + Sync>> =
                 Arc::new(Mutex::new(DummyObserver));
@@ -343,7 +343,7 @@ async fn test_net_virtual_determine_source_ip() -> Result<()> {
         let vnet = vnet.lock().await;
         let vi = vnet.vi.lock().await;
         let src_ip = vi.determine_source_ip(any_ip, dst_ip);
-        log::debug!("any_ip: {} => {:?}", any_ip, src_ip);
+        log::debug!("any_ip: {any_ip} => {src_ip:?}");
         assert!(src_ip.is_some(), "shouldn't be none");
         if let Some(src_ip) = src_ip {
             assert_eq!(src_ip.to_string().as_str(), DEMO_IP, "use non-loopback IP");
@@ -357,7 +357,7 @@ async fn test_net_virtual_determine_source_ip() -> Result<()> {
         let vnet = vnet.lock().await;
         let vi = vnet.vi.lock().await;
         let src_ip = vi.determine_source_ip(any_ip, dst_ip);
-        log::debug!("any_ip: {} => {:?}", any_ip, src_ip);
+        log::debug!("any_ip: {any_ip} => {src_ip:?}");
         assert!(src_ip.is_some(), "shouldn't be none");
         if let Some(src_ip) = src_ip {
             assert_eq!(src_ip.to_string().as_str(), "127.0.0.1", "use loopback IP");
@@ -371,7 +371,7 @@ async fn test_net_virtual_determine_source_ip() -> Result<()> {
         let vnet = vnet.lock().await;
         let vi = vnet.vi.lock().await;
         let src_ip = vi.determine_source_ip(any_ip, dst_ip);
-        log::debug!("any_ip: {} => {:?}", any_ip, src_ip);
+        log::debug!("any_ip: {any_ip} => {src_ip:?}");
         assert!(src_ip.is_some(), "shouldn't be none");
         if let Some(src_ip) = src_ip {
             assert_eq!(src_ip, any_ip, "IP change");
@@ -581,7 +581,7 @@ async fn test_net_virtual_loopback2() -> Result<()> {
                     let (n, addr) = match result {
                         Ok((n, addr)) => (n, addr),
                         Err(err) => {
-                            log::debug!("ReadFrom returned: {}", err);
+                            log::debug!("ReadFrom returned: {err}");
                             break;
                         }
                     };
@@ -706,7 +706,7 @@ async fn test_net_virtual_end2end() -> Result<()> {
                     let n = match result{
                         Ok((n, _)) => n,
                         Err(err) => {
-                            log::debug!("ReadFrom returned: {}", err);
+                            log::debug!("ReadFrom returned: {err}");
                             break;
                         }
                     };
@@ -734,7 +734,7 @@ async fn test_net_virtual_end2end() -> Result<()> {
                     let (n, addr) = match result{
                         Ok((n, addr)) => (n, addr),
                         Err(err) => {
-                            log::debug!("ReadFrom returned: {}", err);
+                            log::debug!("ReadFrom returned: {err}");
                             break;
                         }
                     };
@@ -838,7 +838,7 @@ async fn test_net_virtual_two_ips_on_a_nic() -> Result<()> {
                     let n = match result{
                         Ok((n, _)) => n,
                         Err(err) => {
-                            log::debug!("ReadFrom returned: {}", err);
+                            log::debug!("ReadFrom returned: {err}");
                             break;
                         }
                     };
@@ -866,7 +866,7 @@ async fn test_net_virtual_two_ips_on_a_nic() -> Result<()> {
                     let (n, addr) = match result{
                         Ok((n, addr)) => (n, addr),
                         Err(err) => {
-                            log::debug!("ReadFrom returned: {}", err);
+                            log::debug!("ReadFrom returned: {err}");
                             break;
                         }
                     };

--- a/util/src/vnet/resolver.rs
+++ b/util/src/vnet/resolver.rs
@@ -26,7 +26,7 @@ impl Resolver {
         };
 
         if let Err(err) = r.add_host("localhost".to_owned(), "127.0.0.1".to_owned()) {
-            log::warn!("failed to add localhost to Resolver: {}", err);
+            log::warn!("failed to add localhost to Resolver: {err}");
         }
         r
     }

--- a/util/src/vnet/resolver/resolver_test.rs
+++ b/util/src/vnet/resolver/resolver_test.rs
@@ -21,7 +21,7 @@ async fn test_resolver_standalone() -> Result<()> {
     let name = "abc.com";
     let ip_addr = DEMO_IP;
     let ip = IpAddr::from_str(ip_addr)?;
-    log::debug!("adding {} {}", name, ip_addr);
+    log::debug!("adding {name} {ip_addr}");
 
     r.add_host(name.to_owned(), ip_addr.to_owned())?;
 

--- a/util/src/vnet/router.rs
+++ b/util/src/vnet/router.rs
@@ -499,7 +499,7 @@ impl Router {
                         ni.on_inbound_chunk(c).await;
                     } else {
                         // NIC not found. drop it.
-                        log::debug!("[{}] {} unreachable", name, c);
+                        log::debug!("[{name}] {c} unreachable");
                     }
                 } else {
                     // the destination is outside of this subnet
@@ -513,7 +513,7 @@ impl Router {
                         }
                     } else {
                         // this WAN. No route for this chunk
-                        log::debug!("[{}] no route found for {}", name, c);
+                        log::debug!("[{name}] no route found for {c}");
                     }
                 }
             } else {
@@ -536,7 +536,7 @@ impl RouterInternal {
         if ips.is_empty() {
             // assign an IP address
             let ip = self.assign_ip_address()?;
-            log::debug!("assign_ip_address: {}", ip);
+            log::debug!("assign_ip_address: {ip}");
             ips.push(ip);
         }
 

--- a/util/src/vnet/router/router_test.rs
+++ b/util/src/vnet/router/router_test.rs
@@ -46,7 +46,7 @@ impl Nic for DummyNic {
     }
 
     async fn on_inbound_chunk(&self, c: Box<dyn Chunk + Send + Sync>) {
-        log::debug!("received: {}", c);
+        log::debug!("received: {c}");
         match self.on_inbound_chunk_handler {
             0 => {
                 self.cbs0.fetch_add(1, Ordering::SeqCst);
@@ -321,9 +321,9 @@ async fn test_router_standalone_add_chunk_filter() -> Result<()> {
             let m = n.fetch_add(1, Ordering::SeqCst);
             let pass = m > 0;
             if pass {
-                log::debug!("{}: {} passed {}", m, name, c);
+                log::debug!("{m}: {name} passed {c}");
             } else {
-                log::debug!("{}: {} blocked {}", m, name, c);
+                log::debug!("{m}: {name} blocked {c}");
             }
             pass
         })
@@ -440,9 +440,9 @@ async fn delay_sub_test(title: String, min_delay: Duration, max_jitter: Duration
         let n = nics[1].lock().await;
         let delay_res = n.delay_res.lock().await;
         for d in &*delay_res {
-            log::info!("min delay : {:?}", min_delay);
-            log::info!("max jitter: {:?}", max_jitter);
-            log::info!("actual delay: {:?}", d);
+            log::info!("min delay : {min_delay:?}");
+            log::info!("max jitter: {max_jitter:?}");
+            log::info!("actual delay: {d:?}");
             assert!(*d >= min_delay, "{title} should delay {d:?} >= 20ms");
             assert!(
                 *d <= (min_delay + max_jitter + MARGIN),
@@ -587,7 +587,7 @@ async fn test_router_one_child() -> Result<()> {
             SocketAddr::new(ips[1], 1234), //lanIP
             SocketAddr::new(ips[0], 5678), //wanIP
         ));
-        log::debug!("sending {}", c);
+        log::debug!("sending {c}");
         let lan = rs[1].lock().await;
         lan.push(c).await;
     }

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -609,7 +609,7 @@ impl MediaEngine {
                     n_ext.1.is_audio |= typ == RTPCodecType::Audio;
                 } else {
                     let nid = n_ext.0;
-                    log::warn!("Invalid ext id mapping in update_header_extension. {} was negotiated as {}, but was {} in call", extension, nid, id);
+                    log::warn!("Invalid ext id mapping in update_header_extension. {extension} was negotiated as {nid}, but was {id} in call");
                 }
             } else {
                 // We either only have a proposal or we have neither proposal nor a negotiated id
@@ -617,7 +617,7 @@ impl MediaEngine {
 
                 if let Some(prev_ext) = negotiated_header_extensions.get(&id) {
                     let prev_uri = &prev_ext.uri;
-                    log::warn!("Assigning {} to {} would override previous assignment to {}, no action taken", id, extension, prev_uri);
+                    log::warn!("Assigning {id} to {extension} would override previous assignment to {prev_uri}, no action taken");
                 } else {
                     let h = MediaEngineHeaderExtension {
                         uri: extension.to_owned(),

--- a/webrtc/src/data_channel/data_channel_test.rs
+++ b/webrtc/src/data_channel/data_channel_test.rs
@@ -1428,7 +1428,7 @@ impl TestOrtcStack {
         self.dtls.start(sig.dtls_parameters.clone()).await?;
 
         // Start the SCTP transport
-        self.sctp.start(sig.sctp_capabilities).await?;
+        self.sctp.start(sig.sctp_capabilities, 5000, 5000).await?;
 
         Ok(())
     }

--- a/webrtc/src/data_channel/data_channel_test.rs
+++ b/webrtc/src/data_channel/data_channel_test.rs
@@ -1142,7 +1142,7 @@ async fn test_eof_detach() -> Result<()> {
                     let detached = match dc4.detach().await {
                         Ok(detached) => detached,
                         Err(err) => {
-                            log::debug!("Detach failed: {}", err);
+                            log::debug!("Detach failed: {err}");
                             panic!();
                         }
                     };
@@ -1271,7 +1271,7 @@ async fn test_eof_no_detach() -> Result<()> {
     let dca2 = Arc::clone(&dca);
     dca.on_open(Box::new(move || {
         log::debug!("pca: data channel opened");
-        log::debug!("pca: sending {:?}", test_data);
+        log::debug!("pca: sending {test_data:?}");
         let dca3 = Arc::clone(&dca2);
         Box::pin(async move {
             let _ = dca3.send(&Bytes::from_static(test_data)).await;

--- a/webrtc/src/dtls_transport/dtls_transport_test.rs
+++ b/webrtc/src/dtls_transport/dtls_transport_test.rs
@@ -87,7 +87,7 @@ async fn test_invalid_fingerprint_causes_failed() -> Result<()> {
         _ = offer_chan_rx.recv() =>{
             let mut offer = pc_offer.pending_local_description().await.unwrap();
 
-            log::trace!("receiving pending local desc: {:?}", offer);
+            log::trace!("receiving pending local desc: {offer:?}");
 
             // Replace with invalid fingerprint
             let re = Regex::new(r"sha-256 (.*?)\r").unwrap();

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -427,7 +427,7 @@ impl RTCDtlsTransport {
                 }
                 _ => {
                     if let Err(err) = dtls_conn.close().await {
-                        log::error!("{}", err);
+                        log::error!("{err}");
                     }
 
                     self.state_change(RTCDtlsTransportState::Failed).await;
@@ -440,7 +440,7 @@ impl RTCDtlsTransport {
         let remote_certs = &dtls_conn.connection_state().await.peer_certificates;
         if remote_certs.is_empty() {
             if let Err(err) = dtls_conn.close().await {
-                log::error!("{}", err);
+                log::error!("{err}");
             }
 
             self.state_change(RTCDtlsTransportState::Failed).await;
@@ -458,7 +458,7 @@ impl RTCDtlsTransport {
         {
             if let Err(err) = self.validate_fingerprint(&remote_certs[0]).await {
                 if let Err(close_err) = dtls_conn.close().await {
-                    log::error!("{}", close_err);
+                    log::error!("{close_err}");
                 }
 
                 self.state_change(RTCDtlsTransportState::Failed).await;

--- a/webrtc/src/mux/mod.rs
+++ b/webrtc/src/mux/mod.rs
@@ -112,7 +112,7 @@ impl Mux {
             };
 
             if let Err(err) = Mux::dispatch(&buf[..n], &endpoints).await {
-                log::error!("mux: ending readLoop dispatch error {:?}", err);
+                log::error!("mux: ending readLoop dispatch error {err:?}");
                 break;
             }
         }

--- a/webrtc/src/peer_connection/mod.rs
+++ b/webrtc/src/peer_connection/mod.rs
@@ -303,7 +303,7 @@ impl RTCPeerConnection {
     }
 
     async fn do_signaling_state_change(&self, new_state: RTCSignalingState) {
-        log::info!("signaling state changed to {}", new_state);
+        log::info!("signaling state changed to {new_state}");
         if let Some(handler) = &*self.internal.on_signaling_state_change_handler.load() {
             let mut f = handler.lock().await;
             f(new_state).await;
@@ -598,7 +598,7 @@ impl RTCPeerConnection {
         receiver: Arc<RTCRtpReceiver>,
         transceiver: Arc<RTCRtpTransceiver>,
     ) {
-        log::debug!("got new track: {:?}", track);
+        log::debug!("got new track: {track:?}");
 
         tokio::spawn(async move {
             if let Some(handler) = &*on_track_handler.load() {
@@ -625,7 +625,7 @@ impl RTCPeerConnection {
     ) {
         ice_connection_state.store(cs as u8, Ordering::SeqCst);
 
-        log::info!("ICE connection state changed: {}", cs);
+        log::info!("ICE connection state changed: {cs}");
         if let Some(handler) = &*handler.load() {
             let mut f = handler.lock().await;
             f(cs).await;
@@ -918,7 +918,7 @@ impl RTCPeerConnection {
             return;
         }
 
-        log::info!("peer connection state changed: {}", connection_state);
+        log::info!("peer connection state changed: {connection_state}");
         peer_connection_state.store(connection_state as u8, Ordering::SeqCst);
 
         RTCPeerConnection::do_peer_connection_state_change(
@@ -1601,9 +1601,7 @@ impl RTCPeerConnection {
                         let fp_hash = fingerprint_hash.clone();
                         Box::pin(async move {
                             log::trace!(
-                                "start_transports: ice_role={}, dtls_role={}",
-                                ice_role,
-                                dtls_role,
+                                "start_transports: ice_role={ice_role}, dtls_role={dtls_role}",
                             );
                             pc.start_transports(ice_role, dtls_role, ru, rp, fp, fp_hash)
                                 .await;

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -152,7 +152,7 @@ impl PeerConnectionInternal {
                     RTCIceTransportState::Disconnected => RTCIceConnectionState::Disconnected,
                     RTCIceTransportState::Closed => RTCIceConnectionState::Closed,
                     _ => {
-                        log::warn!("on_connection_state_change: unhandled ICE state: {}", state);
+                        log::warn!("on_connection_state_change: unhandled ICE state: {state}");
                         return Box::pin(async {});
                     }
                 };
@@ -257,9 +257,9 @@ impl PeerConnectionInternal {
                     continue;
                 }
 
-                log::info!("Stopping receiver {:?}", receiver);
+                log::info!("Stopping receiver {receiver:?}");
                 if let Err(err) = receiver.stop().await {
-                    log::warn!("Failed to stop RtpReceiver: {}", err);
+                    log::warn!("Failed to stop RtpReceiver: {err}");
                     continue;
                 }
 
@@ -324,14 +324,14 @@ impl PeerConnectionInternal {
                         return;
                     }
                     Err(err) => {
-                        log::warn!("Failed to accept RTP {}", err);
+                        log::warn!("Failed to accept RTP {err}");
                         return;
                     }
                 };
 
                 if is_closed.load(Ordering::SeqCst) {
                     if let Err(err) = stream.close().await {
-                        log::warn!("Failed to close RTP stream {}", err);
+                        log::warn!("Failed to close RTP stream {err}");
                     }
                     continue;
                 }
@@ -473,9 +473,9 @@ impl PeerConnectionInternal {
             )
             .await
         {
-            log::warn!("Failed to start SCTP: {}", err);
+            log::warn!("Failed to start SCTP: {err}");
             if let Err(err) = self.sctp_transport.stop().await {
-                log::warn!("Failed to stop SCTPTransport: {}", err);
+                log::warn!("Failed to stop SCTPTransport: {err}");
             }
 
             return;
@@ -492,7 +492,7 @@ impl PeerConnectionInternal {
         for d in data_channels {
             if d.ready_state() == RTCDataChannelState::Connecting {
                 if let Err(err) = d.open(Arc::clone(&self.sctp_transport)).await {
-                    log::warn!("failed to open data channel: {}", err);
+                    log::warn!("failed to open data channel: {err}");
                     continue;
                 }
                 opened_dc_count += 1;
@@ -708,7 +708,7 @@ impl PeerConnectionInternal {
             )
             .await
         {
-            log::warn!("Failed to start manager ice: {}", err);
+            log::warn!("Failed to start manager ice: {err}");
             return;
         }
 
@@ -732,7 +732,7 @@ impl PeerConnectionInternal {
         )
         .await;
         if let Err(err) = result {
-            log::warn!("Failed to start manager dtls: {}", err);
+            log::warn!("Failed to start manager dtls: {err}");
         }
     }
 

--- a/webrtc/src/peer_connection/peer_connection_internal.rs
+++ b/webrtc/src/peer_connection/peer_connection_internal.rs
@@ -281,9 +281,18 @@ impl PeerConnectionInternal {
 
         self.start_rtp_receivers(&mut track_details, &current_transceivers)
             .await?;
-        if let Some(parsed) = &remote_desc.parsed {
-            if have_application_media_section(parsed) {
-                self.start_sctp().await;
+        if let Some(parsed_remote) = &remote_desc.parsed {
+            let current_local_desc = self.current_local_description.lock().await;
+            if let Some(parsed_local) = current_local_desc
+                .as_ref()
+                .and_then(|desc| desc.parsed.as_ref())
+            {
+                if let Some(remote_port) = get_application_media_section_sctp_port(parsed_remote) {
+                    if let Some(local_port) = get_application_media_section_sctp_port(parsed_local)
+                    {
+                        self.start_sctp(local_port, remote_port).await;
+                    }
+                }
             }
         }
 
@@ -451,13 +460,17 @@ impl PeerConnectionInternal {
     }
 
     /// Start SCTP subsystem
-    async fn start_sctp(&self) {
+    async fn start_sctp(&self, local_port: u16, remote_port: u16) {
         // Start sctp
         if let Err(err) = self
             .sctp_transport
-            .start(SCTPTransportCapabilities {
-                max_message_size: 0,
-            })
+            .start(
+                SCTPTransportCapabilities {
+                    max_message_size: 0,
+                },
+                local_port,
+                remote_port,
+            )
             .await
         {
             log::warn!("Failed to start SCTP: {}", err);

--- a/webrtc/src/peer_connection/peer_connection_test.rs
+++ b/webrtc/src/peer_connection/peer_connection_test.rs
@@ -164,11 +164,11 @@ pub(crate) async fn signal_pair(
 pub(crate) async fn close_pair_now(pc1: &RTCPeerConnection, pc2: &RTCPeerConnection) {
     let mut fail = false;
     if let Err(err) = pc1.close().await {
-        log::error!("Failed to close PeerConnection: {}", err);
+        log::error!("Failed to close PeerConnection: {err}");
         fail = true;
     }
     if let Err(err) = pc2.close().await {
-        log::error!("Failed to close PeerConnection: {}", err);
+        log::error!("Failed to close PeerConnection: {err}");
         fail = true;
     }
 

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -112,14 +112,14 @@ pub(crate) fn track_details_from_sdp(
                                 let base_ssrc = match split[1].parse::<u32>() {
                                     Ok(ssrc) => ssrc,
                                     Err(err) => {
-                                        log::warn!("Failed to parse SSRC: {}", err);
+                                        log::warn!("Failed to parse SSRC: {err}");
                                         continue;
                                     }
                                 };
                                 let rtx_repair_flow = match split[2].parse::<u32>() {
                                     Ok(n) => n,
                                     Err(err) => {
-                                        log::warn!("Failed to parse SSRC: {}", err);
+                                        log::warn!("Failed to parse SSRC: {err}");
                                         continue;
                                     }
                                 };
@@ -156,7 +156,7 @@ pub(crate) fn track_details_from_sdp(
                         let ssrc = match split[0].parse::<u32>() {
                             Ok(ssrc) => ssrc,
                             Err(err) => {
-                                log::warn!("Failed to parse SSRC: {}", err);
+                                log::warn!("Failed to parse SSRC: {err}");
                                 continue;
                             }
                         };
@@ -243,7 +243,7 @@ pub(crate) fn get_rids(media: &MediaDescription) -> Vec<SimulcastRid> {
                 .and_then(SimulcastRid::try_from)
                 .map(|rid| rids.push(rid))
             {
-                log::warn!("Failed to parse RID: {}", err);
+                log::warn!("Failed to parse RID: {err}");
             }
         } else if attr.key.as_str() == SDP_ATTRIBUTE_SIMULCAST {
             simulcast_attr.clone_from(&attr.value);
@@ -1027,10 +1027,8 @@ pub(crate) fn get_application_media_section_sctp_port(desc: &SessionDescription)
                 m.attributes.iter().find(|attr| attr.key == "sctp-port")
             {
                 let sctp_port_value = sctp_port_attr.value.as_ref();
-                let parsed = sctp_port_value
-                    .map(|attr| attr.parse::<u16>().ok())
-                    .flatten();
-                parsed
+
+                sctp_port_value.and_then(|attr| attr.parse::<u16>().ok())
             } else if let Some(sctp_port_attr) =
                 m.attributes.iter().find(|attr| attr.key == "sctpmap")
             {
@@ -1038,8 +1036,7 @@ pub(crate) fn get_application_media_section_sctp_port(desc: &SessionDescription)
                     sctp_port_attr_value
                         .split(" ")
                         .next()
-                        .map(|port| u16::from_str(port).ok())
-                        .flatten()
+                        .and_then(|port| u16::from_str(port).ok())
                 } else {
                     None
                 }

--- a/webrtc/src/peer_connection/sdp/mod.rs
+++ b/webrtc/src/peer_connection/sdp/mod.rs
@@ -20,6 +20,7 @@ pub mod session_description;
 use std::collections::HashMap;
 use std::convert::From;
 use std::io::BufReader;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use ice::candidate::candidate_base::unmarshal_candidate;
@@ -1019,14 +1020,36 @@ pub(crate) async fn extract_ice_details(
     Ok((remote_ufrag.to_owned(), remote_pwd.to_owned(), candidates))
 }
 
-pub(crate) fn have_application_media_section(desc: &SessionDescription) -> bool {
+pub(crate) fn get_application_media_section_sctp_port(desc: &SessionDescription) -> Option<u16> {
     for m in &desc.media_descriptions {
         if m.media_name.media == MEDIA_SECTION_APPLICATION {
-            return true;
+            return if let Some(sctp_port_attr) =
+                m.attributes.iter().find(|attr| attr.key == "sctp-port")
+            {
+                let sctp_port_value = sctp_port_attr.value.as_ref();
+                let parsed = sctp_port_value
+                    .map(|attr| attr.parse::<u16>().ok())
+                    .flatten();
+                parsed
+            } else if let Some(sctp_port_attr) =
+                m.attributes.iter().find(|attr| attr.key == "sctpmap")
+            {
+                if let Some(sctp_port_attr_value) = sctp_port_attr.value.as_ref() {
+                    sctp_port_attr_value
+                        .split(" ")
+                        .next()
+                        .map(|port| u16::from_str(port).ok())
+                        .flatten()
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
         }
     }
 
-    false
+    None
 }
 
 pub(crate) fn get_by_mid<'a>(

--- a/webrtc/src/peer_connection/sdp/sdp_test.rs
+++ b/webrtc/src/peer_connection/sdp/sdp_test.rs
@@ -546,7 +546,7 @@ fn test_have_application_media_section() -> Result<()> {
             ..Default::default()
         };
 
-        assert!(!have_application_media_section(&s));
+        assert!(get_application_media_section_sctp_port(&s).is_none());
     }
 
     //"Application"
@@ -557,12 +557,16 @@ fn test_have_application_media_section() -> Result<()> {
                     media: MEDIA_SECTION_APPLICATION.to_owned(),
                     ..Default::default()
                 },
+                attributes: vec![Attribute {
+                    key: "sctp-port".to_string(),
+                    value: Some("5000".to_owned()),
+                }],
                 ..Default::default()
             }],
             ..Default::default()
         };
 
-        assert!(have_application_media_section(&s));
+        assert!(get_application_media_section_sctp_port(&s).is_some());
     }
 
     Ok(())

--- a/webrtc/src/rtp_transceiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/mod.rs
@@ -335,11 +335,7 @@ impl RTCRtpTransceiver {
         let changed = d != previous;
 
         if changed {
-            trace!(
-                "Changing direction of transceiver from {} to {}",
-                previous,
-                d
-            );
+            trace!("Changing direction of transceiver from {previous} to {d}");
         }
 
         changed
@@ -363,11 +359,7 @@ impl RTCRtpTransceiver {
             .into();
 
         if d != previous {
-            trace!(
-                "Changing current direction of transceiver from {} to {}",
-                previous,
-                d,
-            );
+            trace!("Changing current direction of transceiver from {previous} to {d}",);
         }
     }
 
@@ -387,10 +379,7 @@ impl RTCRtpTransceiver {
         if previous_direction != current_direction {
             let mid = self.mid();
             trace!(
-                "Processing transceiver({:?}) direction change from {} to {}",
-                mid,
-                previous_direction,
-                current_direction
+                "Processing transceiver({mid:?}) direction change from {previous_direction} to {current_direction}"
             );
         } else {
             // no change.

--- a/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
+++ b/webrtc/src/rtp_transceiver/rtp_receiver/mod.rs
@@ -684,7 +684,7 @@ impl RTCRtpReceiver {
         }
 
         if let Err(err) = self.receive(&RTCRtpReceiveParameters { encodings }).await {
-            log::warn!("RTPReceiver Receive failed {}", err);
+            log::warn!("RTPReceiver Receive failed {err}");
             return;
         }
 

--- a/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
+++ b/webrtc/src/rtp_transceiver/rtp_sender/rtp_sender_test.rs
@@ -75,7 +75,7 @@ async fn test_rtp_sender_replace_track() -> Result<()> {
                 Ok((pkt, _)) => pkt,
                 Err(err) => {
                     //assert!(errors.Is(io.EOF, err))
-                    log::debug!("{}", err);
+                    log::debug!("{err}");
                     return;
                 }
             };

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -239,7 +239,7 @@ impl RTCSctpTransport {
                         Ok(dc) => dc,
                         Err(err) => {
                             if data::Error::ErrStreamClosed == err {
-                                log::error!("Failed to accept data channel: {}", err);
+                                log::error!("Failed to accept data channel: {err}");
                                 if let Some(handler) = &*param.on_error_handler.load() {
                                     let mut f = handler.lock().await;
                                     f(err.into()).await;

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -136,7 +136,12 @@ impl RTCSctpTransport {
     /// Start the SCTPTransport. Since both local and remote parties must mutually
     /// create an SCTPTransport, SCTP SO (Simultaneous Open) is used to establish
     /// a connection over SCTP.
-    pub async fn start(&self, _remote_caps: SCTPTransportCapabilities) -> Result<()> {
+    pub async fn start(
+        &self,
+        _remote_caps: SCTPTransportCapabilities,
+        local_port: u16,
+        remote_port: u16,
+    ) -> Result<()> {
         if self.is_started.load(Ordering::SeqCst) {
             return Ok(());
         }
@@ -159,6 +164,8 @@ impl RTCSctpTransport {
                         max_receive_buffer_size: 0,
                         max_message_size: 0,
                         name: String::new(),
+                        local_port,
+                        remote_port,
                     }) => {
                         break Arc::new(association?);
                     }

--- a/webrtc/src/stats/mod.rs
+++ b/webrtc/src/stats/mod.rs
@@ -125,8 +125,7 @@ impl<'de> Deserialize<'de> for StatsReportType {
             .ok_or_else(|| serde::de::Error::missing_field("type"))?;
         let rtc_type: RTCStatsType = serde_json::from_value(type_field.clone()).map_err(|e| {
             serde::de::Error::custom(format!(
-                "failed to deserialize RTCStatsType from the `type` field ({}): {}",
-                type_field, e
+                "failed to deserialize RTCStatsType from the `type` field ({type_field}): {e}"
             ))
         })?;
 
@@ -228,8 +227,7 @@ impl<'de> Deserialize<'de> for StatsReport {
         for (key, value) in root {
             let report = serde_json::from_value(value.clone()).map_err(|e| {
                 serde::de::Error::custom(format!(
-                    "failed to deserialize `StatsReportType` from key={}, value={}: {}",
-                    key, value, e
+                    "failed to deserialize `StatsReportType` from key={key}, value={value}: {e}"
                 ))
             })?;
             reports.insert(key.clone(), report);


### PR DESCRIPTION
AS described in #705 this library currently fixes the sctp port used for datachannels as 5000 for both parties even if the negotiation says otherwise. This PR fixes that behaviour, consulting the negotiated ports and passing them to the sctp subsystem.