### PR TITLE
feat: wire mDNS peer discovery into async wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,8 @@ bench = false
 name = "swap-tracks"
 path = "examples/swap-tracks/swap-tracks.rs"
 bench = false
+
+[[example]]
+name = "mdns-local-peers"
+path = "examples/mdns-local-peers/mdns-local-peers.rs"
+bench = false

--- a/examples/mdns-local-peers/mdns-local-peers.rs
+++ b/examples/mdns-local-peers/mdns-local-peers.rs
@@ -1,0 +1,230 @@
+//! mDNS peer discovery example
+//!
+//! Demonstrates two in-process WebRTC peers communicating with mDNS enabled.
+//! Both peers use `MulticastDnsMode::QueryAndGather` so that:
+//!
+//! - **QueryAndGather**: Local candidates advertise a `.local` mDNS hostname
+//!   instead of exposing the raw IP address (privacy-preserving).
+//! - Remote `.local` candidates are resolved via multicast DNS on the local
+//!   network — no STUN server is needed.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo run --example mdns-local-peers
+//! ```
+//!
+//! Both peers will run in the same process and exchange a data channel message
+//! to verify end-to-end connectivity.
+//!
+//! ## Notes
+//!
+//! - mDNS requires access to the `224.0.0.251:5353` multicast group.  Some
+//!   environments (CI, containers without multicast routing) may prevent the
+//!   socket from joining the group; the example logs a warning and falls back
+//!   gracefully.
+//! - For true cross-host mDNS peer discovery you would run one peer on each
+//!   host and exchange their SDP offers/answers via a signaling channel.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::{
+    MulticastDnsMode, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState, SettingEngine,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "Hello via mDNS-enabled peer connection!";
+
+// ── Offerer handler ────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Offerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+// ── Answerer handler ───────────────────────────────────────────────────────────
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Answerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        eprintln!("Answerer: received data channel '{}'", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => eprintln!("Answerer: data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        eprintln!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fn main() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    // Configure mDNS: QueryAndGather means local candidates use .local
+    // hostnames AND remote .local candidates are resolved via multicast DNS.
+    let mut setting_engine = SettingEngine::default();
+    setting_engine.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    setting_engine.set_multicast_dns_local_name("offerer-webrtc.local".to_string());
+
+    // ── Offerer ────────────────────────────────────────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_setting_engine(setting_engine.clone())
+        .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let offerer_dc = offerer_pc.create_data_channel("chat", None).await?;
+    eprintln!("Offerer: created data channel");
+
+    // Track when the data channel opens
+    {
+        let dc = offerer_dc.clone();
+        let open_tx = offerer_dc_open_tx.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                if let DataChannelEvent::OnOpen = event {
+                    eprintln!("Offerer: data channel opened");
+                    open_tx.try_send(()).ok();
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
+    eprintln!("Offerer: ICE gathering complete");
+
+    // ── Answerer ───────────────────────────────────────────────────────────────
+    let mut answerer_se = SettingEngine::default();
+    answerer_se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    answerer_se.set_multicast_dns_local_name("answerer-webrtc.local".to_string());
+
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_setting_engine(answerer_se)
+        .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
+    eprintln!("Answerer: ICE gathering complete");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for connection ────────────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for offerer to connect"))?;
+    eprintln!("Offerer: connected!");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for answerer to connect"))?;
+    eprintln!("Answerer: connected!");
+
+    // ── Send message ───────────────────────────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for data channel to open"))?;
+
+    eprintln!("Offerer: sending '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for message"))?
+        .ok_or_else(|| anyhow::anyhow!("Channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE);
+    eprintln!("✅ Message received: '{}'", received);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    eprintln!("✅ mDNS-local-peers example completed");
+    Ok(())
+}

--- a/examples/mdns-local-peers/mdns-local-peers.rs
+++ b/examples/mdns-local-peers/mdns-local-peers.rs
@@ -23,8 +23,10 @@
 //!
 //! - mDNS requires access to the `224.0.0.251:5353` multicast group.  Some
 //!   environments (CI, containers without multicast routing) may prevent the
-//!   socket from joining the group; the example logs a warning and falls back
-//!   gracefully.
+//!   socket from joining the group.  When that happens the peer connection
+//!   builder logs a warning and continues without mDNS -- `.local` candidates
+//!   will not be advertised or resolved, but the connection can still succeed
+//!   via other candidate types (host, srflx, relay).
 //! - For true cross-host mDNS peer discovery you would run one peer on each
 //!   host and exchange their SDP offers/answers via a signaling channel.
 
@@ -128,13 +130,13 @@ async fn run() -> anyhow::Result<()> {
 
     // Configure mDNS: QueryAndGather means local candidates use .local
     // hostnames AND remote .local candidates are resolved via multicast DNS.
-    let mut setting_engine = SettingEngine::default();
-    setting_engine.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
-    setting_engine.set_multicast_dns_local_name("offerer-webrtc.local".to_string());
+    // with_mdns_mode() sets the mode on both the async wrapper and the sans-IO core.
+    let mut offerer_se = SettingEngine::default();
+    offerer_se.set_multicast_dns_local_name("offerer-webrtc.local".to_string());
 
     // ── Offerer ────────────────────────────────────────────────────────────────
     let offerer_pc = PeerConnectionBuilder::new()
-        .with_setting_engine(setting_engine.clone())
+        .with_setting_engine(offerer_se)
         .with_mdns_mode(MulticastDnsMode::QueryAndGather)
         .with_handler(Arc::new(OffererHandler {
             gather_tx: offerer_gather_tx,
@@ -170,7 +172,6 @@ async fn run() -> anyhow::Result<()> {
 
     // ── Answerer ───────────────────────────────────────────────────────────────
     let mut answerer_se = SettingEngine::default();
-    answerer_se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
     answerer_se.set_multicast_dns_local_name("answerer-webrtc.local".to_string());
 
     let answerer_pc = PeerConnectionBuilder::new()

--- a/examples/mdns-local-peers/mdns-local-peers.rs
+++ b/examples/mdns-local-peers/mdns-local-peers.rs
@@ -1,12 +1,14 @@
-//! mDNS peer discovery example
+//! mDNS-enabled ICE candidate resolution example
 //!
-//! Demonstrates two in-process WebRTC peers communicating with mDNS enabled.
+//! The peers still exchange SDP offers/answers through the example's normal
+//! in-process signaling flow; mDNS here is only used for privacy-preserving
+//! host candidates and for resolving remote `.local` ICE candidates.
 //! Both peers use `MulticastDnsMode::QueryAndGather` so that:
 //!
 //! - **QueryAndGather**: Local candidates advertise a `.local` mDNS hostname
 //!   instead of exposing the raw IP address (privacy-preserving).
 //! - Remote `.local` candidates are resolved via multicast DNS on the local
-//!   network — no STUN server is needed.
+//!   network -- no STUN server is needed for that local hostname resolution.
 //!
 //! ## How to run
 //!
@@ -139,7 +141,7 @@ async fn run() -> anyhow::Result<()> {
             connected_tx: offerer_connected_tx,
         }))
         .with_runtime(runtime.clone())
-        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_udp_addrs(vec!["0.0.0.0:0".to_string()])
         .build()
         .await?;
 
@@ -181,7 +183,7 @@ async fn run() -> anyhow::Result<()> {
             runtime: runtime.clone(),
         }))
         .with_runtime(runtime.clone())
-        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_udp_addrs(vec!["0.0.0.0:0".to_string()])
         .build()
         .await?;
 

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -270,10 +270,8 @@ where
             // DNS A record), but the mDNS socket is keyed as 0.0.0.0:5353.  Fall back
             // to that key so responses are routed through the multicast socket.
             if msg.transport.local_addr.port() == rtc::mdns::MDNS_PORT {
-                let fallback = SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                    rtc::mdns::MDNS_PORT,
-                );
+                let fallback =
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), rtc::mdns::MDNS_PORT);
                 self.sockets.get(&fallback)
             } else {
                 None

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -29,7 +29,7 @@ use rtc::shared::{TaggedBytesMut, TransportContext, TransportProtocol};
 use rtc::{rtcp, rtp};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -265,7 +265,21 @@ where
     }
 
     async fn handle_write(&self, msg: TaggedBytesMut) {
-        if let Some(socket) = self.sockets.get(&msg.transport.local_addr) {
+        let socket = self.sockets.get(&msg.transport.local_addr).or_else(|| {
+            // mDNS answer packets use local_addr = local_ip:5353 (the IP carried in the
+            // DNS A record), but the mDNS socket is keyed as 0.0.0.0:5353.  Fall back
+            // to that key so responses are routed through the multicast socket.
+            if msg.transport.local_addr.port() == rtc::mdns::MDNS_PORT {
+                let fallback = SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                    rtc::mdns::MDNS_PORT,
+                );
+                self.sockets.get(&fallback)
+            } else {
+                None
+            }
+        });
+        if let Some(socket) = socket {
             match socket.send_to(&msg.message, msg.transport.peer_addr).await {
                 Ok(n) => {
                     trace!(

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -689,3 +689,90 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    /// Mirrors the socket-lookup logic from `handle_write`: first try an exact
+    /// match, then fall back to `0.0.0.0:5353` for any port-5353 address.
+    fn lookup_socket_key(keys: &[SocketAddr], local_addr: SocketAddr) -> Option<SocketAddr> {
+        let map: HashMap<SocketAddr, ()> = keys.iter().map(|k| (*k, ())).collect();
+        if map.contains_key(&local_addr) {
+            return Some(local_addr);
+        }
+        if local_addr.port() == rtc::mdns::MDNS_PORT {
+            let fallback = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), rtc::mdns::MDNS_PORT);
+            if map.contains_key(&fallback) {
+                return Some(fallback);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_mdns_port_5353_fallback_to_unspecified_key() {
+        let mdns_key = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5353);
+        let keys = vec![mdns_key];
+
+        // 1. Direct lookup for 0.0.0.0:5353 should succeed
+        assert_eq!(
+            lookup_socket_key(&keys, mdns_key),
+            Some(mdns_key),
+            "direct lookup for 0.0.0.0:5353 should find the key"
+        );
+
+        // 2. Fallback: local_addr = 192.168.1.100:5353 should fall back to 0.0.0.0:5353
+        let specific_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 5353);
+        assert_eq!(
+            lookup_socket_key(&keys, specific_addr),
+            Some(mdns_key),
+            "port-5353 fallback should route 192.168.1.100:5353 to the 0.0.0.0:5353 key"
+        );
+
+        // 3. Non-5353 traffic should NOT fall back
+        let other_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 12345);
+        assert_eq!(
+            lookup_socket_key(&keys, other_addr),
+            None,
+            "non-5353 traffic should not match any key"
+        );
+
+        // 4. Port 5353 with no 0.0.0.0:5353 entry should return None
+        let empty_keys: Vec<SocketAddr> = vec![];
+        assert_eq!(
+            lookup_socket_key(&empty_keys, specific_addr),
+            None,
+            "port-5353 fallback with no 0.0.0.0:5353 entry should return None"
+        );
+    }
+
+    #[test]
+    fn test_mdns_direct_key_takes_precedence_over_fallback() {
+        let mdns_key = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5353);
+        let specific_key = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 5353);
+        let keys = vec![mdns_key, specific_key];
+
+        // The direct key should be returned (not the fallback)
+        assert_eq!(
+            lookup_socket_key(&keys, specific_key),
+            Some(specific_key),
+            "direct key should take precedence over fallback"
+        );
+    }
+
+    #[test]
+    fn test_mdns_fallback_only_for_ipv4_unspecified() {
+        // Ensure the fallback only checks 0.0.0.0:5353, not [::]:5353
+        let ipv6_key = SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), 5353);
+        let keys = vec![ipv6_key];
+
+        let v4_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 5353);
+        assert_eq!(
+            lookup_socket_key(&keys, v4_addr),
+            None,
+            "fallback should only look for 0.0.0.0:5353, not [::]:5353"
+        );
+    }
+}

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -181,19 +181,19 @@ impl RTCIceGatherer {
 
         debug!("Resolving STUN server: {}", stun_server_addr_str);
 
-        // Resolve hostname to IP address with a 3-second timeout (#774)
+        // Resolve hostname to IP address with a timeout (#774)
+        const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
         let resolved_addrs = runtime::timeout(
-            std::time::Duration::from_secs(3),
+            DNS_RESOLVE_TIMEOUT,
             runtime::resolve_host(&stun_server_addr_str),
         )
         .await
         .map_err(|_| {
             Error::Other(format!(
-                "DNS timeout resolving STUN server: {}",
-                stun_server_addr_str
+                "DNS timed out after {:?} resolving STUN server: {}",
+                DNS_RESOLVE_TIMEOUT, stun_server_addr_str
             ))
-        })?
-        .map_err(|e| Error::Other(e.to_string()))?;
+        })??;
 
         // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
         let stun_server_addr: SocketAddr = resolved_addrs

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -181,8 +181,19 @@ impl RTCIceGatherer {
 
         debug!("Resolving STUN server: {}", stun_server_addr_str);
 
-        // Resolve hostname to IP address using runtime-agnostic helper
-        let resolved_addrs = runtime::resolve_host(&stun_server_addr_str).await?;
+        // Resolve hostname to IP address with a 3-second timeout (#774)
+        let resolved_addrs = runtime::timeout(
+            std::time::Duration::from_secs(3),
+            runtime::resolve_host(&stun_server_addr_str),
+        )
+        .await
+        .map_err(|_| {
+            Error::Other(format!(
+                "DNS timeout resolving STUN server: {}",
+                stun_server_addr_str
+            ))
+        })?
+        .map_err(|e| Error::Other(e.to_string()))?;
 
         // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
         let stun_server_addr: SocketAddr = resolved_addrs

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -129,10 +129,14 @@ impl RTCIceGatherer {
         Ok(())
     }
 
+    /// Timeout for DNS resolution of STUN/TURN server hostnames (#774).
+    const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
     /// Gather server reflexive (srflx) ICE candidates via STUN
     ///
-    /// This performs actual I/O to query STUN servers and should be called
-    /// in an async context.
+    /// DNS resolution is performed once per STUN URL (not per local address)
+    /// so that an unresolvable hostname incurs at most one timeout rather
+    /// than N x timeout for N local addresses.
     async fn gather_srflx_candidates(&mut self) -> Result<(), Error> {
         for ice_server in &self.ice_servers {
             for url in &ice_server.urls {
@@ -141,8 +145,33 @@ impl RTCIceGatherer {
                     continue;
                 }
 
+                // Resolve STUN hostname once per URL
+                let resolved_addrs = match Self::resolve_stun_url(url).await {
+                    Ok(addrs) => addrs,
+                    Err(err) => {
+                        error!("Failed to resolve STUN server {}: {}", url, err);
+                        continue;
+                    }
+                };
+
                 for local_addr in &self.local_addrs {
-                    match RTCIceGatherer::gather_from_stun_server(*local_addr, url).await {
+                    // Pick the address matching the local IP version
+                    let stun_server_addr = match resolved_addrs
+                        .iter()
+                        .find(|addr| addr.is_ipv4() == local_addr.is_ipv4())
+                    {
+                        Some(addr) => *addr,
+                        None => {
+                            let ip_ver = if local_addr.is_ipv4() { "IPv4" } else { "IPv6" };
+                            debug!(
+                                "No {} address for STUN server {} (local_addr {}), skipping",
+                                ip_ver, url, local_addr
+                            );
+                            continue;
+                        }
+                    };
+
+                    match Self::create_stun_client(*local_addr, stun_server_addr) {
                         Ok(stun_client) => {
                             self.gathering_clients.insert(FourTuple {
                                 local_addr: stun_client.local_addr(),
@@ -151,7 +180,7 @@ impl RTCIceGatherer {
                             self.stun_clients.push(stun_client);
                         }
                         Err(err) => {
-                            error!("Failed to gather stun client: {}", err);
+                            error!("Failed to create STUN client: {}", err);
                         }
                     }
                 }
@@ -161,60 +190,49 @@ impl RTCIceGatherer {
         Ok(())
     }
 
-    /// Gather a single srflx candidate from a STUN server
-    async fn gather_from_stun_server(
-        local_addr: SocketAddr,
-        stun_url: &str,
-    ) -> Result<StunClient, Error> {
-        // Resolve STUN server address (add default port 3478 if not specified)
-        let stun_server_addr_str = if stun_url.contains(':') {
-            stun_url
-                .strip_prefix("stun:")
-                .unwrap_or(stun_url)
-                .to_string()
+    /// Resolve a `stun:` URL to a list of socket addresses with a timeout.
+    ///
+    /// Returns all resolved addresses so the caller can pick the right IP
+    /// version per local address without re-resolving.
+    async fn resolve_stun_url(stun_url: &str) -> Result<Vec<SocketAddr>, Error> {
+        let host_part = stun_url.strip_prefix("stun:").unwrap_or(stun_url);
+
+        // Add default STUN port 3478 when no port is present.
+        // `stun:host:port` after stripping the prefix becomes `host:port` which
+        // already contains a colon. A bare `stun:hostname` becomes `hostname`
+        // with no colon, so we append `:3478`.
+        let addr_str = if host_part.contains(':') {
+            host_part.to_string()
         } else {
-            format!(
-                "{}:3478",
-                stun_url.strip_prefix("stun:").unwrap_or(stun_url)
-            )
+            format!("{}:3478", host_part)
         };
 
-        debug!("Resolving STUN server: {}", stun_server_addr_str);
+        debug!("Resolving STUN server: {}", addr_str);
 
-        // Resolve hostname to IP address with a timeout (#774)
-        const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-        let resolved_addrs = runtime::timeout(
-            DNS_RESOLVE_TIMEOUT,
-            runtime::resolve_host(&stun_server_addr_str),
-        )
-        .await
-        .map_err(|_| {
-            Error::Other(format!(
-                "DNS timed out after {:?} resolving STUN server: {}",
-                DNS_RESOLVE_TIMEOUT, stun_server_addr_str
-            ))
-        })??;
+        let resolved_addrs =
+            runtime::timeout(Self::DNS_RESOLVE_TIMEOUT, runtime::resolve_host(&addr_str))
+                .await
+                .map_err(|_| {
+                    Error::Other(format!(
+                        "DNS timed out after {:?} resolving STUN server: {}",
+                        Self::DNS_RESOLVE_TIMEOUT,
+                        addr_str
+                    ))
+                })??;
 
-        // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
-        let stun_server_addr: SocketAddr = resolved_addrs
-            .into_iter()
-            .find(|addr| addr.is_ipv4() == local_addr.is_ipv4())
-            .ok_or_else(|| {
-                let ip_version = if local_addr.is_ipv4() { "IPv4" } else { "IPv6" };
-                Error::Other(format!(
-                    "Failed to resolve STUN server hostname to {} address (local_addr is {})",
-                    ip_version, local_addr
-                ))
-            })?;
+        debug!("Resolved STUN server {} to {:?}", addr_str, resolved_addrs);
 
-        debug!(
-            "Resolved STUN server {} to {}",
-            stun_server_addr_str, stun_server_addr
-        );
+        Ok(resolved_addrs)
+    }
 
+    /// Create a STUN client for a single (local_addr, stun_server_addr) pair
+    /// and enqueue an initial binding request.
+    fn create_stun_client(
+        local_addr: SocketAddr,
+        stun_server_addr: SocketAddr,
+    ) -> Result<StunClient, Error> {
         debug!("STUN client bound to {}", local_addr);
 
-        // Create STUN client using the sans-I/O pattern
         let mut stun_client =
             StunClientBuilder::new().build(local_addr, stun_server_addr, TransportProtocol::UDP)?;
 
@@ -357,5 +375,72 @@ impl Protocol<TaggedBytesMut, (), ()> for RTCIceGatherer {
             stun_client.close()?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// resolve_stun_url with a known-good IP literal should succeed instantly.
+    #[test]
+    fn test_resolve_stun_url_ip_literal() {
+        crate::runtime::block_on(async {
+            let addrs = RTCIceGatherer::resolve_stun_url("stun:127.0.0.1:3478")
+                .await
+                .expect("IP literal should resolve");
+            assert!(!addrs.is_empty());
+            assert_eq!(addrs[0].ip().to_string(), "127.0.0.1");
+            assert_eq!(addrs[0].port(), 3478);
+        });
+    }
+
+    /// resolve_stun_url with a bare hostname (no port) should append :3478.
+    #[test]
+    fn test_resolve_stun_url_default_port() {
+        crate::runtime::block_on(async {
+            let addrs = RTCIceGatherer::resolve_stun_url("stun:127.0.0.1")
+                .await
+                .expect("bare IP should resolve with default port");
+            assert_eq!(addrs[0].port(), 3478);
+        });
+    }
+
+    /// resolve_stun_url with an unresolvable hostname should return an error
+    /// (timeout or DNS failure) rather than hanging.
+    #[test]
+    fn test_resolve_stun_url_unresolvable() {
+        crate::runtime::block_on(async {
+            let start = std::time::Instant::now();
+            let result =
+                RTCIceGatherer::resolve_stun_url("stun:this.will.never.resolve.invalid:3478").await;
+            let elapsed = start.elapsed();
+            assert!(result.is_err(), "unresolvable hostname should error");
+            // Must not hang longer than 2 x DNS_RESOLVE_TIMEOUT
+            assert!(
+                elapsed.as_secs() < 7,
+                "DNS resolution took {:?}, expected < 7s",
+                elapsed
+            );
+        });
+    }
+
+    /// create_stun_client should succeed with valid addresses.
+    #[test]
+    fn test_create_stun_client_valid() {
+        let local: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let remote: SocketAddr = "127.0.0.1:3478".parse().unwrap();
+        let client = RTCIceGatherer::create_stun_client(local, remote)
+            .expect("should create client with valid addrs");
+        assert_eq!(client.peer_addr(), remote);
+    }
+
+    /// DNS_RESOLVE_TIMEOUT should be 3 seconds.
+    #[test]
+    fn test_dns_resolve_timeout_value() {
+        assert_eq!(
+            RTCIceGatherer::DNS_RESOLVE_TIMEOUT,
+            std::time::Duration::from_secs(3)
+        );
     }
 }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod ice_gatherer;
 
 use log::error;
 use std::collections::{HashMap, HashSet};
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -23,6 +23,7 @@ use ice_gatherer::RTCIceGatherOptions;
 use ice_gatherer::RTCIceGatherer;
 
 use rtc::data_channel::{RTCDataChannelId, RTCDataChannelInit};
+use rtc::mdns::MulticastSocket;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::{RTCAnswerOptions, RTCOfferOptions};
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
@@ -36,6 +37,7 @@ use crate::media_stream::track_local::static_rtp::TrackLocalStaticRTP;
 use crate::media_stream::track_remote::TrackRemoteEvent;
 use crate::peer_connection::driver::PeerConnectionDriverEvent;
 use crate::rtp_transceiver::rtp_sender::RtpSenderImpl;
+pub use rtc::ice::mdns::MulticastDnsMode;
 pub use rtc::interceptor::{Interceptor, NoopInterceptor, Registry};
 use rtc::media_stream::MediaStreamTrackId;
 pub use rtc::peer_connection::{
@@ -117,6 +119,9 @@ where
     handler: Option<Arc<dyn PeerConnectionEventHandler>>,
     udp_addrs: Vec<A>,
     tcp_addrs: Vec<A>,
+    /// mDNS mode extracted from the SettingEngine so the async layer can
+    /// create the multicast socket before the driver starts.
+    mdns_mode: MulticastDnsMode,
 }
 
 impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
@@ -127,6 +132,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             handler: None,
             udp_addrs: vec![],
             tcp_addrs: vec![],
+            mdns_mode: MulticastDnsMode::Disabled,
         }
     }
 }
@@ -156,6 +162,25 @@ where
         self
     }
 
+    /// Set the mDNS mode for this peer connection.
+    ///
+    /// When using [`SettingEngine::set_multicast_dns_mode`], also call this method
+    /// so the async wrapper knows to create the multicast socket:
+    ///
+    /// ```no_run
+    /// # use webrtc::peer_connection::{PeerConnectionBuilder, MulticastDnsMode, SettingEngine};
+    /// let mut se = SettingEngine::default();
+    /// se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    ///
+    /// let builder = PeerConnectionBuilder::new()
+    ///     .with_setting_engine(se)
+    ///     .with_mdns_mode(MulticastDnsMode::QueryAndGather);
+    /// ```
+    pub fn with_mdns_mode(mut self, mode: MulticastDnsMode) -> Self {
+        self.mdns_mode = mode;
+        self
+    }
+
     pub fn with_interceptor_registry<P>(
         self,
         interceptor_registry: Registry<P>,
@@ -169,6 +194,7 @@ where
             handler: self.handler,
             udp_addrs: self.udp_addrs,
             tcp_addrs: self.tcp_addrs,
+            mdns_mode: self.mdns_mode,
         }
     }
 
@@ -212,6 +238,7 @@ where
             runtime,
             self.handler
                 .ok_or_else(|| std::io::Error::other("no event handler found"))?,
+            self.mdns_mode,
             opts,
             self.udp_addrs,
             self.tcp_addrs,
@@ -359,6 +386,7 @@ where
         core: RTCPeerConnection<I>,
         runtime: Arc<dyn Runtime>,
         handler: Arc<dyn PeerConnectionEventHandler>,
+        mdns_mode: MulticastDnsMode,
         opts: RTCIceGatherOptions,
         udp_addrs: Vec<A>,
         _tcp_addrs: Vec<A>,
@@ -375,6 +403,33 @@ where
                 .is_none()
             {
                 local_addrs.push(local_addr);
+            }
+        }
+
+        // If mDNS is enabled, create the multicast socket and add it to the socket map.
+        // Incoming mDNS packets will be routed through the normal handle_read path to the
+        // peer connection core; outgoing mDNS packets from poll_write (port 5353) will be
+        // sent via this socket by the driver's handle_write lookup.
+        if mdns_mode != MulticastDnsMode::Disabled {
+            match MulticastSocket::new().into_std() {
+                Ok(std_sock) => {
+                    let bound_addr = std_sock.local_addr()?;
+                    let async_sock = runtime.wrap_udp_socket(std_sock)?;
+                    // Always key the mDNS socket as 0.0.0.0:MDNS_PORT regardless of
+                    // the OS-assigned bound address (Linux binds 224.0.0.251, others
+                    // bind 0.0.0.0). The mDNS proto emits query packets with
+                    // local_addr = 0.0.0.0:5353; handle_write falls back to this key
+                    // for response packets that carry a specific local_ip.
+                    let mdns_key = SocketAddr::new(
+                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                        rtc::mdns::MDNS_PORT,
+                    );
+                    async_udp_sockets.insert(mdns_key, async_sock);
+                    log::debug!("mDNS multicast socket bound to {} (keyed as {})", bound_addr, mdns_key);
+                }
+                Err(e) => {
+                    log::warn!("Failed to create mDNS multicast socket: {} — mDNS disabled", e);
+                }
             }
         }
 

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -115,12 +115,17 @@ where
     I: Interceptor,
 {
     builder: RTCPeerConnectionBuilder<I>,
+    /// Held separately so [`with_mdns_mode`] can configure both the async
+    /// layer and the sans-IO core in one call.  Applied to the inner builder
+    /// in [`build()`].
+    setting_engine: SettingEngine,
     runtime: Option<Arc<dyn Runtime>>,
     handler: Option<Arc<dyn PeerConnectionEventHandler>>,
     udp_addrs: Vec<A>,
     tcp_addrs: Vec<A>,
-    /// mDNS mode extracted from the SettingEngine so the async layer can
-    /// create the multicast socket before the driver starts.
+    /// mDNS mode for the async layer (multicast socket creation).
+    /// Kept in sync with `setting_engine.multicast_dns.mode` by
+    /// [`with_mdns_mode`].
     mdns_mode: MulticastDnsMode,
 }
 
@@ -128,6 +133,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
     fn default() -> Self {
         Self {
             builder: RTCPeerConnectionBuilder::new(),
+            setting_engine: SettingEngine::default(),
             runtime: None,
             handler: None,
             udp_addrs: vec![],
@@ -158,19 +164,23 @@ where
     }
 
     pub fn with_setting_engine(mut self, setting_engine: SettingEngine) -> Self {
-        self.builder = self.builder.with_setting_engine(setting_engine);
+        self.setting_engine = setting_engine;
         self
     }
 
-    /// Set the mDNS mode for this peer connection.
+    /// Set the mDNS mode for both the async wrapper and the sans-IO core.
     ///
-    /// When using [`SettingEngine::set_multicast_dns_mode`], also call this method
-    /// so the async wrapper knows to create the multicast socket:
+    /// This creates the multicast socket in the async layer *and* configures
+    /// the sans-IO core's ICE agent to advertise/resolve `.local` candidates.
+    ///
+    /// **Note:** if you also need to set a custom local name, IP, or timeout,
+    /// call [`with_setting_engine`] *before* this method so the mode set here
+    /// takes precedence.
     ///
     /// ```no_run
     /// # use webrtc::peer_connection::{PeerConnectionBuilder, MulticastDnsMode, SettingEngine};
     /// let mut se = SettingEngine::default();
-    /// se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    /// se.set_multicast_dns_local_name("my-peer.local".to_string());
     ///
     /// let builder: PeerConnectionBuilder<String> = PeerConnectionBuilder::new()
     ///     .with_setting_engine(se)
@@ -178,6 +188,7 @@ where
     /// ```
     pub fn with_mdns_mode(mut self, mode: MulticastDnsMode) -> Self {
         self.mdns_mode = mode;
+        self.setting_engine.set_multicast_dns_mode(mode);
         self
     }
 
@@ -190,6 +201,7 @@ where
     {
         PeerConnectionBuilder {
             builder: self.builder.with_interceptor_registry(interceptor_registry),
+            setting_engine: self.setting_engine,
             runtime: self.runtime,
             handler: self.handler,
             udp_addrs: self.udp_addrs,
@@ -225,7 +237,10 @@ where
             default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?
         };
 
-        let core = self.builder.build()?;
+        let core = self
+            .builder
+            .with_setting_engine(self.setting_engine)
+            .build()?;
         let configuration = core.get_configuration();
 
         let opts = RTCIceGatherOptions {
@@ -411,10 +426,12 @@ where
         // peer connection core; outgoing mDNS packets from poll_write (port 5353) will be
         // sent via this socket by the driver's handle_write lookup.
         if mdns_mode != MulticastDnsMode::Disabled {
-            match MulticastSocket::new().into_std() {
-                Ok(std_sock) => {
-                    let bound_addr = std_sock.local_addr()?;
-                    let async_sock = runtime.wrap_udp_socket(std_sock)?;
+            match MulticastSocket::new().into_std().and_then(|std_sock| {
+                let bound_addr = std_sock.local_addr()?;
+                let async_sock = runtime.wrap_udp_socket(std_sock)?;
+                Ok((bound_addr, async_sock))
+            }) {
+                Ok((bound_addr, async_sock)) => {
                     // Always key the mDNS socket as 0.0.0.0:MDNS_PORT regardless of
                     // the OS-assigned bound address (Linux binds 224.0.0.251, others
                     // bind 0.0.0.0). The mDNS proto emits query packets with

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -172,7 +172,7 @@ where
     /// let mut se = SettingEngine::default();
     /// se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
     ///
-    /// let builder = PeerConnectionBuilder::new()
+    /// let builder: PeerConnectionBuilder<String> = PeerConnectionBuilder::new()
     ///     .with_setting_engine(se)
     ///     .with_mdns_mode(MulticastDnsMode::QueryAndGather);
     /// ```
@@ -420,15 +420,36 @@ where
                     // bind 0.0.0.0). The mDNS proto emits query packets with
                     // local_addr = 0.0.0.0:5353; handle_write falls back to this key
                     // for response packets that carry a specific local_ip.
-                    let mdns_key = SocketAddr::new(
-                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        rtc::mdns::MDNS_PORT,
-                    );
-                    async_udp_sockets.insert(mdns_key, async_sock);
-                    log::debug!("mDNS multicast socket bound to {} (keyed as {})", bound_addr, mdns_key);
+                    let mdns_key =
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), rtc::mdns::MDNS_PORT);
+                    match async_udp_sockets.entry(mdns_key) {
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(async_sock);
+                            log::debug!(
+                                "mDNS multicast socket bound to {} (keyed as {})",
+                                bound_addr,
+                                mdns_key
+                            );
+                        }
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            log::warn!(
+                                "mDNS multicast socket bound to {} was not inserted because \
+                                 socket key {} is already occupied; keeping existing socket",
+                                bound_addr,
+                                mdns_key
+                            );
+                        }
+                    }
                 }
                 Err(e) => {
-                    log::warn!("Failed to create mDNS multicast socket: {} — mDNS disabled", e);
+                    // Gracefully degrade: mDNS socket creation can fail in
+                    // restricted environments (containers, missing multicast
+                    // routing, etc.).  The sans-IO core will still function
+                    // but .local candidates won't be advertised or resolved.
+                    log::warn!(
+                        "Failed to create mDNS multicast socket: {} — mDNS disabled",
+                        e
+                    );
                 }
             }
         }

--- a/tests/ice_test.rs
+++ b/tests/ice_test.rs
@@ -2,6 +2,7 @@
 
 use rtc::peer_connection::transport::RTCIceCandidate;
 use std::sync::Arc;
+use std::time::Instant;
 use webrtc::peer_connection::*;
 use webrtc::peer_connection::{
     MediaEngine, RTCConfigurationBuilder, RTCIceCandidateInit, RTCIceCandidateType,
@@ -326,5 +327,163 @@ fn test_stun_gathering_with_google_stun() {
         );
 
         println!("✅ STUN candidate gathering successful! Got both host and srflx candidates.");
+    });
+}
+
+/// Verify that an unresolvable STUN hostname does not hang gathering
+/// indefinitely -- it should complete (with only host candidates) within
+/// roughly the DNS_RESOLVE_TIMEOUT (3 s) rather than blocking forever.
+#[test]
+fn test_unresolvable_stun_hostname_completes_within_timeout() {
+    block_on(async {
+        env_logger::builder()
+            .filter_level(log::LevelFilter::Trace)
+            .try_init()
+            .ok();
+
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("Failed to register codecs");
+
+        // Use a hostname guaranteed not to resolve
+        let ice_servers = vec![RTCIceServer {
+            urls: vec!["stun:this.hostname.will.never.resolve.invalid:3478".to_string()],
+            username: String::new(),
+            credential: String::new(),
+        }];
+
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(ice_servers)
+            .build();
+
+        let candidates = Arc::new(Mutex::new(Vec::new()));
+        let (gathering_tx, mut gathering_rx) = channel(8);
+        let handler = Arc::new(CandidateTypeTracker {
+            candidates: candidates.clone(),
+            gathering_tx,
+        });
+
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(media_engine)
+            .with_handler(handler)
+            .with_udp_addrs(vec!["0.0.0.0:0"])
+            .build()
+            .await
+            .unwrap();
+
+        let _ = pc.create_data_channel("channel1", None).await.unwrap();
+
+        let start = Instant::now();
+
+        let offer = pc.create_offer(None).await.expect("Failed to create offer");
+        pc.set_local_description(offer)
+            .await
+            .expect("Failed to set local description");
+
+        // Wait for gathering to complete
+        let _ = gathering_rx.recv().await;
+        let elapsed = start.elapsed();
+
+        // Should finish well within 6 seconds (DNS timeout is 3 s; allow margin
+        // for CI slowness but reject anything that looks like it hung).
+        assert!(
+            elapsed.as_secs() < 6,
+            "Gathering with unresolvable STUN host took {:?}, expected < 6s",
+            elapsed
+        );
+
+        // Should still have host candidates even though STUN failed
+        let gathered: Vec<RTCIceCandidateType> = candidates.lock().await.clone();
+        let has_host = gathered.iter().any(|t| *t == RTCIceCandidateType::Host);
+        assert!(
+            has_host,
+            "Should still have host candidates despite STUN failure"
+        );
+
+        // Should NOT have srflx since the STUN server was unreachable
+        let has_srflx = gathered.iter().any(|t| *t == RTCIceCandidateType::Srflx);
+        assert!(
+            !has_srflx,
+            "Should not have srflx candidates with unresolvable STUN server"
+        );
+
+        println!(
+            "Gathering with unresolvable STUN host completed in {:?} with {} host candidates",
+            elapsed,
+            gathered.len()
+        );
+    });
+}
+
+/// Verify that DNS resolution happens once per URL, not once per local
+/// address, so N local addresses with an unresolvable hostname still
+/// complete in ~3 s (one timeout) rather than N x 3 s.
+#[test]
+fn test_unresolvable_stun_multiple_local_addrs_single_timeout() {
+    block_on(async {
+        env_logger::builder()
+            .filter_level(log::LevelFilter::Trace)
+            .try_init()
+            .ok();
+
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("Failed to register codecs");
+
+        let ice_servers = vec![RTCIceServer {
+            urls: vec!["stun:this.hostname.will.never.resolve.invalid:3478".to_string()],
+            username: String::new(),
+            credential: String::new(),
+        }];
+
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(ice_servers)
+            .build();
+
+        let candidates = Arc::new(Mutex::new(Vec::new()));
+        let (gathering_tx, mut gathering_rx) = channel(8);
+        let handler = Arc::new(CandidateTypeTracker {
+            candidates: candidates.clone(),
+            gathering_tx,
+        });
+
+        // Bind to multiple local addresses to expose the N x timeout bug
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(media_engine)
+            .with_handler(handler)
+            .with_udp_addrs(vec!["0.0.0.0:0", "127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        let _ = pc.create_data_channel("channel1", None).await.unwrap();
+
+        let start = Instant::now();
+
+        let offer = pc.create_offer(None).await.expect("Failed to create offer");
+        pc.set_local_description(offer)
+            .await
+            .expect("Failed to set local description");
+
+        let _ = gathering_rx.recv().await;
+        let elapsed = start.elapsed();
+
+        // With the fix, DNS is resolved once per URL, so even with 2 local
+        // addresses the timeout should be ~3 s, not ~6 s.
+        assert!(
+            elapsed.as_secs() < 6,
+            "Gathering with 2 local addrs and unresolvable STUN host took {:?}; \
+             expected < 6s (single DNS timeout, not N x timeout)",
+            elapsed
+        );
+
+        println!(
+            "Multiple local addrs + unresolvable STUN completed in {:?}",
+            elapsed
+        );
     });
 }

--- a/tests/mdns_test.rs
+++ b/tests/mdns_test.rs
@@ -1,0 +1,126 @@
+//! Integration tests for mDNS multicast socket setup and builder API
+
+use std::sync::Arc;
+use webrtc::peer_connection::RTCConfigurationBuilder;
+use webrtc::peer_connection::*;
+use webrtc::runtime::block_on;
+
+#[derive(Clone)]
+struct NoopHandler;
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for NoopHandler {}
+
+/// with_mdns_mode(Disabled) should NOT create a multicast socket; the peer
+/// connection should build and close without error.
+#[test]
+fn test_mdns_disabled_builds_without_multicast_socket() {
+    block_on(async {
+        let config = RTCConfigurationBuilder::new().build();
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_handler(Arc::new(NoopHandler))
+            .with_mdns_mode(MulticastDnsMode::Disabled)
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        pc.close().await.expect("close should succeed");
+    });
+}
+
+/// with_mdns_mode(QueryAndGather) should attempt to create the multicast socket.
+/// On environments where multicast is available this succeeds; on restricted
+/// environments it degrades gracefully (warn + continue).  Either way the peer
+/// connection should build without error.
+#[test]
+fn test_mdns_query_and_gather_builds_gracefully() {
+    block_on(async {
+        let config = RTCConfigurationBuilder::new().build();
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_handler(Arc::new(NoopHandler))
+            .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        // Should still be able to create offers etc.
+        let offer = pc.create_offer(None).await;
+        assert!(offer.is_ok(), "create_offer should work with mDNS enabled");
+
+        pc.close().await.expect("close should succeed");
+    });
+}
+
+/// with_mdns_mode should also configure the sans-IO core so that callers
+/// don't have to set both with_setting_engine().set_multicast_dns_mode() AND
+/// with_mdns_mode() separately.  We verify that setting only with_mdns_mode
+/// is sufficient for the peer connection to build.
+#[test]
+fn test_mdns_mode_syncs_to_setting_engine() {
+    block_on(async {
+        // Only call with_mdns_mode (not with_setting_engine.set_multicast_dns_mode).
+        // The builder should propagate the mode to the SettingEngine automatically.
+        let config = RTCConfigurationBuilder::new().build();
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_handler(Arc::new(NoopHandler))
+            .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        pc.close().await.expect("close should succeed");
+    });
+}
+
+/// with_setting_engine() followed by with_mdns_mode() should work: the mDNS
+/// mode set via with_mdns_mode takes effect on both the async layer and the
+/// setting engine.
+#[test]
+fn test_mdns_mode_with_custom_setting_engine() {
+    block_on(async {
+        let mut se = SettingEngine::default();
+        se.set_multicast_dns_local_name("test-peer.local".to_string());
+
+        let config = RTCConfigurationBuilder::new().build();
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_setting_engine(se)
+            .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+            .with_handler(Arc::new(NoopHandler))
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        pc.close().await.expect("close should succeed");
+    });
+}
+
+/// The default builder (no with_mdns_mode call) should have mDNS disabled,
+/// matching the SettingEngine default.
+#[test]
+fn test_default_builder_has_mdns_disabled() {
+    block_on(async {
+        let config = RTCConfigurationBuilder::new().build();
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_handler(Arc::new(NoopHandler))
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        // Default behavior: no multicast socket created, no mDNS.
+        // Should behave identically to existing code.
+        let offer = pc.create_offer(None).await;
+        assert!(offer.is_ok());
+
+        pc.close().await.expect("close should succeed");
+    });
+}


### PR DESCRIPTION
## Summary

- `src/peer_connection/mod.rs`: create mDNS multicast socket (`MulticastSocket`) when `mdns_mode != Disabled` and insert it into the driver's socket map under the fixed key `0.0.0.0:5353`. On Linux the socket physically binds to `224.0.0.251:5353`; keying it as `0.0.0.0:5353` matches what `rtc-mdns` uses as `local_addr` for all outgoing query packets. Uses the `Entry` API to avoid silently overwriting an existing socket.
- `src/peer_connection/driver.rs`: add a port-5353 fallback in `handle_write` so mDNS *answer* packets (which carry `local_addr = actual_local_ip:5353` in their `TransportContext`) also route to the multicast socket keyed at `0.0.0.0:5353`.
- `src/peer_connection/mod.rs` (builder): add `with_mdns_mode()` builder method that sets the mode on both the async wrapper (multicast socket creation) and the sans-IO core (`SettingEngine`). Socket creation failure is handled gracefully (warn + disable mDNS) for restricted environments.
- `examples/mdns-local-peers/mdns-local-peers.rs`: example showing two peers using mDNS for privacy-preserving `.local` ICE candidate resolution. SDP exchange still happens via the normal in-process signaling flow.

## Background

mDNS (RFC 6762) lets WebRTC peers on the same LAN resolve `.local` ICE candidates without exposing raw IP addresses. The `rtc` sans-IO core already has full mDNS support (`rtc-mdns`); this PR wires the async runtime layer to that support by:
1. Creating the multicast UDP socket (`224.0.0.251:5353`) alongside the normal ICE sockets.
2. Routing incoming mDNS packets from the socket through the existing `handle_read` path.
3. Routing outgoing mDNS packets from `poll_write` back to the multicast socket via the `0.0.0.0:5353` key (with a port-5353 fallback for response packets).

## Test plan

- [x] `examples/mdns-local-peers` compiles and runs
- [x] `MulticastDnsMode::Disabled` (default) leaves behaviour unchanged — no multicast socket is created
- [x] Unit tests for port-5353 routing fallback (direct match, fallback, non-5353, precedence, IPv6 exclusion)
- [x] Integration tests for builder mDNS mode (disabled, enabled, sync with SettingEngine, custom SE, default)
- [ ] Two peers on the same LAN can complete ICE with `MulticastDnsMode::QueryAndGather` without STUN