### PR TITLE
stun: simplify URI parsing logic

### DIFF
--- a/stun/src/uri.rs
+++ b/stun/src/uri.rs
@@ -44,11 +44,8 @@ impl Uri {
 
         let mut s = raw.to_string();
         let pos = raw.find(':');
-        if let Some(p) = pos {
-            s.replace_range(p..p + 1, "://");
-        } else {
-            return Err(Error::ErrSchemeType);
-        }
+        let p = pos.ok_or(Error::ErrSchemeType)?;
+        s.replace_range(p..p + 1, "://");
 
         let raw_parts = url::Url::parse(&s)?;
 
@@ -57,14 +54,13 @@ impl Uri {
             return Err(Error::ErrSchemeType);
         }
 
-        let host = if let Some(host) = raw_parts.host_str() {
-            host.trim()
-                .trim_start_matches('[')
-                .trim_end_matches(']')
-                .to_owned()
-        } else {
-            return Err(Error::ErrHost);
-        };
+        let host = raw_parts
+            .host_str()
+            .ok_or(Error::ErrHost)?
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .to_owned();
 
         let port = raw_parts.port();
 


### PR DESCRIPTION
Refactor the `Uri::new` function to use the `?` operator for more concise error handling.

This change replaces `if let`/`else` constructs with the `?` operator, making the code more idiomatic and easier to read.