### PR TITLE
util: Simplify timeout error handling in Buffer

### DIFF
--- a/util/src/buffer/mod.rs
+++ b/util/src/buffer/mod.rs
@@ -254,9 +254,9 @@ impl Buffer {
 
             // Wait for signal.
             if let Some(d) = duration {
-                if timeout(d, self.notify.notified()).await.is_err() {
-                    return Err(Error::ErrTimeout);
-                }
+                timeout(d, self.notify.notified())
+                    .await
+                    .map_err(|_| Error::ErrTimeout)?;
             } else {
                 self.notify.notified().await;
             }


### PR DESCRIPTION
Refactor the timeout error handling in `util/src/buffer/mod.rs` to use the `?` operator.

This change simplifies the code by using `map_err` to convert the timeout error to `Error::ErrTimeout`, which is more concise and idiomatic.