### PR TITLE
fix: add DNS timeout to STUN server resolution to prevent ICE gather hang

### DIFF
--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -181,19 +181,19 @@ impl RTCIceGatherer {
 
         debug!("Resolving STUN server: {}", stun_server_addr_str);
 
-        // Resolve hostname to IP address with a 3-second timeout (#774)
+        // Resolve hostname to IP address with a timeout (#774)
+        const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
         let resolved_addrs = runtime::timeout(
-            std::time::Duration::from_secs(3),
+            DNS_RESOLVE_TIMEOUT,
             runtime::resolve_host(&stun_server_addr_str),
         )
         .await
         .map_err(|_| {
             Error::Other(format!(
-                "DNS timeout resolving STUN server: {}",
-                stun_server_addr_str
+                "DNS timed out after {:?} resolving STUN server: {}",
+                DNS_RESOLVE_TIMEOUT, stun_server_addr_str
             ))
-        })?
-        .map_err(|e| Error::Other(e.to_string()))?;
+        })??;
 
         // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
         let stun_server_addr: SocketAddr = resolved_addrs

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -181,8 +181,19 @@ impl RTCIceGatherer {
 
         debug!("Resolving STUN server: {}", stun_server_addr_str);
 
-        // Resolve hostname to IP address using runtime-agnostic helper
-        let resolved_addrs = runtime::resolve_host(&stun_server_addr_str).await?;
+        // Resolve hostname to IP address with a 3-second timeout (#774)
+        let resolved_addrs = runtime::timeout(
+            std::time::Duration::from_secs(3),
+            runtime::resolve_host(&stun_server_addr_str),
+        )
+        .await
+        .map_err(|_| {
+            Error::Other(format!(
+                "DNS timeout resolving STUN server: {}",
+                stun_server_addr_str
+            ))
+        })?
+        .map_err(|e| Error::Other(e.to_string()))?;
 
         // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
         let stun_server_addr: SocketAddr = resolved_addrs

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -129,10 +129,14 @@ impl RTCIceGatherer {
         Ok(())
     }
 
+    /// Timeout for DNS resolution of STUN/TURN server hostnames (#774).
+    const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
     /// Gather server reflexive (srflx) ICE candidates via STUN
     ///
-    /// This performs actual I/O to query STUN servers and should be called
-    /// in an async context.
+    /// DNS resolution is performed once per STUN URL (not per local address)
+    /// so that an unresolvable hostname incurs at most one timeout rather
+    /// than N x timeout for N local addresses.
     async fn gather_srflx_candidates(&mut self) -> Result<(), Error> {
         for ice_server in &self.ice_servers {
             for url in &ice_server.urls {
@@ -141,8 +145,33 @@ impl RTCIceGatherer {
                     continue;
                 }
 
+                // Resolve STUN hostname once per URL
+                let resolved_addrs = match Self::resolve_stun_url(url).await {
+                    Ok(addrs) => addrs,
+                    Err(err) => {
+                        error!("Failed to resolve STUN server {}: {}", url, err);
+                        continue;
+                    }
+                };
+
                 for local_addr in &self.local_addrs {
-                    match RTCIceGatherer::gather_from_stun_server(*local_addr, url).await {
+                    // Pick the address matching the local IP version
+                    let stun_server_addr = match resolved_addrs
+                        .iter()
+                        .find(|addr| addr.is_ipv4() == local_addr.is_ipv4())
+                    {
+                        Some(addr) => *addr,
+                        None => {
+                            let ip_ver = if local_addr.is_ipv4() { "IPv4" } else { "IPv6" };
+                            debug!(
+                                "No {} address for STUN server {} (local_addr {}), skipping",
+                                ip_ver, url, local_addr
+                            );
+                            continue;
+                        }
+                    };
+
+                    match Self::create_stun_client(*local_addr, stun_server_addr) {
                         Ok(stun_client) => {
                             self.gathering_clients.insert(FourTuple {
                                 local_addr: stun_client.local_addr(),
@@ -151,7 +180,7 @@ impl RTCIceGatherer {
                             self.stun_clients.push(stun_client);
                         }
                         Err(err) => {
-                            error!("Failed to gather stun client: {}", err);
+                            error!("Failed to create STUN client: {}", err);
                         }
                     }
                 }
@@ -161,60 +190,49 @@ impl RTCIceGatherer {
         Ok(())
     }
 
-    /// Gather a single srflx candidate from a STUN server
-    async fn gather_from_stun_server(
-        local_addr: SocketAddr,
-        stun_url: &str,
-    ) -> Result<StunClient, Error> {
-        // Resolve STUN server address (add default port 3478 if not specified)
-        let stun_server_addr_str = if stun_url.contains(':') {
-            stun_url
-                .strip_prefix("stun:")
-                .unwrap_or(stun_url)
-                .to_string()
+    /// Resolve a `stun:` URL to a list of socket addresses with a timeout.
+    ///
+    /// Returns all resolved addresses so the caller can pick the right IP
+    /// version per local address without re-resolving.
+    async fn resolve_stun_url(stun_url: &str) -> Result<Vec<SocketAddr>, Error> {
+        let host_part = stun_url.strip_prefix("stun:").unwrap_or(stun_url);
+
+        // Add default STUN port 3478 when no port is present.
+        // `stun:host:port` after stripping the prefix becomes `host:port` which
+        // already contains a colon. A bare `stun:hostname` becomes `hostname`
+        // with no colon, so we append `:3478`.
+        let addr_str = if host_part.contains(':') {
+            host_part.to_string()
         } else {
-            format!(
-                "{}:3478",
-                stun_url.strip_prefix("stun:").unwrap_or(stun_url)
-            )
+            format!("{}:3478", host_part)
         };
 
-        debug!("Resolving STUN server: {}", stun_server_addr_str);
+        debug!("Resolving STUN server: {}", addr_str);
 
-        // Resolve hostname to IP address with a timeout (#774)
-        const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-        let resolved_addrs = runtime::timeout(
-            DNS_RESOLVE_TIMEOUT,
-            runtime::resolve_host(&stun_server_addr_str),
-        )
-        .await
-        .map_err(|_| {
-            Error::Other(format!(
-                "DNS timed out after {:?} resolving STUN server: {}",
-                DNS_RESOLVE_TIMEOUT, stun_server_addr_str
-            ))
-        })??;
+        let resolved_addrs =
+            runtime::timeout(Self::DNS_RESOLVE_TIMEOUT, runtime::resolve_host(&addr_str))
+                .await
+                .map_err(|_| {
+                    Error::Other(format!(
+                        "DNS timed out after {:?} resolving STUN server: {}",
+                        Self::DNS_RESOLVE_TIMEOUT,
+                        addr_str
+                    ))
+                })??;
 
-        // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
-        let stun_server_addr: SocketAddr = resolved_addrs
-            .into_iter()
-            .find(|addr| addr.is_ipv4() == local_addr.is_ipv4())
-            .ok_or_else(|| {
-                let ip_version = if local_addr.is_ipv4() { "IPv4" } else { "IPv6" };
-                Error::Other(format!(
-                    "Failed to resolve STUN server hostname to {} address (local_addr is {})",
-                    ip_version, local_addr
-                ))
-            })?;
+        debug!("Resolved STUN server {} to {:?}", addr_str, resolved_addrs);
 
-        debug!(
-            "Resolved STUN server {} to {}",
-            stun_server_addr_str, stun_server_addr
-        );
+        Ok(resolved_addrs)
+    }
 
+    /// Create a STUN client for a single (local_addr, stun_server_addr) pair
+    /// and enqueue an initial binding request.
+    fn create_stun_client(
+        local_addr: SocketAddr,
+        stun_server_addr: SocketAddr,
+    ) -> Result<StunClient, Error> {
         debug!("STUN client bound to {}", local_addr);
 
-        // Create STUN client using the sans-I/O pattern
         let mut stun_client =
             StunClientBuilder::new().build(local_addr, stun_server_addr, TransportProtocol::UDP)?;
 
@@ -357,5 +375,72 @@ impl Protocol<TaggedBytesMut, (), ()> for RTCIceGatherer {
             stun_client.close()?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// resolve_stun_url with a known-good IP literal should succeed instantly.
+    #[test]
+    fn test_resolve_stun_url_ip_literal() {
+        crate::runtime::block_on(async {
+            let addrs = RTCIceGatherer::resolve_stun_url("stun:127.0.0.1:3478")
+                .await
+                .expect("IP literal should resolve");
+            assert!(!addrs.is_empty());
+            assert_eq!(addrs[0].ip().to_string(), "127.0.0.1");
+            assert_eq!(addrs[0].port(), 3478);
+        });
+    }
+
+    /// resolve_stun_url with a bare hostname (no port) should append :3478.
+    #[test]
+    fn test_resolve_stun_url_default_port() {
+        crate::runtime::block_on(async {
+            let addrs = RTCIceGatherer::resolve_stun_url("stun:127.0.0.1")
+                .await
+                .expect("bare IP should resolve with default port");
+            assert_eq!(addrs[0].port(), 3478);
+        });
+    }
+
+    /// resolve_stun_url with an unresolvable hostname should return an error
+    /// (timeout or DNS failure) rather than hanging.
+    #[test]
+    fn test_resolve_stun_url_unresolvable() {
+        crate::runtime::block_on(async {
+            let start = std::time::Instant::now();
+            let result =
+                RTCIceGatherer::resolve_stun_url("stun:this.will.never.resolve.invalid:3478").await;
+            let elapsed = start.elapsed();
+            assert!(result.is_err(), "unresolvable hostname should error");
+            // Must not hang longer than 2 x DNS_RESOLVE_TIMEOUT
+            assert!(
+                elapsed.as_secs() < 7,
+                "DNS resolution took {:?}, expected < 7s",
+                elapsed
+            );
+        });
+    }
+
+    /// create_stun_client should succeed with valid addresses.
+    #[test]
+    fn test_create_stun_client_valid() {
+        let local: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let remote: SocketAddr = "127.0.0.1:3478".parse().unwrap();
+        let client = RTCIceGatherer::create_stun_client(local, remote)
+            .expect("should create client with valid addrs");
+        assert_eq!(client.peer_addr(), remote);
+    }
+
+    /// DNS_RESOLVE_TIMEOUT should be 3 seconds.
+    #[test]
+    fn test_dns_resolve_timeout_value() {
+        assert_eq!(
+            RTCIceGatherer::DNS_RESOLVE_TIMEOUT,
+            std::time::Duration::from_secs(3)
+        );
     }
 }

--- a/tests/ice_test.rs
+++ b/tests/ice_test.rs
@@ -2,6 +2,7 @@
 
 use rtc::peer_connection::transport::RTCIceCandidate;
 use std::sync::Arc;
+use std::time::Instant;
 use webrtc::peer_connection::*;
 use webrtc::peer_connection::{
     MediaEngine, RTCConfigurationBuilder, RTCIceCandidateInit, RTCIceCandidateType,
@@ -326,5 +327,163 @@ fn test_stun_gathering_with_google_stun() {
         );
 
         println!("✅ STUN candidate gathering successful! Got both host and srflx candidates.");
+    });
+}
+
+/// Verify that an unresolvable STUN hostname does not hang gathering
+/// indefinitely -- it should complete (with only host candidates) within
+/// roughly the DNS_RESOLVE_TIMEOUT (3 s) rather than blocking forever.
+#[test]
+fn test_unresolvable_stun_hostname_completes_within_timeout() {
+    block_on(async {
+        env_logger::builder()
+            .filter_level(log::LevelFilter::Trace)
+            .try_init()
+            .ok();
+
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("Failed to register codecs");
+
+        // Use a hostname guaranteed not to resolve
+        let ice_servers = vec![RTCIceServer {
+            urls: vec!["stun:this.hostname.will.never.resolve.invalid:3478".to_string()],
+            username: String::new(),
+            credential: String::new(),
+        }];
+
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(ice_servers)
+            .build();
+
+        let candidates = Arc::new(Mutex::new(Vec::new()));
+        let (gathering_tx, mut gathering_rx) = channel(8);
+        let handler = Arc::new(CandidateTypeTracker {
+            candidates: candidates.clone(),
+            gathering_tx,
+        });
+
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(media_engine)
+            .with_handler(handler)
+            .with_udp_addrs(vec!["0.0.0.0:0"])
+            .build()
+            .await
+            .unwrap();
+
+        let _ = pc.create_data_channel("channel1", None).await.unwrap();
+
+        let start = Instant::now();
+
+        let offer = pc.create_offer(None).await.expect("Failed to create offer");
+        pc.set_local_description(offer)
+            .await
+            .expect("Failed to set local description");
+
+        // Wait for gathering to complete
+        let _ = gathering_rx.recv().await;
+        let elapsed = start.elapsed();
+
+        // Should finish well within 6 seconds (DNS timeout is 3 s; allow margin
+        // for CI slowness but reject anything that looks like it hung).
+        assert!(
+            elapsed.as_secs() < 6,
+            "Gathering with unresolvable STUN host took {:?}, expected < 6s",
+            elapsed
+        );
+
+        // Should still have host candidates even though STUN failed
+        let gathered: Vec<RTCIceCandidateType> = candidates.lock().await.clone();
+        let has_host = gathered.iter().any(|t| *t == RTCIceCandidateType::Host);
+        assert!(
+            has_host,
+            "Should still have host candidates despite STUN failure"
+        );
+
+        // Should NOT have srflx since the STUN server was unreachable
+        let has_srflx = gathered.iter().any(|t| *t == RTCIceCandidateType::Srflx);
+        assert!(
+            !has_srflx,
+            "Should not have srflx candidates with unresolvable STUN server"
+        );
+
+        println!(
+            "Gathering with unresolvable STUN host completed in {:?} with {} host candidates",
+            elapsed,
+            gathered.len()
+        );
+    });
+}
+
+/// Verify that DNS resolution happens once per URL, not once per local
+/// address, so N local addresses with an unresolvable hostname still
+/// complete in ~3 s (one timeout) rather than N x 3 s.
+#[test]
+fn test_unresolvable_stun_multiple_local_addrs_single_timeout() {
+    block_on(async {
+        env_logger::builder()
+            .filter_level(log::LevelFilter::Trace)
+            .try_init()
+            .ok();
+
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("Failed to register codecs");
+
+        let ice_servers = vec![RTCIceServer {
+            urls: vec!["stun:this.hostname.will.never.resolve.invalid:3478".to_string()],
+            username: String::new(),
+            credential: String::new(),
+        }];
+
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(ice_servers)
+            .build();
+
+        let candidates = Arc::new(Mutex::new(Vec::new()));
+        let (gathering_tx, mut gathering_rx) = channel(8);
+        let handler = Arc::new(CandidateTypeTracker {
+            candidates: candidates.clone(),
+            gathering_tx,
+        });
+
+        // Bind to multiple local addresses to expose the N x timeout bug
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(media_engine)
+            .with_handler(handler)
+            .with_udp_addrs(vec!["0.0.0.0:0", "127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        let _ = pc.create_data_channel("channel1", None).await.unwrap();
+
+        let start = Instant::now();
+
+        let offer = pc.create_offer(None).await.expect("Failed to create offer");
+        pc.set_local_description(offer)
+            .await
+            .expect("Failed to set local description");
+
+        let _ = gathering_rx.recv().await;
+        let elapsed = start.elapsed();
+
+        // With the fix, DNS is resolved once per URL, so even with 2 local
+        // addresses the timeout should be ~3 s, not ~6 s.
+        assert!(
+            elapsed.as_secs() < 6,
+            "Gathering with 2 local addrs and unresolvable STUN host took {:?}; \
+             expected < 6s (single DNS timeout, not N x timeout)",
+            elapsed
+        );
+
+        println!(
+            "Multiple local addrs + unresolvable STUN completed in {:?}",
+            elapsed
+        );
     });
 }


### PR DESCRIPTION
## Summary

- Wraps `runtime::resolve_host()` with a 3-second timeout (`DNS_RESOLVE_TIMEOUT`), preventing ICE gathering from hanging indefinitely when a STUN server's hostname cannot be resolved (#774).
- DNS resolution is performed **once per STUN URL** (not once per local address), so N local addresses with an unresolvable hostname incur a single timeout rather than N x 3s.
- STUN *response* timeouts (#778) are already handled by the Sans-IO `StunClient` retry loop (7 attempts x 300 ms RTO ~ 9 s max), which fires via the driver's existing `poll_timeout` / `handle_timeout` call chain -- no additional fix required there.

## Changes

**`src/peer_connection/ice_gatherer.rs`**
- Refactored `gather_srflx_candidates` to resolve DNS once per STUN URL before iterating local addresses, eliminating the N x timeout risk.
- Extracted `resolve_stun_url()` -- handles URL parsing, default port, DNS timeout, and error formatting.
- Extracted `create_stun_client()` -- pure synchronous function that builds a `StunClient` and enqueues the initial STUN binding request.
- `DNS_RESOLVE_TIMEOUT` is an associated constant on `RTCIceGatherer` (3 seconds).
- Inner `io::Error` from `resolve_host` is propagated directly via `??` instead of being stringified.

**`tests/ice_test.rs`**
- `test_unresolvable_stun_hostname_completes_within_timeout` -- verifies gathering completes in < 6s with an unresolvable STUN hostname (only host candidates, no srflx).
- `test_unresolvable_stun_multiple_local_addrs_single_timeout` -- verifies that multiple local addresses with an unresolvable STUN hostname still complete in < 6s (single DNS timeout, not N x timeout).

**Unit tests (`ice_gatherer::tests`)**
- `test_resolve_stun_url_ip_literal` -- IP literal resolves correctly.
- `test_resolve_stun_url_default_port` -- bare hostname gets `:3478` appended.
- `test_resolve_stun_url_unresolvable` -- unresolvable hostname returns an error promptly.
- `test_create_stun_client_valid` -- STUN client creation with valid addresses.
- `test_dns_resolve_timeout_value` -- constant is 3 seconds.

## Test plan

- [x] `cargo check -p webrtc` -- clean compile
- [x] `cargo clippy` -- no warnings
- [x] `cargo fmt --check` -- no formatting issues
- [x] `cargo test` -- all tests pass
- [x] Automated: configure a STUN URL with an unresolvable hostname; confirm gathering completes (with an error log) within ~3 seconds instead of hanging.

## Review feedback addressed

- [x] Extract magic number into named constant (`DNS_RESOLVE_TIMEOUT`)
- [x] Include timeout duration in error message
- [x] Propagate inner error directly with `??` instead of stringifying
- [x] Resolve STUN hostname once per URL, not once per local address (N x 3s fix)

Closes #774

Generated with [Claude Code](https://claude.com/claude-code)