### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,7 +2959,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
- "tokio-test",
  "webrtc-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,6 @@ version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64",
- "chrono",
  "clap 3.2.25",
  "criterion",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
- "tokio-test",
  "webrtc-util",
  "x25519-dalek",
  "x509-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,7 +3048,6 @@ dependencies = [
  "clap 3.2.25",
  "der-parser",
  "env_logger",
- "hkdf",
  "hmac",
  "hub",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,7 +2774,6 @@ dependencies = [
  "stun",
  "thiserror",
  "tokio",
- "tokio-test",
  "tokio-util",
  "webrtc-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,6 @@ dependencies = [
  "smol_str",
  "stun",
  "thiserror",
- "time",
  "tokio",
  "tokio-test",
  "turn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,7 +3144,6 @@ dependencies = [
  "rand",
  "thiserror",
  "tokio",
- "tokio-test",
  "webrtc-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,6 @@ dependencies = [
  "portable-atomic",
  "thiserror",
  "tokio",
- "tokio-test",
  "webrtc-sctp",
  "webrtc-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,6 @@ dependencies = [
  "stun",
  "thiserror",
  "tokio",
- "tokio-test",
  "turn",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,6 @@ dependencies = [
  "rtp",
  "thiserror",
  "tokio",
- "tokio-test",
  "waitgroup",
  "webrtc-srtp",
  "webrtc-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,7 +3064,6 @@ dependencies = [
  "serde",
  "sha1",
  "sha2",
- "subtle",
  "thiserror",
  "tokio",
  "webrtc-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,6 @@ dependencies = [
  "env_logger",
  "ipnet",
  "lazy_static",
- "libc",
  "log",
  "nix",
  "portable-atomic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,6 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
- "tokio-test",
  "url",
  "webrtc-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,6 @@ dependencies = [
  "stun",
  "thiserror",
  "tokio",
- "tokio-test",
  "turn",
  "unicase",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,7 +2767,6 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "cfg-if",
  "env_logger",
  "hex",
  "interceptor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,6 @@ dependencies = [
  "ring",
  "rtcp",
  "rtp",
- "rustls",
  "sdp",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,77 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,12 +204,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -386,19 +309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -591,15 +501,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "const-oid"
@@ -897,37 +798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "examples"
 version = "0.5.0"
 dependencies = [
@@ -948,12 +818,6 @@ dependencies = [
  "tokio-util",
  "webrtc",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1048,19 +912,6 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1213,12 +1064,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-abi"
@@ -1588,12 +1433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,12 +1683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,17 +1743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,21 +1784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2254,19 +2061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3174,7 +2968,6 @@ dependencies = [
 name = "webrtc-util"
 version = "0.11.0"
 dependencies = [
- "async-global-executor",
  "async-trait",
  "bitflags 1.3.2",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+tokio-test = { version = "0.4.4" }
+
 [profile.dev]
 opt-level = 0

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -31,6 +31,5 @@ thiserror = "1"
 portable-atomic = "1.6"
 
 [dev-dependencies]
-tokio-test = "0.4" # must match the min version of the `tokio` crate above
 env_logger = "0.11.3"
 chrono = "0.4.28"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -46,7 +46,6 @@ ring = "0.17.14"
 rustls = { version = "0.23.27", default-features = false, features = ["std", "ring"] }
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
-subtle = "2"
 log = "0.4"
 thiserror = "1"
 pem = { version = "3", optional = true }

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -14,7 +14,6 @@ util = { version = "0.11.0", path = "../util", package = "webrtc-util", default-
 
 byteorder = "1"
 rand_core = "0.6"
-hkdf = "0.12"
 p256 = { version = "0.13", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.13"
 rand = "0.9"

--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -54,7 +54,6 @@ portable-atomic = "1.6"
 chacha20poly1305 = "0.10.1"
 
 [dev-dependencies]
-tokio-test = "0.4"
 env_logger = "0.11.3"
 chrono = "0.4.28"
 clap = "3"

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -41,7 +41,6 @@ waitgroup = "0.1"
 portable-atomic = "1.6"
 
 [dev-dependencies]
-tokio-test = "0.4"
 regex = "1.9.5"
 env_logger = "0.11.3"
 chrono = "0.4.28"

--- a/interceptor/Cargo.toml
+++ b/interceptor/Cargo.toml
@@ -26,5 +26,4 @@ log = "0.4"
 portable-atomic = "1.6"
 
 [dev-dependencies]
-tokio-test = "0.4"
 chrono = "0.4.28"

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -34,7 +34,6 @@ thiserror = "1"
 portable-atomic = "1.6"
 
 [dev-dependencies]
-tokio-test = "0.4"
 lazy_static = "1"
 env_logger = "0.11.3"
 chrono = "0.4.28"

--- a/srtp/Cargo.toml
+++ b/srtp/Cargo.toml
@@ -49,7 +49,6 @@ openssl = { version = "0.10.72", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_futures"] }
-tokio-test = "0.4"
 lazy_static = "1"
 
 [[bench]]

--- a/stun/Cargo.toml
+++ b/stun/Cargo.toml
@@ -39,7 +39,6 @@ md-5 = "0.10"
 thiserror = "1"
 
 [dev-dependencies]
-tokio-test = "0.4"
 clap = "3"
 criterion = "0.5"
 

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -40,7 +40,6 @@ portable-atomic = "1.6"
 [dev-dependencies]
 tokio-test = "0.4"
 env_logger = "0.11.3"
-chrono = "0.4.28"
 hex = "0.4"
 clap = "3"
 criterion = "0.5"

--- a/turn/Cargo.toml
+++ b/turn/Cargo.toml
@@ -38,7 +38,6 @@ thiserror = "1"
 portable-atomic = "1.6"
 
 [dev-dependencies]
-tokio-test = "0.4"
 env_logger = "0.11.3"
 hex = "0.4"
 clap = "3"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -59,7 +59,6 @@ tokio-test = "0.4"
 env_logger = "0.11.3"
 chrono = "0.4.28"
 criterion = { version = "0.5", features = ["async_futures"] }
-async-global-executor = "2"
 
 [[bench]]
 name = "bench"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -54,7 +54,7 @@ winapi = { version = "0.3.9", features = [
 ] }
 
 [dev-dependencies]
-tokio-test = "0.4"
+tokio-test.workspace = true
 env_logger = "0.11.3"
 chrono = "0.4.28"
 criterion = { version = "0.5", features = ["async_futures"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -42,7 +42,6 @@ portable-atomic = "1.6"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.26.2"
-libc = "0.2.126"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.3"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -50,10 +50,6 @@ waitgroup = "0.1"
 regex = "1.9.5"
 smol_str = { version = "0.2", features = ["serde"] }
 url = "2"
-rustls = { version = "0.23.27", default-features = false, features = [
-    "std",
-    "ring",
-] }
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 ring = "0.17.14"
 sha2 = "0.10"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -60,7 +60,6 @@ portable-atomic = "1.6"
 unicase = "2.8"
 
 [dev-dependencies]
-tokio-test = "0.4"
 env_logger = "0.11.3"
 
 [features]

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -60,7 +60,6 @@ sha2 = "0.10"
 lazy_static = "1.4"
 hex = "0.4"
 pem = { version = "3", optional = true }
-time = "0.3"
 cfg-if = "1"
 portable-atomic = "1.6"
 unicase = "2.8"

--- a/webrtc/Cargo.toml
+++ b/webrtc/Cargo.toml
@@ -56,7 +56,6 @@ sha2 = "0.10"
 lazy_static = "1.4"
 hex = "0.4"
 pem = { version = "3", optional = true }
-cfg-if = "1"
 portable-atomic = "1.6"
 unicase = "2.8"
 


### PR DESCRIPTION
[cargo-machete](https://crates.io/crates/cargo-machete) is a tool that detects unused dependencies. 

Running cargo-machete on this project yielded a number of unused dependencies that we can safely remove.