### PR TITLE
feat(srtp): add AES CM 256 crypto profiles

### DIFF
--- a/srtp/src/cipher/cipher_aead_aes_gcm.rs
+++ b/srtp/src/cipher/cipher_aead_aes_gcm.rs
@@ -9,7 +9,7 @@ use byteorder::{BigEndian, ByteOrder};
 use bytes::{Bytes, BytesMut};
 use util::marshal::*;
 
-use super::Cipher;
+use super::{Cipher, Kdf};
 use crate::error::{Error, Result};
 use crate::key_derivation::*;
 use crate::protection_profile::ProtectionProfile;
@@ -172,7 +172,6 @@ where
         assert_eq!(profile.key_len(), AES::key_size());
         assert_eq!(profile.salt_len(), master_salt.len());
 
-        type Kdf = fn(u8, &[u8], &[u8], usize, usize) -> Result<Vec<u8>>;
         let kdf: Kdf = match profile {
             ProtectionProfile::AeadAes128Gcm => aes_cm_key_derivation,
             // AES_256_GCM must use AES_256_CM_PRF as per https://datatracker.ietf.org/doc/html/rfc7714#section-11

--- a/srtp/src/cipher/mod.rs
+++ b/srtp/src/cipher/mod.rs
@@ -5,6 +5,8 @@ use bytes::Bytes;
 
 use crate::error::Result;
 
+type Kdf = fn(u8, &[u8], &[u8], usize, usize) -> Result<Vec<u8>>;
+
 ///NOTE: Auth tag and AEAD auth tag are placed at the different position in SRTCP
 ///
 ///In non-AEAD cipher, the authentication tag is placed *after* the ESRTCP word

--- a/srtp/src/context/context_test.rs
+++ b/srtp/src/context/context_test.rs
@@ -287,38 +287,56 @@ fn test_rollover_count_2() -> Result<()> {
 }
 
 lazy_static! {
-    static ref MASTER_KEY: Bytes = Bytes::from_static(&[
+    static ref MASTER_KEY_16_BYTES: Bytes = Bytes::from_static(&[
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
         0x0f,
     ]);
-    static ref MASTER_SALT: Bytes = Bytes::from_static(&[
+    static ref MASTER_KEY_32_BYTES: Bytes = Bytes::from_static(&[
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+        0x0e, 0x0f
+    ]);
+    static ref MASTER_SALT_12_BYTES: Bytes = Bytes::from_static(&[
         0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+    ]);
+    static ref MASTER_SALT_14_BYTES: Bytes = Bytes::from_static(&[
+        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad
     ]);
     static ref DECRYPTED_RTP_PACKET: Bytes = Bytes::from_static(&[
         0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad, 0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab,
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
     ]);
-    static ref ENCRYPTED_RTP_PACKET: Bytes = Bytes::from_static(&[
+    static ref ENCRYPTED_AEAD_AES_128_GCM_RTP_PACKET: Bytes = Bytes::from_static(&[
         0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad, 0xca, 0xfe, 0xba, 0xbe, 0xc5, 0x00, 0x2e,
         0xde, 0x04, 0xcf, 0xdd, 0x2e, 0xb9, 0x11, 0x59, 0xe0, 0x88, 0x0a, 0xa0, 0x6e, 0xd2, 0x97,
         0x68, 0x26, 0xf7, 0x96, 0xb2, 0x01, 0xdf, 0x31, 0x31, 0xa1, 0x27, 0xe8, 0xa3, 0x92,
+    ]);
+    static ref ENCRYPTED_AES_256_CM_RTP_PACKET: Bytes = Bytes::from_static(&[
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad, 0xca, 0xfe, 0xba, 0xbe, 0xac, 0x3b, 0xca,
+        0x88, 0x14, 0x37, 0x57, 0x83, 0x35, 0xc6, 0xd4, 0x57, 0xf1, 0xc3, 0x6b, 0xa7, 0x3d, 0x71,
+        0x48, 0x63, 0x90, 0x9b, 0xbf, 0x15, 0xac, 0xec
     ]);
     static ref DECRYPTED_RTCP_PACKET: Bytes = Bytes::from_static(&[
         0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
     ]);
-    static ref ENCRYPTED_RTCP_PACKET: Bytes = Bytes::from_static(&[
+    static ref ENCRYPTED_AEAD_AES_128_GCM_RTCP_PACKET: Bytes = Bytes::from_static(&[
         0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe, 0xc9, 0x8b, 0x8b, 0x5d, 0xf0, 0x39, 0x2a,
         0x55, 0x85, 0x2b, 0x6c, 0x21, 0xac, 0x8e, 0x70, 0x25, 0xc5, 0x2c, 0x6f, 0xbe, 0xa2, 0xb3,
         0xb4, 0x46, 0xea, 0x31, 0x12, 0x3b, 0xa8, 0x8c, 0xe6, 0x1e, 0x80, 0x00, 0x00, 0x01,
     ]);
+    static ref ENCRYPTED_AES_256_CM_RTCP_PACKET: Bytes = Bytes::from_static(&[
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe, 0x97, 0x04, 0x31, 0xdc, 0x4a, 0xe6, 0xd2,
+        0xaf, 0xd6, 0x54, 0xbf, 0x90, 0xf4, 0x35, 0x44, 0x9e, 0x80, 0x00, 0x00, 0x01, 0xbf, 0x18,
+        0x18, 0x2d, 0xd1, 0x18, 0x81, 0x28, 0x78, 0xb1
+    ]);
 }
 
 #[test]
-fn test_encrypt_rtp() {
+fn test_encrypt_aead_aes_128_gcm_rtp() {
     let mut ctx = Context::new(
-        &MASTER_KEY,
-        &MASTER_SALT,
+        &MASTER_KEY_16_BYTES,
+        &MASTER_SALT_12_BYTES,
         ProtectionProfile::AeadAes128Gcm,
         None,
         None,
@@ -329,14 +347,17 @@ fn test_encrypt_rtp() {
         .encrypt_rtp(&DECRYPTED_RTP_PACKET)
         .expect("Error encrypting rtp payload");
 
-    assert_eq!(gotten_encrypted_rtp_packet, *ENCRYPTED_RTP_PACKET)
+    assert_eq!(
+        gotten_encrypted_rtp_packet,
+        *ENCRYPTED_AEAD_AES_128_GCM_RTP_PACKET
+    )
 }
 
 #[test]
-fn test_decrypt_rtp() {
+fn test_decrypt_aead_aes_128_gcm_rtp() {
     let mut ctx = Context::new(
-        &MASTER_KEY,
-        &MASTER_SALT,
+        &MASTER_KEY_16_BYTES,
+        &MASTER_SALT_12_BYTES,
         ProtectionProfile::AeadAes128Gcm,
         None,
         None,
@@ -344,17 +365,17 @@ fn test_decrypt_rtp() {
     .expect("Error creating srtp context");
 
     let gotten_decrypted_rtp_packet = ctx
-        .decrypt_rtp(&ENCRYPTED_RTP_PACKET)
+        .decrypt_rtp(&ENCRYPTED_AEAD_AES_128_GCM_RTP_PACKET)
         .expect("Error decrypting rtp payload");
 
     assert_eq!(gotten_decrypted_rtp_packet, *DECRYPTED_RTP_PACKET)
 }
 
 #[test]
-fn test_encrypt_rtcp() {
+fn test_encrypt_aead_aes_128_gcm_rtcp() {
     let mut ctx = Context::new(
-        &MASTER_KEY,
-        &MASTER_SALT,
+        &MASTER_KEY_16_BYTES,
+        &MASTER_SALT_12_BYTES,
         ProtectionProfile::AeadAes128Gcm,
         None,
         None,
@@ -365,14 +386,17 @@ fn test_encrypt_rtcp() {
         .encrypt_rtcp(&DECRYPTED_RTCP_PACKET)
         .expect("Error encrypting rtcp payload");
 
-    assert_eq!(gotten_encrypted_rtcp_packet, *ENCRYPTED_RTCP_PACKET)
+    assert_eq!(
+        gotten_encrypted_rtcp_packet,
+        *ENCRYPTED_AEAD_AES_128_GCM_RTCP_PACKET
+    )
 }
 
 #[test]
-fn test_decrypt_rtcp() {
+fn test_decrypt_aead_aes_128_gcm_rtcp() {
     let mut ctx = Context::new(
-        &MASTER_KEY,
-        &MASTER_SALT,
+        &MASTER_KEY_16_BYTES,
+        &MASTER_SALT_12_BYTES,
         ProtectionProfile::AeadAes128Gcm,
         None,
         None,
@@ -380,7 +404,85 @@ fn test_decrypt_rtcp() {
     .expect("Error creating srtp context");
 
     let gotten_decrypted_rtcp_packet = ctx
-        .decrypt_rtcp(&ENCRYPTED_RTCP_PACKET)
+        .decrypt_rtcp(&ENCRYPTED_AEAD_AES_128_GCM_RTCP_PACKET)
+        .expect("Error decrypting rtcp payload");
+
+    assert_eq!(gotten_decrypted_rtcp_packet, *DECRYPTED_RTCP_PACKET)
+}
+
+#[test]
+fn test_encrypt_aes_256_cm_rtp() {
+    let mut ctx = Context::new(
+        &MASTER_KEY_32_BYTES,
+        &MASTER_SALT_14_BYTES,
+        ProtectionProfile::Aes256CmHmacSha1_80,
+        None,
+        None,
+    )
+    .expect("Error creating srtp context");
+
+    let gotten_encrypted_rtp_packet = ctx
+        .encrypt_rtp(&DECRYPTED_RTP_PACKET)
+        .expect("Error encrypting rtp payload");
+
+    assert_eq!(
+        gotten_encrypted_rtp_packet,
+        *ENCRYPTED_AES_256_CM_RTP_PACKET
+    )
+}
+
+#[test]
+fn test_decrypt_aes_256_cm_rtp() {
+    let mut ctx = Context::new(
+        &MASTER_KEY_32_BYTES,
+        &MASTER_SALT_14_BYTES,
+        ProtectionProfile::Aes256CmHmacSha1_80,
+        None,
+        None,
+    )
+    .expect("Error creating srtp context");
+
+    let gotten_decrypted_rtp_packet = ctx
+        .decrypt_rtp(&ENCRYPTED_AES_256_CM_RTP_PACKET)
+        .expect("Error decrypting rtp payload");
+
+    assert_eq!(gotten_decrypted_rtp_packet, *DECRYPTED_RTP_PACKET)
+}
+
+#[test]
+fn test_encrypt_aes_256_cm_rtcp() {
+    let mut ctx = Context::new(
+        &MASTER_KEY_32_BYTES,
+        &MASTER_SALT_14_BYTES,
+        ProtectionProfile::Aes256CmHmacSha1_80,
+        None,
+        None,
+    )
+    .expect("Error creating srtp context");
+
+    let gotten_encrypted_rtcp_packet = ctx
+        .encrypt_rtcp(&DECRYPTED_RTCP_PACKET)
+        .expect("Error encrypting rtcp payload");
+
+    assert_eq!(
+        gotten_encrypted_rtcp_packet,
+        *ENCRYPTED_AES_256_CM_RTCP_PACKET
+    )
+}
+
+#[test]
+fn test_decrypt_aes_256_cm_rtcp() {
+    let mut ctx = Context::new(
+        &MASTER_KEY_32_BYTES,
+        &MASTER_SALT_14_BYTES,
+        ProtectionProfile::Aes256CmHmacSha1_80,
+        None,
+        None,
+    )
+    .expect("Error creating srtp context");
+
+    let gotten_decrypted_rtcp_packet = ctx
+        .decrypt_rtcp(&ENCRYPTED_AES_256_CM_RTCP_PACKET)
         .expect("Error decrypting rtcp payload");
 
     assert_eq!(gotten_decrypted_rtcp_packet, *DECRYPTED_RTCP_PACKET)

--- a/srtp/src/context/mod.rs
+++ b/srtp/src/context/mod.rs
@@ -121,7 +121,10 @@ impl Context {
         }
 
         let cipher: Box<dyn Cipher + Send> = match profile {
-            ProtectionProfile::Aes128CmHmacSha1_32 | ProtectionProfile::Aes128CmHmacSha1_80 => {
+            ProtectionProfile::Aes128CmHmacSha1_32
+            | ProtectionProfile::Aes128CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_32 => {
                 Box::new(CipherAesCmHmacSha1::new(profile, master_key, master_salt)?)
             }
 

--- a/srtp/src/protection_profile.rs
+++ b/srtp/src/protection_profile.rs
@@ -5,6 +5,8 @@ pub enum ProtectionProfile {
     #[default]
     Aes128CmHmacSha1_80 = 0x0001,
     Aes128CmHmacSha1_32 = 0x0002,
+    Aes256CmHmacSha1_80 = 0x0003,
+    Aes256CmHmacSha1_32 = 0x0004,
     AeadAes128Gcm = 0x0007,
     AeadAes256Gcm = 0x0008,
 }
@@ -15,42 +17,55 @@ impl ProtectionProfile {
             ProtectionProfile::Aes128CmHmacSha1_32
             | ProtectionProfile::Aes128CmHmacSha1_80
             | ProtectionProfile::AeadAes128Gcm => 16,
+            ProtectionProfile::Aes256CmHmacSha1_32 | ProtectionProfile::Aes256CmHmacSha1_80 => 32,
             ProtectionProfile::AeadAes256Gcm => 32,
         }
     }
 
     pub fn salt_len(&self) -> usize {
         match *self {
-            ProtectionProfile::Aes128CmHmacSha1_32 | ProtectionProfile::Aes128CmHmacSha1_80 => 14,
+            ProtectionProfile::Aes128CmHmacSha1_32
+            | ProtectionProfile::Aes128CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_32
+            | ProtectionProfile::Aes256CmHmacSha1_80 => 14,
             ProtectionProfile::AeadAes128Gcm | ProtectionProfile::AeadAes256Gcm => 12,
         }
     }
 
     pub fn rtp_auth_tag_len(&self) -> usize {
         match *self {
-            ProtectionProfile::Aes128CmHmacSha1_80 => 10,
-            ProtectionProfile::Aes128CmHmacSha1_32 => 4,
+            ProtectionProfile::Aes128CmHmacSha1_80 | ProtectionProfile::Aes256CmHmacSha1_80 => 10,
+            ProtectionProfile::Aes128CmHmacSha1_32 | ProtectionProfile::Aes256CmHmacSha1_32 => 4,
             ProtectionProfile::AeadAes128Gcm | ProtectionProfile::AeadAes256Gcm => 0,
         }
     }
 
     pub fn rtcp_auth_tag_len(&self) -> usize {
         match *self {
-            ProtectionProfile::Aes128CmHmacSha1_80 | ProtectionProfile::Aes128CmHmacSha1_32 => 10,
+            ProtectionProfile::Aes128CmHmacSha1_80
+            | ProtectionProfile::Aes128CmHmacSha1_32
+            | ProtectionProfile::Aes256CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_32 => 10,
             ProtectionProfile::AeadAes128Gcm | ProtectionProfile::AeadAes256Gcm => 0,
         }
     }
 
     pub fn aead_auth_tag_len(&self) -> usize {
         match *self {
-            ProtectionProfile::Aes128CmHmacSha1_80 | ProtectionProfile::Aes128CmHmacSha1_32 => 0,
+            ProtectionProfile::Aes128CmHmacSha1_80
+            | ProtectionProfile::Aes128CmHmacSha1_32
+            | ProtectionProfile::Aes256CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_32 => 0,
             ProtectionProfile::AeadAes128Gcm | ProtectionProfile::AeadAes256Gcm => 16,
         }
     }
 
     pub fn auth_key_len(&self) -> usize {
         match *self {
-            ProtectionProfile::Aes128CmHmacSha1_80 | ProtectionProfile::Aes128CmHmacSha1_32 => 20,
+            ProtectionProfile::Aes128CmHmacSha1_80
+            | ProtectionProfile::Aes128CmHmacSha1_32
+            | ProtectionProfile::Aes256CmHmacSha1_80
+            | ProtectionProfile::Aes256CmHmacSha1_32 => 20,
             ProtectionProfile::AeadAes128Gcm | ProtectionProfile::AeadAes256Gcm => 0,
         }
     }


### PR DESCRIPTION
This PR adds `Aes256CmHmacSha1_80` and `Aes256CmHmacSha1_32` protection profiles. They're defined in [RFC6188](https://datatracker.ietf.org/doc/html/rfc6188). I didn't implement a new struct for handling them, but extended `CipherAesCmHmacSha1` to not only support AES CM 128.