### PR TITLE
feat: add data-channel-with-video example and integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,8 @@ bench = false
 name = "swap-tracks"
 path = "examples/swap-tracks/swap-tracks.rs"
 bench = false
+
+[[example]]
+name = "data-channel-with-video"
+path = "examples/data-channel-with-video/data-channel-with-video.rs"
+bench = false

--- a/examples/data-channel-with-video/data-channel-with-video.rs
+++ b/examples/data-channel-with-video/data-channel-with-video.rs
@@ -19,10 +19,11 @@
 //! cargo run --example data-channel-with-video
 //! ```
 //!
-//! Both peers run in the same process.  The offerer adds a `Recvonly` video
-//! transceiver and a data channel; the answerer mirrors this.  After ICE+DTLS
-//! negotiate, the offerer sends a text message over the data channel and the
-//! answerer prints it.  No actual video RTP is sent.
+//! Both peers run in the same process. The offerer adds a `Recvonly` video
+//! transceiver and a data channel; the answerer applies the remote description
+//! and creates an answer for that offer. After ICE+DTLS negotiate, the offerer
+//! sends a text message over the data channel and the answerer prints it. No
+//! actual video RTP is sent.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,8 +33,8 @@ use rtc::rtp_transceiver::RTCRtpTransceiverInit;
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
 use webrtc::data_channel::{DataChannel, DataChannelEvent};
 use webrtc::peer_connection::{
-    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
-    RTCIceGatheringState, RTCPeerConnectionState,
+    MediaEngine, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
+    RTCPeerConnectionState,
 };
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
@@ -181,8 +182,14 @@ async fn run() -> anyhow::Result<()> {
     }
 
     let offer = offerer_pc.create_offer(None).await?;
-    eprintln!("Offerer: SDP offer contains m=video: {}", offer.sdp.contains("m=video"));
-    eprintln!("Offerer: SDP offer contains m=application: {}", offer.sdp.contains("m=application"));
+    eprintln!(
+        "Offerer: SDP offer contains m=video: {}",
+        offer.sdp.contains("m=video")
+    );
+    eprintln!(
+        "Offerer: SDP offer contains m=application: {}",
+        offer.sdp.contains("m=application")
+    );
 
     offerer_pc.set_local_description(offer).await?;
     let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
