### PR TITLE
feat: Add H.264 High Profile codec support

### DIFF
--- a/webrtc/src/api/media_engine/media_engine_test.rs
+++ b/webrtc/src/api/media_engine/media_engine_test.rs
@@ -875,3 +875,43 @@ a=ssrc:4281768245 msid:6ff05509-be96-4ef1-a74f-425e14720983 16d5d7fe-d076-4718-9
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_h264_high_profile_codecs() -> Result<()> {
+    let mut m = MediaEngine::default();
+    m.register_default_codecs()?;
+
+    // Verify High Profile Level 4.0
+    let (codec, _) = m.get_codec_by_payload(118).await?;
+    assert_eq!(codec.capability.mime_type, MIME_TYPE_H264);
+    assert!(codec
+        .capability
+        .sdp_fmtp_line
+        .contains("profile-level-id=640028"));
+
+    // Verify High Profile Level 4.1
+    let (codec, _) = m.get_codec_by_payload(119).await?;
+    assert_eq!(codec.capability.mime_type, MIME_TYPE_H264);
+    assert!(codec
+        .capability
+        .sdp_fmtp_line
+        .contains("profile-level-id=640029"));
+
+    // Verify High Profile Level 4.2
+    let (codec, _) = m.get_codec_by_payload(120).await?;
+    assert_eq!(codec.capability.mime_type, MIME_TYPE_H264);
+    assert!(codec
+        .capability
+        .sdp_fmtp_line
+        .contains("profile-level-id=64002a"));
+
+    // Verify High Profile Level 5.1
+    let (codec, _) = m.get_codec_by_payload(121).await?;
+    assert_eq!(codec.capability.mime_type, MIME_TYPE_H264);
+    assert!(codec
+        .capability
+        .sdp_fmtp_line
+        .contains("profile-level-id=640033"));
+
+    Ok(())
+}

--- a/webrtc/src/api/media_engine/mod.rs
+++ b/webrtc/src/api/media_engine/mod.rs
@@ -284,6 +284,62 @@ impl MediaEngine {
                 payload_type: 123,
                 ..Default::default()
             },
+            // H.264 High Profile, Level 4.0 (20 Mbps, 720p60/1080p30)
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_H264.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line:
+                        "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640028"
+                            .to_owned(),
+                    rtcp_feedback: video_rtcp_feedback.clone(),
+                },
+                payload_type: 118,
+                ..Default::default()
+            },
+            // H.264 High Profile, Level 4.1 (50 Mbps, 720p120/1080p60)
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_H264.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line:
+                        "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640029"
+                            .to_owned(),
+                    rtcp_feedback: video_rtcp_feedback.clone(),
+                },
+                payload_type: 119,
+                ..Default::default()
+            },
+            // H.264 High Profile, Level 4.2 (50 Mbps, 1080p64)
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_H264.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line:
+                        "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64002a"
+                            .to_owned(),
+                    rtcp_feedback: video_rtcp_feedback.clone(),
+                },
+                payload_type: 120,
+                ..Default::default()
+            },
+            // H.264 High Profile, Level 5.1 (240 Mbps, 4K30)
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_H264.to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line:
+                        "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640033"
+                            .to_owned(),
+                    rtcp_feedback: video_rtcp_feedback.clone(),
+                },
+                payload_type: 121,
+                ..Default::default()
+            },
             RTCRtpCodecParameters {
                 capability: RTCRtpCodecCapability {
                     mime_type: MIME_TYPE_AV1.to_owned(),


### PR DESCRIPTION
Adds H.264 High Profile (levels 4.0, 4.1, 4.2, 5.0) to default codec registry. 

Currently webrtc-rs only registers Baseline Profile by default. High Profile 
offers significantly better compression efficiency and is widely supported by 
modern encoders and decoders.

This matches pion/webrtc's H.264 support and enables professional streaming 
use cases without breaking changes. 

**Changes:**
- Added 4 High Profile variants to `MediaEngine:: register_default_codecs()`
- Payload types 118-121 (currently unused)
- All with standard RTCP feedback (NACK, PLI, FIR, REMB)

**Testing:**
- Verified codec registration
- Confirmed no conflicts with existing codecs