### PR TITLE
fmtp: add Unicode case-folding support for parameter compariso

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3003,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "turn",
+ "unicase",
  "url",
  "waitgroup",
  "webrtc-data",

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -50,7 +50,10 @@ waitgroup = "0.1"
 regex = "1.9.5"
 smol_str = { version = "0.2", features = ["serde"] }
 url = "2"
-rustls = { version = "0.23.27", default-features = false, features = ["std", "ring"] }
+rustls = { version = "0.23.27", default-features = false, features = [
+    "std",
+    "ring",
+] }
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 ring = "0.17.14"
 sha2 = "0.10"
@@ -60,6 +63,7 @@ pem = { version = "3", optional = true }
 time = "0.3"
 cfg-if = "1"
 portable-atomic = "1.6"
+unicase = "2.8"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/webrtc/src/rtp_transceiver/fmtp/generic/mod.rs
+++ b/webrtc/src/rtp_transceiver/fmtp/generic/mod.rs
@@ -1,21 +1,22 @@
 #[cfg(test)]
 mod generic_test;
 
+use unicase::UniCase;
+
 use super::*;
 
 /// fmtp_consist checks that two FMTP parameters are not inconsistent.
 fn fmtp_consist(a: &HashMap<String, String>, b: &HashMap<String, String>) -> bool {
-    //TODO: add unicode case-folding equal support
     for (k, v) in a {
         if let Some(vb) = b.get(k) {
-            if vb.to_uppercase() != v.to_uppercase() {
+            if UniCase::new(v) != UniCase::new(vb) {
                 return false;
             }
         }
     }
     for (k, v) in b {
         if let Some(va) = a.get(k) {
-            if va.to_uppercase() != v.to_uppercase() {
+            if UniCase::new(v) != UniCase::new(va) {
                 return false;
             }
         }


### PR DESCRIPTION
Replace to_uppercase() with unicase library for proper Unicode
case-insensitive comparison in FMTP parameters. Resolves TODO
for unicode case-folding equal support.