### PR TITLE
examples: add reflect-http-html: Example on how to set up a WebRTC-Connection over HTTP and with HTML and JavaScript.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,190 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "base64",
+ "bitflags 2.9.4",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "foldhash",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "actix-macros",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1654a77ba142e37f049637a3e5685f864514af11fcbc51cb51eb6596afe5b8d6"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.0",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +243,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -306,6 +505,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +542,15 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bytestring"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "cast"
@@ -345,6 +574,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -503,6 +734,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +782,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -699,6 +959,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +1081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +1122,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "examples"
 version = "0.5.0"
 dependencies = [
+ "actix-rt",
+ "actix-web",
  "anyhow",
  "bytes",
  "chrono",
@@ -844,6 +1138,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "uuid",
  "webrtc",
  "webrtc-signal",
 ]
@@ -871,10 +1166,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1320,6 +1631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1760,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1778,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -1469,6 +1802,23 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -1512,6 +1862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1533,6 +1890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -2024,6 +2382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2601,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2658,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
@@ -2568,8 +2950,21 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2629,6 +3024,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,12 +3077,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3426,4 +3834,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,8 @@ repository = "https://github.com/webrtc-rs/webrtc/tree/master/examples"
 [dev-dependencies]
 webrtc = { path = "../webrtc" }
 
+actix-web = { version = "4.12.1", features = ["macros"] }
+actix-rt = "2.11.0"
 tokio = { version = "1.32.0", features = ["full"] }
 env_logger = "0.11.3"
 clap = "3"
@@ -26,6 +28,7 @@ chrono = "0.4.28"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1.19.0", features = ["v4", "serde"] }
 bytes = "1"
 lazy_static = "1"
 rand = "0.9"
@@ -150,4 +153,9 @@ bench = false
 [[example]]
 name = "ice-restart"
 path = "examples/ice-restart/ice-restart.rs"
+bench = false
+
+[[example]]
+name = "http-html"
+path = "examples/reflect-http-html/http-html.rs"
 bench = false

