### PR TITLE
Fix badge URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 <p align="center">
  <a href="https://github.com/webrtc-rs/webrtc/actions">
-  <img src="https://github.com/webrtc-rs/webrtc/workflows/cargo/badge.svg?branch=master">
+  <img src="https://github.com/webrtc-rs/webrtc/workflows/cargo/badge.svg">
  </a>
  <a href="https://codecov.io/gh/webrtc-rs/webrtc">
   <img src="https://codecov.io/gh/webrtc-rs/webrtc/branch/master/graph/badge.svg">


### PR DESCRIPTION
Updated badge URL to reflect the default branch.