@@ -205,8 +212,14 @@ async fn run() -> anyhow::Result<()> {
 
     answerer_pc.set_remote_description(offer_sdp).await?;
     let answer = answerer_pc.create_answer(None).await?;
-    eprintln!("Answerer: SDP answer contains m=video: {}", answer.sdp.contains("m=video"));
-    eprintln!("Answerer: SDP answer contains m=application: {}", answer.sdp.contains("m=application"));
+    eprintln!(
+        "Answerer: SDP answer contains m=video: {}",
+        answer.sdp.contains("m=video")
+    );
+    eprintln!(
+        "Answerer: SDP answer contains m=application: {}",
+        answer.sdp.contains("m=application")
+    );
 
     answerer_pc.set_local_description(answer).await?;
     let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;

--- a/examples/data-channel-with-video/data-channel-with-video.rs
+++ b/examples/data-channel-with-video/data-channel-with-video.rs
@@ -33,8 +33,8 @@ use rtc::rtp_transceiver::RTCRtpTransceiverInit;
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
 use webrtc::data_channel::{DataChannel, DataChannelEvent};
 use webrtc::peer_connection::{
-    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
-    RTCIceGatheringState, RTCPeerConnectionState,
+    MediaEngine, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
+    RTCPeerConnectionState,
 };
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 

--- a/examples/data-channel-with-video/data-channel-with-video.rs
+++ b/examples/data-channel-with-video/data-channel-with-video.rs
@@ -20,10 +20,10 @@
 //! ```
 //!
 //! Both peers run in the same process. The offerer adds a `Recvonly` video
-//! transceiver and a data channel; the answerer applies the remote description
-//! and creates an answer for that offer. After ICE+DTLS negotiate, the offerer
-//! sends a text message over the data channel and the answerer prints it. No
-//! actual video RTP is sent.
+//! transceiver and a data channel; the answerer sets the remote description
+//! (which implicitly creates matching transceivers) and creates an answer. After
+//! ICE+DTLS negotiate, the offerer sends a text message over the data channel
+//! and the answerer prints it. No actual video RTP is sent.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,8 +33,8 @@ use rtc::rtp_transceiver::RTCRtpTransceiverInit;
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
 use webrtc::data_channel::{DataChannel, DataChannelEvent};
 use webrtc::peer_connection::{
-    MediaEngine, PeerConnectionBuilder, PeerConnectionEventHandler, RTCIceGatheringState,
-    RTCPeerConnectionState,
+    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState,
 };
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
@@ -192,9 +192,16 @@ async fn run() -> anyhow::Result<()> {
     );
 
     offerer_pc.set_local_description(offer).await?;
-    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    match timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await {
+        Ok(Some(_)) => eprintln!("Offerer: ICE gathering complete"),
+        Ok(None) => return Err(anyhow::anyhow!("Offerer ICE gathering channel closed")),
+        Err(_) => {
+            return Err(anyhow::anyhow!(
+                "Timeout: offerer ICE gathering did not complete within 5s"
+            ));
+        }
+    }
     let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
-    eprintln!("Offerer: ICE gathering complete");
 
     // ── Answerer: mirror the offerer's configuration ───────────────────────────
     let answerer_pc = PeerConnectionBuilder::new()
@@ -222,9 +229,16 @@ async fn run() -> anyhow::Result<()> {
     );
 
     answerer_pc.set_local_description(answer).await?;
-    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    match timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await {
+        Ok(Some(_)) => eprintln!("Answerer: ICE gathering complete"),
+        Ok(None) => return Err(anyhow::anyhow!("Answerer ICE gathering channel closed")),
+        Err(_) => {
+            return Err(anyhow::anyhow!(
+                "Timeout: answerer ICE gathering did not complete within 5s"
+            ));
+        }
+    }
     let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
-    eprintln!("Answerer: ICE gathering complete");
 
     offerer_pc.set_remote_description(answer_sdp).await?;
 

--- a/examples/data-channel-with-video/data-channel-with-video.rs
+++ b/examples/data-channel-with-video/data-channel-with-video.rs
@@ -1,0 +1,251 @@
+//! DataChannel + Video transceiver on the same PeerConnection
+//!
+//! Demonstrates that a single [`RTCPeerConnection`] can simultaneously host:
+//!
+//! - An **RTP video transceiver** (`m=video` in SDP)
+//! - A **data channel** (`m=application` / SCTP in SDP)
+//!
+//! ## Key requirement
+//!
+//! You **must** call [`MediaEngine::register_default_codecs`] (or register at
+//! least one video codec manually) before creating an offer.  Without a codec
+//! registration the SDP generator has no payload types to advertise and emits a
+//! rejected `m=video 0 …` line, which can make it look as if mixing a data
+//! channel with a video transceiver is broken — it is not.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo run --example data-channel-with-video
+//! ```
+//!
+//! Both peers run in the same process.  The offerer adds a `Recvonly` video
+//! transceiver and a data channel; the answerer mirrors this.  After ICE+DTLS
+//! negotiate, the offerer sends a text message over the data channel and the
+//! answerer prints it.  No actual video RTP is sent.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::RTCRtpTransceiverInit;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::{
+    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "Hello from data channel (alongside video)!";
+
+// ── Offerer handler ────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Offerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+// ── Answerer handler ───────────────────────────────────────────────────────────
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Answerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        eprintln!("Answerer: received data channel '{}'", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => eprintln!("Answerer: data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        eprintln!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Build a MediaEngine with all default codecs registered.
+///
+/// This is the critical step that ensures video m-lines in the SDP have valid
+/// payload types.  Omitting it causes `m=video 0 …` (rejected) to appear in
+/// the offer, which has nothing to do with mixing data channels and video.
+fn make_media_engine() -> MediaEngine {
+    let mut me = MediaEngine::default();
+    me.register_default_codecs()
+        .expect("register_default_codecs failed");
+    me
+}
+
+fn recvonly_init() -> Option<RTCRtpTransceiverInit> {
+    Some(RTCRtpTransceiverInit {
+        direction: RTCRtpTransceiverDirection::Recvonly,
+        send_encodings: vec![],
+        streams: vec![],
+    })
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fn main() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    // ── Offerer: video transceiver + data channel ──────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine()) // <-- required for valid m=video
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    offerer_pc
+        .add_transceiver_from_kind(RtpCodecKind::Video, recvonly_init())
+        .await?;
+    eprintln!("Offerer: added video transceiver (recvonly)");
+
+    let offerer_dc = offerer_pc.create_data_channel("chat", None).await?;
+    eprintln!("Offerer: created data channel");
+
+    {
+        let dc = offerer_dc.clone();
+        let open_tx = offerer_dc_open_tx;
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                if let DataChannelEvent::OnOpen = event {
+                    eprintln!("Offerer: data channel opened");
+                    open_tx.try_send(()).ok();
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    eprintln!("Offerer: SDP offer contains m=video: {}", offer.sdp.contains("m=video"));
+    eprintln!("Offerer: SDP offer contains m=application: {}", offer.sdp.contains("m=application"));
+
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
+    eprintln!("Offerer: ICE gathering complete");
+
+    // ── Answerer: mirror the offerer's configuration ───────────────────────────
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine()) // <-- required on answerer too
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    eprintln!("Answerer: SDP answer contains m=video: {}", answer.sdp.contains("m=video"));
+    eprintln!("Answerer: SDP answer contains m=application: {}", answer.sdp.contains("m=application"));
+
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
+    eprintln!("Answerer: ICE gathering complete");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for connection ────────────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for offerer to connect"))?;
+    eprintln!("Offerer: connected!");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for answerer to connect"))?;
+    eprintln!("Answerer: connected!");
+
+    // ── Send message over the data channel ─────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for data channel to open"))?;
+
+    eprintln!("Offerer: sending '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for message"))?
+        .ok_or_else(|| anyhow::anyhow!("Channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE);
+    eprintln!("✅ Message received: '{}'", received);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    eprintln!("✅ data-channel-with-video example completed");
+    Ok(())
+}

--- a/tests/datachannel_video_interop.rs
+++ b/tests/datachannel_video_interop.rs
@@ -1,0 +1,276 @@
+/// Integration test: DataChannel + Video transceiver on the same RTCPeerConnection (#784)
+///
+/// Verifies that a PeerConnection can simultaneously host:
+///   - An RTP video transceiver (m=video in SDP)
+///   - A data channel          (m=application / SCTP in SDP)
+///
+/// The test confirms:
+///   1. `create_offer()` succeeds and produces SDP containing both m-lines
+///   2. The answerer can parse the offer and generate a valid answer with both m-lines
+///   3. ICE + DTLS + SCTP establish successfully (data channel opens)
+///   4. A message can be sent/received over the data channel
+///
+/// Default codecs are registered so video m-lines have real codec payloads.
+/// No actual video RTP is sent — the transceivers are inactive (Recvonly on both sides).
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::RTCRtpTransceiverInit;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::*;
+use webrtc::peer_connection::{
+    MediaEngine, RTCIceGatheringState, RTCPeerConnectionState,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "DC over video+DC peer connection";
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        log::info!("Answerer received data channel: {}", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => log::info!("Answerer data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        log::info!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_media_engine() -> MediaEngine {
+    let mut me = MediaEngine::default();
+    me.register_default_codecs()
+        .expect("register_default_codecs failed");
+    me
+}
+
+// ── Test entry point ──────────────────────────────────────────────────────────
+
+/// Verify that a video transceiver and a data channel coexist on the same PeerConnection.
+#[test]
+fn test_datachannel_and_video_transceiver() {
+    block_on(run_test()).unwrap();
+}
+
+async fn run_test() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    log::info!("Starting DataChannel + Video transceiver test (#784)");
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (offerer_msg_tx, mut offerer_msg_rx) = channel::<String>(8);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    let recvonly_init = || Some(RTCRtpTransceiverInit {
+        direction: RTCRtpTransceiverDirection::Recvonly,
+        send_encodings: vec![],
+        streams: vec![],
+    });
+
+    // ── Build offerer ──────────────────────────────────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine())
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    offerer_pc
+        .add_transceiver_from_kind(RtpCodecKind::Video, recvonly_init())
+        .await?;
+    log::info!("Offerer: added video transceiver (recvonly)");
+
+    let offerer_dc = offerer_pc.create_data_channel("test", None).await?;
+    log::info!("Offerer: created data channel");
+
+    {
+        let dc = offerer_dc.clone();
+        let dc_open_tx = offerer_dc_open_tx.clone();
+        let msg_tx = offerer_msg_tx.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        log::info!("Offerer data channel opened");
+                        dc_open_tx.try_send(()).ok();
+                    }
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        log::info!("Offerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    log::info!("Offerer created offer:\n{}", offer.sdp);
+
+    // Both m-lines must be present in the offer with valid ports
+    assert!(
+        offer.sdp.contains("m=video") && !offer.sdp.contains("m=video 0 "),
+        "Offer must contain active m=video (not rejected), got:\n{}",
+        offer.sdp
+    );
+    assert!(
+        offer.sdp.contains("m=application"),
+        "Offer must contain m=application (SCTP), got:\n{}",
+        offer.sdp
+    );
+    log::info!("✅ Offer SDP contains both m=video (active) and m=application");
+
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc
+        .local_description()
+        .await
+        .expect("offerer local description must be set");
+
+    // ── Build answerer (also has video + DC) ───────────────────────────────────
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine())
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    log::info!("Answerer created answer:\n{}", answer.sdp);
+
+    assert!(
+        answer.sdp.contains("m=video"),
+        "Answer must contain m=video, got:\n{}",
+        answer.sdp
+    );
+    assert!(
+        answer.sdp.contains("m=application"),
+        "Answer must contain m=application, got:\n{}",
+        answer.sdp
+    );
+    log::info!("✅ Answer SDP contains both m=video and m=application");
+
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc
+        .local_description()
+        .await
+        .expect("answerer local description must be set");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for both to connect ───────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: offerer did not connect"))?;
+    log::info!("Offerer connected");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: answerer did not connect"))?;
+    log::info!("Answerer connected");
+
+    // ── Send message over data channel ─────────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: offerer data channel did not open"))?;
+
+    log::info!("Offerer sending: '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: answerer did not receive message"))?
+        .ok_or_else(|| anyhow::anyhow!("Answerer message channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE, "Answerer must receive the test message");
+    log::info!("✅ Data channel message received over video+DC peer connection");
+
+    // Offerer_msg_rx is intentionally unused — we only test one-way delivery here
+    drop(offerer_msg_rx);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    log::info!("✅ test_datachannel_and_video_transceiver passed");
+    Ok(())
+}

--- a/tests/datachannel_video_interop.rs
+++ b/tests/datachannel_video_interop.rs
@@ -1,17 +1,18 @@
-/// Integration test: DataChannel + Video transceiver on the same RTCPeerConnection (#784)
+/// Integration test: DataChannel + Video transceiver SDP coexistence (#784)
 ///
-/// Verifies that a PeerConnection can simultaneously host:
-///   - An RTP video transceiver (m=video in SDP)
-///   - A data channel          (m=application / SCTP in SDP)
+/// Validates that a PeerConnection can negotiate SDP containing both a video
+/// m-line and a DataChannel (SCTP) m-line, and that the DataChannel works.
 ///
 /// The test confirms:
 ///   1. `create_offer()` succeeds and produces SDP containing both m-lines
-///   2. The answerer can parse the offer and generate a valid answer with both m-lines
+///   2. The answerer can parse the offer and generate a valid answer with both
+///      m-lines (video is accepted, not rejected with port 0)
 ///   3. ICE + DTLS + SCTP establish successfully (data channel opens)
 ///   4. A message can be sent/received over the data channel
 ///
 /// Default codecs are registered so video m-lines have real codec payloads.
-/// No actual video RTP is sent — the transceivers are inactive (Recvonly on both sides).
+/// No actual video RTP/frames are sent -- the test only validates SDP
+/// coexistence and DataChannel behavior.
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,9 +22,7 @@ use rtc::rtp_transceiver::RTCRtpTransceiverInit;
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
 use webrtc::data_channel::{DataChannel, DataChannelEvent};
 use webrtc::peer_connection::*;
-use webrtc::peer_connection::{
-    MediaEngine, RTCIceGatheringState, RTCPeerConnectionState,
-};
+use webrtc::peer_connection::{MediaEngine, RTCIceGatheringState, RTCPeerConnectionState};
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
 const TEST_MESSAGE: &str = "DC over video+DC peer connection";
@@ -121,16 +120,18 @@ async fn run_test() -> Result<()> {
     let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
     let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
     let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
-    let (offerer_msg_tx, mut offerer_msg_rx) = channel::<String>(8);
+    let (offerer_msg_tx, offerer_msg_rx) = channel::<String>(8);
     let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
     let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
     let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
 
-    let recvonly_init = || Some(RTCRtpTransceiverInit {
-        direction: RTCRtpTransceiverDirection::Recvonly,
-        send_encodings: vec![],
-        streams: vec![],
-    });
+    let recvonly_init = || {
+        Some(RTCRtpTransceiverInit {
+            direction: RTCRtpTransceiverDirection::Recvonly,
+            send_encodings: vec![],
+            streams: vec![],
+        })
+    };
 
     // ── Build offerer ──────────────────────────────────────────────────────────
     let offerer_pc = PeerConnectionBuilder::new()
@@ -192,7 +193,10 @@ async fn run_test() -> Result<()> {
     log::info!("✅ Offer SDP contains both m=video (active) and m=application");
 
     offerer_pc.set_local_description(offer).await?;
-    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    timeout(Duration::from_secs(5), offerer_gather_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: offerer ICE gathering did not complete"))?
+        .ok_or_else(|| anyhow::anyhow!("Offerer ICE gathering channel closed before completion"))?;
     let offer_sdp = offerer_pc
         .local_description()
         .await
@@ -216,9 +220,20 @@ async fn run_test() -> Result<()> {
     let answer = answerer_pc.create_answer(None).await?;
     log::info!("Answerer created answer:\n{}", answer.sdp);
 
+    let has_video_mline = answer.sdp.lines().any(|line| line.starts_with("m=video "));
+    let video_mline_rejected = answer
+        .sdp
+        .lines()
+        .any(|line| line.starts_with("m=video 0 "));
+
     assert!(
-        answer.sdp.contains("m=video"),
+        has_video_mline,
         "Answer must contain m=video, got:\n{}",
+        answer.sdp
+    );
+    assert!(
+        !video_mline_rejected,
+        "Answer must not reject the video m-line (found `m=video 0 ...`), got:\n{}",
         answer.sdp
     );
     assert!(
@@ -226,10 +241,15 @@ async fn run_test() -> Result<()> {
         "Answer must contain m=application, got:\n{}",
         answer.sdp
     );
-    log::info!("✅ Answer SDP contains both m=video and m=application");
+    log::info!("✅ Answer SDP contains both m=video and m=application, and video is accepted");
 
     answerer_pc.set_local_description(answer).await?;
-    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    timeout(Duration::from_secs(5), answerer_gather_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: answerer ICE gathering did not complete"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("Answerer ICE gathering channel closed before completion")
+        })?;
     let answer_sdp = answerer_pc
         .local_description()
         .await
@@ -261,7 +281,10 @@ async fn run_test() -> Result<()> {
         .map_err(|_| anyhow::anyhow!("Timeout: answerer did not receive message"))?
         .ok_or_else(|| anyhow::anyhow!("Answerer message channel closed"))?;
 
-    assert_eq!(received, TEST_MESSAGE, "Answerer must receive the test message");
+    assert_eq!(
+        received, TEST_MESSAGE,
+        "Answerer must receive the test message"
+    );
     log::info!("✅ Data channel message received over video+DC peer connection");
 
     // Offerer_msg_rx is intentionally unused — we only test one-way delivery here

--- a/tests/datachannel_video_interop.rs
+++ b/tests/datachannel_video_interop.rs
@@ -120,7 +120,8 @@ async fn run_test() -> Result<()> {
     let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
     let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
     let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
-    let (offerer_msg_tx, offerer_msg_rx) = channel::<String>(8);
+    // Receiver kept alive so offerer_msg_tx.send() doesn't fail; one-way test only.
+    let (offerer_msg_tx, _offerer_msg_rx) = channel::<String>(8);
     let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
     let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
     let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
@@ -288,7 +289,7 @@ async fn run_test() -> Result<()> {
     log::info!("✅ Data channel message received over video+DC peer connection");
 
     // Offerer_msg_rx is intentionally unused — we only test one-way delivery here
-    drop(offerer_msg_rx);
+    drop(_offerer_msg_rx);
 
     sleep(Duration::from_millis(100)).await;
     offerer_pc.close().await?;

--- a/tests/datachannel_video_interop.rs
+++ b/tests/datachannel_video_interop.rs
@@ -177,7 +177,7 @@ async fn run_test() -> Result<()> {
     }
 
     let offer = offerer_pc.create_offer(None).await?;
-    log::info!("Offerer created offer:\n{}", offer.sdp);
+    log::debug!("Offerer created offer:\n{}", offer.sdp);
 
     // Both m-lines must be present in the offer with valid ports
     assert!(
@@ -218,7 +218,7 @@ async fn run_test() -> Result<()> {
 
     answerer_pc.set_remote_description(offer_sdp).await?;
     let answer = answerer_pc.create_answer(None).await?;
-    log::info!("Answerer created answer:\n{}", answer.sdp);
+    log::debug!("Answerer created answer:\n{}", answer.sdp);
 
     let has_video_mline = answer.sdp.lines().any(|line| line.starts_with("m=video "));
     let video_mline_rejected = answer


### PR DESCRIPTION
## Summary

- **Example** (`examples/data-channel-with-video/data-channel-with-video.rs`): demonstrates a PeerConnection with both a DataChannel and a video transceiver coexisting in the same SDP session
- **Integration test** (`tests/datachannel_video_interop.rs`): validates SDP coexistence of video and SCTP m-lines, and verifies DataChannel message delivery works when a video transceiver is present (no actual video RTP/frames are sent)
- **Cargo.toml**: registers the new example

## Test plan
- [x] `cargo build --example data-channel-with-video`
- [x] `cargo test datachannel_video_interop`
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)