--- a/examples/examples/README.md
+++ b/examples/examples/README.md
@@ -6,6 +6,7 @@ All examples are ported from [Pion](https://github.com/pion/webrtc/tree/master/e
 
 #### Media API
 - [x] [Reflect](reflect): The reflect example demonstrates how to have webrtc-rs send back to the user exactly what it receives using the same PeerConnection.
+- [x] [Reflect with HTTP+HTML](reflect-http-html): The reflect with HTTP and HTML example on how to set up a WebRTC-Connection over HTTP and with HTML and JavaScript.
 - [x] [Play from Disk VPx](play-from-disk-vpx): The play-from-disk-vp8 example demonstrates how to send VP8/VP9 video to your browser from a file saved to disk.
 - [x] [Play from Disk H264](play-from-disk-h264): The play-from-disk-h264 example demonstrates how to send H264 video to your browser from a file saved to disk.
 - [x] [Play from Disk Renegotiation](play-from-disk-renegotiation): The play-from-disk-renegotiation example is an extension of the play-from-disk example, but demonstrates how you can add/remove video tracks from an already negotiated PeerConnection.

--- a/examples/examples/reflect-http-html/client.html
+++ b/examples/examples/reflect-http-html/client.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>WebRTC Example</title>
+</head>
+<body>
+<h1>WebRTC Example</h1>
+<button onclick="start()">Start</button>
+<button onclick="stop()">Stop</button>
+<code id="state"></code>
+</body>
+
+<script type="application/javascript">
+    let audioEl, pc, connectionId;
+
+    const base = window.location.href;
+    async function post(path, body) {
+        return await fetch(`${base}${path}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: body ? JSON.stringify(body) : null
+        })
+    }
+
+    async function get(path) {
+        return await fetch(`${base}${path}`, {
+            headers: {
+                'Accept': 'application/json',
+            },
+        })
+    }
+
+    function logState(state) {
+        console.log('state', state)
+        document.getElementById('state').innerHTML = state
+    }
+
+    async function start() {
+        const configuration = {
+            "iceServers": [{
+                "urls": "stun:stun.l.google.com:19302"
+            }]
+        };
+
+        pc = new RTCPeerConnection(configuration);
+
+        pc.addEventListener("icecandidate", (ev) => onLocalIceCandidateEvent(ev));
+        pc.addEventListener("track", (ev) => onTrackEvent(ev));
+        pc.addEventListener("connectionstatechange", () => onStateChangeEvent());
+        pc.addEventListener("signalingstatechange", () => onStateChangeEvent());
+
+        const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: false});
+        const firstTrack = localStream.getTracks().at(0);
+        if (firstTrack) {
+            pc.addTrack(firstTrack, localStream);
+        }
+
+        const offer = await pc.createOffer();
+        const startRes = await post('start', {
+            "request": offer,
+        })
+        const startJson = await startRes.json()
+
+        const answer = startJson['response'];
+        connectionId = startJson['connection_id'];
+
+        await pc.setLocalDescription(offer);
+        await pc.setRemoteDescription(answer);
+
+        while (true) {
+            const candidate = await get(`trickle/${connectionId}`)
+            if (candidate.status === 204) {
+                console.log('no more remote ice-candidates')
+                break
+            }
+            const candidateJson = await candidate.json();
+            console.log('remote ice-candidate', candidateJson)
+            await pc.addIceCandidate(candidateJson.ice_candidate);
+        }
+
+        async function onLocalIceCandidateEvent(ev) {
+            if (!ev.candidate) {
+                return
+            }
+
+            const ice_candidate = {
+                "sdpMid": ev.candidate.sdpMid,
+                "sdpMLineIndex": ev.candidate.sdpMLineIndex,
+                "candidate": ev.candidate.candidate,
+            };
+            if (ice_candidate.candidate) {
+                console.log('local ice-candidate', ice_candidate)
+            } else {
+                console.log('no more local ice-candidates')
+            }
+            await post(`trickle/${connectionId}`, {
+                "ice_candidate": ice_candidate
+            })
+        }
+
+        async function onStateChangeEvent() {
+            logState(pc.connectionState + ' ' + pc.signalingState);
+        }
+
+        async function onTrackEvent(ev) {
+            if (ev.track.kind !== "audio") return
+
+            if (audioEl) {
+                document.body.removeChild(audioEl)
+                audioEl = undefined
+            }
+
+            if (!ev.track.enabled) {
+                // Track removed, just remove audio element
+                return
+            }
+
+            const stream = new MediaStream([ev.track])
+            audioEl = document.createElement("audio")
+            document.body.appendChild(audioEl)
+            audioEl.autoplay = true
+            audioEl.srcObject = stream
+            audioEl.play().then(() => onPlaying())
+
+            // show volume
+        }
+
+        async function onPlaying() {
+            logState('playing')
+        }
+    }
+
+    async function stop() {
+        logState('stopping')
+        await post(`stop/${connectionId}`)
+
+        pc.getSenders().forEach((sender) => {
+            sender.track.stop();
+            pc.removeTrack(sender)
+        })
+
+        pc.close()
+        pc = null
+        logState('stopped')
+    }
+</script>
+</html>

--- a/examples/examples/reflect-http-html/http-html.rs
+++ b/examples/examples/reflect-http-html/http-html.rs
@@ -1,0 +1,431 @@
+use actix_web::middleware::Logger;
+use actix_web::web::Json;
+use actix_web::{get, post, web, App, HttpResponse, HttpServer};
+use log::{debug, info, warn, LevelFilter};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::{env, fs, io};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+use tokio::sync::{Mutex, RwLock};
+use uuid::Uuid;
+use webrtc::api::interceptor_registry::register_default_interceptors;
+use webrtc::api::media_engine::{MediaEngine, MIME_TYPE_OPUS};
+use webrtc::api::{APIBuilder, API};
+use webrtc::ice_transport::ice_candidate::{RTCIceCandidate, RTCIceCandidateInit};
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::interceptor::registry::Registry;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::rtp_transceiver::rtp_codec::{
+    RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType,
+};
+use webrtc::rtp_transceiver::PayloadType;
+use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
+use webrtc::track::track_local::{TrackLocal, TrackLocalWriter};
+
+/// Represents one active connection in memory
+struct StoredConnection {
+    peer_connection: Arc<RTCPeerConnection>,
+    ice_candidates_channel: Mutex<UnboundedReceiver<Option<RTCIceCandidate>>>,
+}
+
+/// Represents shared state between all web-worker threads
+pub struct AppState {
+    // The API is accessed from multiple actix handling-threads, which is why we need Arc
+    api: Arc<API>,
+
+    // The HashMap must be write-locked so that no other threads access them at the same time
+    connections: Arc<RwLock<HashMap<Uuid, Arc<StoredConnection>>>>,
+}
+
+const PAYLOAD_TYPE_OPUS: PayloadType = 120;
+
+/// Create the WebRTC Media-Engine and Actix-Web-Server
+#[actix_rt::main]
+async fn main() -> io::Result<()> {
+    env_logger::builder()
+        .filter_level(LevelFilter::Debug)
+        .filter_module("actix_web", LevelFilter::Debug)
+        .filter_module("actix_server", LevelFilter::Info)
+        .init();
+
+    // Create a MediaEngine object to configure the supported codec
+    let mut media_engine = MediaEngine::default();
+
+    // Set up the available codecs
+    media_engine
+        .register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_OPUS.to_owned(),
+                    ..Default::default()
+                },
+                payload_type: PAYLOAD_TYPE_OPUS,
+                ..Default::default()
+            },
+            RTPCodecType::Audio,
+        )
+        .expect("error registering codec");
+
+    // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
+    // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
+    // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
+    // for each PeerConnection.
+    let mut registry = Registry::new();
+
+    // Use the default set of Interceptors
+    registry = register_default_interceptors(registry, &mut media_engine)
+        .expect("error registering default interceptors");
+
+    // Create the API object with the MediaEngine
+    let api = APIBuilder::new()
+        .with_media_engine(media_engine)
+        .with_interceptor_registry(registry)
+        .build();
+
+    let api = Arc::new(api);
+    let connections = Arc::new(RwLock::new(HashMap::new()));
+
+    info!("Starting HTTP server");
+    let app_server = HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .app_data(web::Data::new(AppState {
+                api: api.clone(),
+                connections: connections.clone(),
+            }))
+            .service(index)
+            .service(start)
+            .service(trickle_in)
+            .service(trickle_out)
+            .service(stop)
+    });
+
+    app_server.workers(2).bind("[::]:8000")?.run().await
+}
+
+/// Read and return "client.html"
+#[get("/")]
+async fn index() -> Result<HttpResponse, Box<dyn std::error::Error>> {
+    let path = "examples/examples/reflect-http-html/client.html";
+    let cwd = env::current_dir()?;
+    let content = fs::read_to_string(path)
+        .expect(format!("Cannot read file at {}, cwd is {}", path, cwd.display()).as_str());
+
+    Ok(HttpResponse::Ok().content_type("text/html").body(content))
+}
+
+#[derive(Deserialize)]
+struct StartRequest {
+    request: RTCSessionDescription,
+}
+
+#[derive(Serialize)]
+struct StartResponse {
+    response: RTCSessionDescription,
+    connection_id: Uuid,
+}
+
+/// Start a WebRTC Connection by taking an SDP offer and returning a Connection-ID and an SDP answer back
+#[post("/start")]
+async fn start(
+    body: Json<StartRequest>,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, Box<dyn std::error::Error>> {
+    info!("Start connection");
+    debug!(
+        "Received SDP: {} {}",
+        body.request.sdp_type, body.request.sdp
+    );
+
+    // Prepare the WebRTC configuration
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_string()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let connection_id = Uuid::new_v4();
+
+    // Create the peer-connection
+    let peer_connection = Arc::new(state.api.new_peer_connection(config).await?);
+
+    // Allocate one output-track (we will only handle a single audio-track encoded as opus in this example)
+    let output_track = Arc::new(TrackLocalStaticRTP::new(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_OPUS.to_owned(),
+            ..Default::default()
+        },
+        "webrtc-rs-0".to_owned(), // track-id
+        "webrtc-rs".to_owned(),   // session-id
+    ));
+
+    // Add the output-track to the peer-connection
+    let rtp_sender = peer_connection
+        .add_track(Arc::clone(&output_track) as Arc<dyn TrackLocal + Send + Sync>)
+        .await?;
+
+    // spawn a worker for reading rtcp-packets
+    tokio::spawn(async move {
+        debug!("Starting RTCP-Message Worker");
+        let mut rtcp_buf = vec![0u8; 1500];
+        while let Ok((rtcp_pkt, _)) = rtp_sender.read(&mut rtcp_buf).await {
+            info!("RTCP-Message: {:?}", rtcp_pkt);
+        }
+
+        debug!("Ending RTCP-Message Worker");
+    });
+
+    // Configure a Listener for received Tracks
+    peer_connection.on_track(Box::new(move |track, _, _| {
+        debug!("Received On-Track Event: {:?}", track);
+
+        // Verify track is audio (we will only handle a single opus-encoded audio-track in this example)
+        if track.kind() != RTPCodecType::Audio {
+            debug!("Ignoring track kind {:?}", track.kind());
+            return Box::pin(async {});
+        }
+
+        // Verify track is opus
+        if track.codec().capability.mime_type.ne(MIME_TYPE_OPUS) {
+            debug!("Ignoring track codec {:?}", track.codec());
+            return Box::pin(async {});
+        }
+
+        // Spawn packet-copy worker
+        let output_track = output_track.clone();
+        tokio::spawn(async move {
+            info!("Starting Packet-Copy-Worker");
+
+            let mut packet_counter: i64 = 0;
+            while let Ok((rtp, _)) = track.read_rtp().await {
+                if packet_counter % 250 == 0 {
+                    debug!("Forwarding packet ({} forwarded total)", packet_counter);
+                }
+                packet_counter += 1;
+
+                // Send received packet right back
+                // In a production application you might instead want to clone and forward this packet to different recipients
+                // or even decode its audio-content from opus to raw samples, which could then be manipulated or mixed together
+                // and then re-encoded before sending them back
+                if let Err(err) = output_track.write_rtp(&rtp).await {
+                    warn!("Error copying Packet to Output-Track: {err}");
+                    break;
+                }
+            }
+
+            debug!("Ending Packet-Copy-Worker");
+        });
+
+        Box::pin(async {})
+    }));
+
+    // we need to explicitly clone the Arcs here (and again below) to be able to move them into the ownership scope of the event-handler
+    let peer_connection_closer = peer_connection.clone();
+    let connections_closer = state.connections.clone();
+
+    // Configure listener for Peer connection state
+    peer_connection.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+        info!("Peer Connection State has changed: {s}");
+
+        if s == RTCPeerConnectionState::Failed {
+            // Wait until PeerConnection has had no network activity for 30 seconds or another failure.
+            // It may be reconnected using an ICE Restart.
+            // Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+            // Note that the PeerConnection might come back from a PeerConnectionStateDisconnected event.
+            info!("Peer Connection has failed, closing");
+            let peer_connection_closer = peer_connection_closer.clone();
+
+            tokio::spawn(async move {
+                // close the PeerConnection - this will stop all network listeners and end all receiver tasks
+                // it will also re-trigger this state-liner with the "Closed" state afterwards
+                peer_connection_closer
+                    .close()
+                    .await
+                    .expect("Error closing peer connection");
+            });
+        } else if s == RTCPeerConnectionState::Closed {
+            // Connection has been closed, either through network inactivity and a "failed"-state or
+            // voluntarily through the stop-api below
+            info!("Peer Connection is closed, removing from storage");
+
+            let connections_closer = connections_closer.clone();
+            tokio::spawn(async move {
+                // remove the stored connection info from memory, freeing up the PeerConnection and all associated memory
+                connections_closer.write().await.remove(&connection_id);
+            });
+
+            info!("Peer Connection has been closed and removed");
+        }
+
+        Box::pin(async {})
+    }));
+
+    // Configure listener for local ice-candidates:
+    // this handler will be called when the local ice-agent has gatherd another candidate for communication
+    let (ice_tx, ice_rx) = unbounded_channel::<Option<RTCIceCandidate>>();
+    peer_connection.on_ice_candidate(Box::new(move |ice_candidate: Option<RTCIceCandidate>| {
+        info!("Ice-Candidate found: {ice_candidate:?}");
+
+        // send the ice-candidate into the channel where it will be stored until a (waiting or new) long-poll http request reads it
+        ice_tx
+            .send(ice_candidate)
+            .expect("Error sending Ice-Candidate to channel");
+
+        Box::pin(async {})
+    }));
+
+    // Cet the received SDP Offer
+    peer_connection
+        .set_remote_description(body.request.to_owned())
+        .await?;
+
+    // Create an SDP-Answer
+    let response = peer_connection.create_answer(None).await?;
+
+    // Set the LocalDescription and start network listeners
+    peer_connection
+        .set_local_description(response.clone())
+        .await?;
+
+    let mut connections = state.connections.write().await;
+
+    // Store the Peer-Connection and the Ice-Candidate channel
+    // for further activity under the connection-id
+    // Lock the connections HashMap for writing
+    connections.insert(
+        connection_id,
+        Arc::new(StoredConnection {
+            peer_connection: peer_connection.clone(),
+            ice_candidates_channel: Mutex::new(ice_rx),
+        }),
+    );
+
+    // Respond with the generated SDP Answer and the connection-id
+    debug!("Responding SDP: {} {}", response.sdp_type, response.sdp);
+    Ok(HttpResponse::Ok().json(StartResponse {
+        response,
+        connection_id,
+    }))
+}
+
+#[derive(Deserialize)]
+struct TrickleRequest {
+    ice_candidate: RTCIceCandidateInit,
+}
+
+/// Receive Ice-Candidate from the client
+#[post("/trickle/{connection_id}")]
+async fn trickle_in(
+    connection_id: web::Path<Uuid>,
+    body: Json<TrickleRequest>,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, Box<dyn std::error::Error>> {
+    info!("Received Trickle Ice Candidate: {:?}", body.ice_candidate);
+    // This code is repeated in all http endpoints but only commented here
+
+    // Lock the connections HashMap for reading
+    let connections = state.connections.read().await;
+    // get the Option<Arc<StoredConnection>> and clone Option & Arc
+    let maybe_connection = connections.get(connection_id.as_ref()).cloned();
+    // release the read-lock to that parallel start-requests can acquire the write-lock to add new connections
+    drop(connections);
+
+    // at this point the Option and the Arc are cloned, which means that we can continue to use both
+    // for the lifetime of this function and the StoredConnection will not be freed in the meantime.
+
+    match maybe_connection {
+        Some(connection) => {
+            // deliver the ice-candidate to the stored connection
+            connection
+                .peer_connection
+                .add_ice_candidate(body.ice_candidate.to_owned())
+                .await?;
+            Ok(HttpResponse::Ok().finish())
+        }
+        None => {
+            Ok(HttpResponse::NotFound().body(format!("Unknown Connection-Id {}", connection_id)))
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct TrickleGetResponse {
+    ice_candidate: RTCIceCandidateInit,
+}
+
+/// Send Ice-Candidates to the client via http long-polling
+#[get("/trickle/{connection_id}")]
+async fn trickle_out(
+    connection_id: web::Path<Uuid>,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, Box<dyn std::error::Error>> {
+    info!("Received Long-Poll Request for Remote Trickle Ice Candidates");
+    let connections = state.connections.read().await;
+    let maybe_connection = connections.get(connection_id.as_ref()).cloned();
+    drop(connections);
+
+    match maybe_connection {
+        Some(connection) => {
+            // lock the channels read-end exclusively - this is a mpsc (multi-producer-single-consumer) channel which
+            // gurantees that each message will be delivered exactly once.
+            let mut receiver = connection.ice_candidates_channel.lock().await;
+
+            // Wait for messages on the channel receiver
+            match receiver.recv().await {
+                // Successfully received a value from the channel and it did indeed contain an ice-candidate
+                Some(Some(ice_candidate)) => Ok(
+                    // return the ice-candidate in its serialized form
+                    HttpResponse::Ok().json(TrickleGetResponse {
+                        ice_candidate: ice_candidate.to_json()?,
+                    }),
+                ),
+
+                // Successfully received a value from the channel, but it did not contain an ice-candidate
+                // this signals the last candidate has been received and no more will follow
+                Some(None) => {
+                    // close the channel
+                    receiver.close();
+
+                    // communicate: no more candidates
+                    Ok(HttpResponse::NoContent().finish())
+                }
+
+                // Did not receive a value from the channel because it was already closed
+                None => {
+                    // communicate: no more candidates
+                    Ok(HttpResponse::NoContent().finish())
+                }
+            }
+        }
+        None => {
+            Ok(HttpResponse::NotFound().body(format!("Unknown Connection-Id {}", connection_id)))
+        }
+    }
+}
+
+/// Voluntarily close a running connection
+#[post("/stop/{connection_id}")]
+async fn stop(
+    connection_id: web::Path<Uuid>,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, Box<dyn std::error::Error>> {
+    let connections = state.connections.read().await;
+    let maybe_connection = connections.get(connection_id.as_ref()).cloned();
+    drop(connections);
+
+    match maybe_connection {
+        Some(connection) => {
+            connection.peer_connection.close().await?;
+            Ok(HttpResponse::Ok().finish())
+        }
+        None => {
+            Ok(HttpResponse::NotFound().body(format!("Unknown Connection-Id {}", connection_id)))
+        }
+    }
+}


### PR DESCRIPTION
While trying to setup an "real world" application with HTTP, HTML and JS which would transfer audio to a rust-webrtc application I found no example that showed how to transfer ice-candidates from the browser to the application an back, even though this seems to be one of the most common use-cases. For people getting started with WebRTC this can be a real show-stopper, proven by various comments about communication only working in Local-LAN where the webrtc-server can freely connect to the browser and no further ice-negotiation is required.

I therefore would like to sponsor this minimal, documented and functionally-complete example which showcases the use of the rust webrtc-crate together with actix and appropriate html + javascript to create a internet-compatible WebRTC connection.

Please let me know if you have any requests for changes.
Best regards,
Peter
