### PR TITLE
dtls: Add packet length validation in CBC decryption

### DIFF
--- a/dtls/src/crypto/crypto_cbc.rs
+++ b/dtls/src/crypto/crypto_cbc.rs
@@ -94,10 +94,17 @@ impl CryptoCbc {
             return Ok(r.to_vec());
         }
 
+        if r.len() < RECORD_LAYER_HEADER_SIZE + Self::BLOCK_SIZE {
+            return Err(Error::ErrInvalidPacketLength);
+        }
+
         let body = &r[RECORD_LAYER_HEADER_SIZE..];
         let iv = &body[0..Self::BLOCK_SIZE];
         let body = &body[Self::BLOCK_SIZE..];
-        //TODO: add body.len() check
+
+        if body.is_empty() || body.len() % Self::BLOCK_SIZE != 0 {
+            return Err(Error::ErrInvalidPacketLength);
+        }
 
         let read_cbc = Aes256CbcDec::new_from_slices(&self.remote_key, iv)?;
 


### PR DESCRIPTION
This change adds more rigorous checks for the length of incoming DTLS packets when using a CBC-mode cipher.

Previously, a malformed or truncated packet could lead to out-of-bounds reads or other panics during the decryption process.

The following checks have been added:
- Ensure the total packet length is sufficient to contain at least the record layer header and one initialization vector (IV) block.
- After extracting the IV, validate that the remaining encrypted body is not empty and its length is a multiple of the cipher's block size.

These checks ensure that only structurally valid packets are processed, improving the robustness of the DTLS implementation.