### PR TITLE
sdp: add UnmarshalConfig for deserialization

### DIFF
--- a/sdp/src/lexer/mod.rs
+++ b/sdp/src/lexer/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::io;
 use std::io::SeekFrom;
 
-use super::description::session::SessionDescription;
+use super::description::session::{SessionDescription, UnmarshalConfig};
 use super::error::{Error, Result};
 
 pub(crate) const END_LINE: &str = "\r\n";
@@ -11,6 +11,7 @@ pub(crate) const END_LINE: &str = "\r\n";
 pub struct Lexer<'a, R: io::BufRead + io::Seek> {
     pub desc: SessionDescription,
     pub reader: &'a mut R,
+    pub config: UnmarshalConfig,
 }
 
 pub type StateFnType<'a, R> = fn(&mut Lexer<'a, R>) -> Result<Option<StateFn<'a, R>>>;


### PR DESCRIPTION
Sometimes an SDP contains proprietary protocols not listed in https://datatracker.ietf.org/doc/html/rfc8866#section-5.14 and/or not registered with IANA. To be able to parse such SDPs, this change adds `UnmarshalConfig` which allows to specify a custom list of allowed protocols in addition to those accepted by default.