### PR TITLE
Accept unknown bandwidth types in SDP parser per RFC 8866

### DIFF
--- a/sdp/src/description/session.rs
+++ b/sdp/src/description/session.rs
@@ -1070,15 +1070,9 @@ fn unmarshal_bandwidth(value: &str) -> Result<Bandwidth> {
     let experimental = parts[0].starts_with("X-");
     if experimental {
         parts[0] = parts[0].trim_start_matches("X-");
-    } else {
-        // Set according to currently registered with IANA
-        // https://tools.ietf.org/html/rfc4566#section-5.8 and
-        // https://datatracker.ietf.org/doc/html/rfc3890
-        let i = index_of(parts[0], &["CT", "AS", "TIAS"]);
-        if i == -1 {
-            return Err(Error::SdpInvalidValue(parts[0].to_owned()));
-        }
     }
+    // RFC 8866 section 5.8: SDP parsers MUST ignore bandwidth-fields with unknown <bwtype> names.
+    // Accept any bandwidth type instead of validating against a specific list.
 
     let bandwidth = parts[1].parse::<u64>()?;
 


### PR DESCRIPTION
RFC 8866 section 5.8 specifies that SDP parsers MUST ignore bandwidth-fields with unknown <bwtype> names instead of failing.

This change removes the strict validation that only allowed 'CT', 'AS', and 'TIAS' bandwidth types, allowing the parser to accept any bandwidth type (e.g., 'RS', 'RR') as per the RFC requirement.