### PR TITLE
interceptor: Use futures::future::join_all in stats interceptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "futures",
  "log",
  "portable-atomic",
  "rand",

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -17,6 +17,7 @@ srtp = { version = "0.15.0", path = "../srtp", package = "webrtc-srtp" }
 
 tokio = { version = "1.32.0", features = ["sync", "time"] }
 async-trait = "0.1"
+futures = "0.3"
 bytes = "1"
 thiserror = "1"
 rand = "0.9"

--- a/interceptor/src/stats/interceptor.rs
+++ b/interceptor/src/stats/interceptor.rs
@@ -570,10 +570,8 @@ where
                     },
                 })
             });
-            for fut in futures {
-                // TODO: Use futures::join_all
-                let _ = fut.await;
-            }
+
+            futures::future::join_all(futures).await;
 
             let futures = sender_reports.into_iter().map(|sr| {
                 let rtt_ms = match (sr.dlrr_last_rr, sr.dlrr_delay_rr, sr.sr_packets_sent) {
@@ -593,10 +591,8 @@ where
                     },
                 })
             });
-            for fut in futures {
-                // TODO: Use futures::join_all
-                let _ = fut.await;
-            }
+
+            futures::future::join_all(futures).await;
         }
 
         Ok((pkts, attributes))


### PR DESCRIPTION
The previous implementation iterated through a list of futures and awaited them one by one. This is inefficient as it doesn't allow the futures to run concurrently.

This commit refactors the code to use `futures::future::join_all` to await all futures concurrently, which is more efficient. This also involved adding the `futures` crate as a dependency to the `interceptor` crate.