### PR TITLE
fix(driver): track TCP task handles and abort on shutdown

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rtc"]
 	path = rtc
-	url = https://github.com/webrtc-rs/rtc
+	url = https://github.com/Brainwires/webrtc-rs-rtc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,8 @@ bench = false
 name = "swap-tracks"
 path = "examples/swap-tracks/swap-tracks.rs"
 bench = false
+
+[[example]]
+name = "data-channel-with-video"
+path = "examples/data-channel-with-video/data-channel-with-video.rs"
+bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,8 @@ bench = false
 name = "swap-tracks"
 path = "examples/swap-tracks/swap-tracks.rs"
 bench = false
+
+[[example]]
+name = "mdns-local-peers"
+path = "examples/mdns-local-peers/mdns-local-peers.rs"
+bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ runtime-smol = ["dep:smol", "dep:async-broadcast"]
 
 [dependencies]
 rtc = { version = "0.20.0-alpha.1", path = "rtc/rtc" }
+rtc-shared = { version = "0.20.0-alpha.1", path = "rtc/rtc-shared", package = "rtc-shared" }
 
 bytes = "1.11.1"
 async-trait = "0.1.89"
@@ -25,7 +26,7 @@ log = "0.4.29"
 futures = "0.3.31"
 
 # Async runtimes (all optional)
-tokio = { version = "1.49.0", features = ["net", "time", "sync", "rt", "rt-multi-thread"], optional = true }
+tokio = { version = "1.49.0", features = ["net", "time", "sync", "rt", "rt-multi-thread", "io-util"], optional = true }
 smol = { version = "2.0.2", optional = true }
 async-broadcast = { version = "0.7", optional = true }
 
@@ -144,4 +145,9 @@ bench = false
 [[example]]
 name = "swap-tracks"
 path = "examples/swap-tracks/swap-tracks.rs"
+bench = false
+
+[[example]]
+name = "ice-tcp"
+path = "examples/ice-tcp/ice-tcp.rs"
 bench = false

--- a/examples/data-channel-with-video/data-channel-with-video.rs
+++ b/examples/data-channel-with-video/data-channel-with-video.rs
@@ -1,0 +1,251 @@
+//! DataChannel + Video transceiver on the same PeerConnection
+//!
+//! Demonstrates that a single [`RTCPeerConnection`] can simultaneously host:
+//!
+//! - An **RTP video transceiver** (`m=video` in SDP)
+//! - A **data channel** (`m=application` / SCTP in SDP)
+//!
+//! ## Key requirement
+//!
+//! You **must** call [`MediaEngine::register_default_codecs`] (or register at
+//! least one video codec manually) before creating an offer.  Without a codec
+//! registration the SDP generator has no payload types to advertise and emits a
+//! rejected `m=video 0 …` line, which can make it look as if mixing a data
+//! channel with a video transceiver is broken — it is not.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo run --example data-channel-with-video
+//! ```
+//!
+//! Both peers run in the same process.  The offerer adds a `Recvonly` video
+//! transceiver and a data channel; the answerer mirrors this.  After ICE+DTLS
+//! negotiate, the offerer sends a text message over the data channel and the
+//! answerer prints it.  No actual video RTP is sent.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::RTCRtpTransceiverInit;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::{
+    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "Hello from data channel (alongside video)!";
+
+// ── Offerer handler ────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Offerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+// ── Answerer handler ───────────────────────────────────────────────────────────
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Answerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        eprintln!("Answerer: received data channel '{}'", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => eprintln!("Answerer: data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        eprintln!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Build a MediaEngine with all default codecs registered.
+///
+/// This is the critical step that ensures video m-lines in the SDP have valid
+/// payload types.  Omitting it causes `m=video 0 …` (rejected) to appear in
+/// the offer, which has nothing to do with mixing data channels and video.
+fn make_media_engine() -> MediaEngine {
+    let mut me = MediaEngine::default();
+    me.register_default_codecs()
+        .expect("register_default_codecs failed");
+    me
+}
+
+fn recvonly_init() -> Option<RTCRtpTransceiverInit> {
+    Some(RTCRtpTransceiverInit {
+        direction: RTCRtpTransceiverDirection::Recvonly,
+        send_encodings: vec![],
+        streams: vec![],
+    })
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fn main() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    // ── Offerer: video transceiver + data channel ──────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine()) // <-- required for valid m=video
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    offerer_pc
+        .add_transceiver_from_kind(RtpCodecKind::Video, recvonly_init())
+        .await?;
+    eprintln!("Offerer: added video transceiver (recvonly)");
+
+    let offerer_dc = offerer_pc.create_data_channel("chat", None).await?;
+    eprintln!("Offerer: created data channel");
+
+    {
+        let dc = offerer_dc.clone();
+        let open_tx = offerer_dc_open_tx;
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                if let DataChannelEvent::OnOpen = event {
+                    eprintln!("Offerer: data channel opened");
+                    open_tx.try_send(()).ok();
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    eprintln!("Offerer: SDP offer contains m=video: {}", offer.sdp.contains("m=video"));
+    eprintln!("Offerer: SDP offer contains m=application: {}", offer.sdp.contains("m=application"));
+
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
+    eprintln!("Offerer: ICE gathering complete");
+
+    // ── Answerer: mirror the offerer's configuration ───────────────────────────
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine()) // <-- required on answerer too
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    eprintln!("Answerer: SDP answer contains m=video: {}", answer.sdp.contains("m=video"));
+    eprintln!("Answerer: SDP answer contains m=application: {}", answer.sdp.contains("m=application"));
+
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
+    eprintln!("Answerer: ICE gathering complete");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for connection ────────────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for offerer to connect"))?;
+    eprintln!("Offerer: connected!");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for answerer to connect"))?;
+    eprintln!("Answerer: connected!");
+
+    // ── Send message over the data channel ─────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for data channel to open"))?;
+
+    eprintln!("Offerer: sending '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for message"))?
+        .ok_or_else(|| anyhow::anyhow!("Channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE);
+    eprintln!("✅ Message received: '{}'", received);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    eprintln!("✅ data-channel-with-video example completed");
+    Ok(())
+}

--- a/examples/ice-tcp/ice-tcp.rs
+++ b/examples/ice-tcp/ice-tcp.rs
@@ -1,0 +1,214 @@
+//! ICE over TCP (RFC 6544) example
+//!
+//! Demonstrates two in-process peers connected exclusively over TCP using the
+//! active/passive ICE-TCP mechanism defined in RFC 6544.
+//!
+//! - **Answerer** — binds a TCP passive listener (`with_tcp_addrs`); emits a
+//!   `tcptype passive` host candidate.
+//! - **Offerer** — no TCP listener; the ICE agent emits a `tcptype active`
+//!   candidate with port 9 as placeholder.  When the ICE engine selects the
+//!   pair, the async wrapper dials out to the answerer's TCP address on the
+//!   first outbound packet.
+//!
+//! All STUN / DTLS / SCTP traffic is framed with the 2-byte RFC 4571 length
+//! prefix by the driver automatically.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo run --example ice-tcp
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::{
+    PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "Hello over TCP ICE!";
+
+// ── Offerer handler ────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Offerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+// ── Answerer handler ───────────────────────────────────────────────────────────
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Answerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        eprintln!("Answerer: received data channel '{}'", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => eprintln!("Answerer: data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        eprintln!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fn main() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    // ── Answerer: TCP passive listener ─────────────────────────────────────────
+    // Bind a TCP listener on a random port — the driver emits this as a
+    // `tcptype passive` host candidate.
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_tcp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+    eprintln!("Answerer: TCP passive listener bound");
+
+    // ── Offerer: no sockets configured — pure active TCP ──────────────────────
+    // The driver emits a `tcptype active` candidate with port 9 (placeholder).
+    // When ICE selects the pair, the wrapper dials out to the answerer's TCP addr.
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_tcp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let offerer_dc = offerer_pc.create_data_channel("chat", None).await?;
+    eprintln!("Offerer: created data channel");
+
+    {
+        let dc = offerer_dc.clone();
+        let open_tx = offerer_dc_open_tx;
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                if let DataChannelEvent::OnOpen = event {
+                    eprintln!("Offerer: data channel opened");
+                    open_tx.try_send(()).ok();
+                }
+            }
+        }));
+    }
+
+    // ── Signaling (in-process) ─────────────────────────────────────────────────
+    let offer = offerer_pc.create_offer(None).await?;
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
+    eprintln!("Offerer: ICE gathering complete");
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
+    eprintln!("Answerer: ICE gathering complete");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for connection ────────────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for offerer to connect"))?;
+    eprintln!("Offerer: connected!");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for answerer to connect"))?;
+    eprintln!("Answerer: connected!");
+
+    // ── Send message ───────────────────────────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for data channel to open"))?;
+
+    eprintln!("Offerer: sending '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for message"))?
+        .ok_or_else(|| anyhow::anyhow!("Channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE);
+    eprintln!("✅ Message received: '{}'", received);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    eprintln!("✅ ice-tcp example completed");
+    Ok(())
+}

--- a/examples/mdns-local-peers/mdns-local-peers.rs
+++ b/examples/mdns-local-peers/mdns-local-peers.rs
@@ -1,0 +1,230 @@
+//! mDNS peer discovery example
+//!
+//! Demonstrates two in-process WebRTC peers communicating with mDNS enabled.
+//! Both peers use `MulticastDnsMode::QueryAndGather` so that:
+//!
+//! - **QueryAndGather**: Local candidates advertise a `.local` mDNS hostname
+//!   instead of exposing the raw IP address (privacy-preserving).
+//! - Remote `.local` candidates are resolved via multicast DNS on the local
+//!   network — no STUN server is needed.
+//!
+//! ## How to run
+//!
+//! ```sh
+//! cargo run --example mdns-local-peers
+//! ```
+//!
+//! Both peers will run in the same process and exchange a data channel message
+//! to verify end-to-end connectivity.
+//!
+//! ## Notes
+//!
+//! - mDNS requires access to the `224.0.0.251:5353` multicast group.  Some
+//!   environments (CI, containers without multicast routing) may prevent the
+//!   socket from joining the group; the example logs a warning and falls back
+//!   gracefully.
+//! - For true cross-host mDNS peer discovery you would run one peer on each
+//!   host and exchange their SDP offers/answers via a signaling channel.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::{
+    MulticastDnsMode, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCIceGatheringState, RTCPeerConnectionState, SettingEngine,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "Hello via mDNS-enabled peer connection!";
+
+// ── Offerer handler ────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Offerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+// ── Answerer handler ───────────────────────────────────────────────────────────
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        eprintln!("Answerer connection state: {}", state);
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        eprintln!("Answerer: received data channel '{}'", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => eprintln!("Answerer: data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        eprintln!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fn main() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> anyhow::Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    // Configure mDNS: QueryAndGather means local candidates use .local
+    // hostnames AND remote .local candidates are resolved via multicast DNS.
+    let mut setting_engine = SettingEngine::default();
+    setting_engine.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    setting_engine.set_multicast_dns_local_name("offerer-webrtc.local".to_string());
+
+    // ── Offerer ────────────────────────────────────────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_setting_engine(setting_engine.clone())
+        .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let offerer_dc = offerer_pc.create_data_channel("chat", None).await?;
+    eprintln!("Offerer: created data channel");
+
+    // Track when the data channel opens
+    {
+        let dc = offerer_dc.clone();
+        let open_tx = offerer_dc_open_tx.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                if let DataChannelEvent::OnOpen = event {
+                    eprintln!("Offerer: data channel opened");
+                    open_tx.try_send(()).ok();
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc.local_description().await.expect("offerer SDP");
+    eprintln!("Offerer: ICE gathering complete");
+
+    // ── Answerer ───────────────────────────────────────────────────────────────
+    let mut answerer_se = SettingEngine::default();
+    answerer_se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    answerer_se.set_multicast_dns_local_name("answerer-webrtc.local".to_string());
+
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_setting_engine(answerer_se)
+        .with_mdns_mode(MulticastDnsMode::QueryAndGather)
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc.local_description().await.expect("answerer SDP");
+    eprintln!("Answerer: ICE gathering complete");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for connection ────────────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for offerer to connect"))?;
+    eprintln!("Offerer: connected!");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for answerer to connect"))?;
+    eprintln!("Answerer: connected!");
+
+    // ── Send message ───────────────────────────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for data channel to open"))?;
+
+    eprintln!("Offerer: sending '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for message"))?
+        .ok_or_else(|| anyhow::anyhow!("Channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE);
+    eprintln!("✅ Message received: '{}'", received);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    eprintln!("✅ mDNS-local-peers example completed");
+    Ok(())
+}

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -11,11 +11,11 @@ use crate::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
 use crate::peer_connection::PeerConnectionRef;
 use crate::rtp_transceiver::rtp_receiver::RtpReceiverImpl;
 use crate::rtp_transceiver::{RtpReceiver, RtpTransceiverImpl};
-use crate::runtime::{AsyncUdpSocket, Receiver, channel};
+use crate::runtime::{AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, Receiver, Runtime, Sender, channel};
 use bytes::BytesMut;
-use futures::FutureExt; // For .fuse() in futures::select!
+use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
-use log::{error, trace};
+use log::{error, trace, warn};
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::media_stream::MediaStreamTrack;
 use rtc::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent, RTCTrackEvent};
@@ -27,6 +27,7 @@ use rtc::sansio::Protocol;
 use rtc::shared::error::{Error, Result};
 use rtc::shared::{TaggedBytesMut, TransportContext, TransportProtocol};
 use rtc::{rtcp, rtp};
+use rtc_shared::tcp_framing::{TcpFrameDecoder, frame_packet};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::net::SocketAddr;
@@ -55,6 +56,9 @@ pub(crate) enum PeerConnectionDriverEvent {
     Close,
 }
 
+/// Inbound TCP packet + connection info — sent from per-connection read tasks into the driver loop
+type TcpInbound = (SocketAddr, SocketAddr, BytesMut); // (local, peer, payload)
+
 /// The driver for a peer connection
 ///
 /// Runs the event loop following rtc's EventLoop pattern with select!
@@ -66,6 +70,16 @@ where
     /// ICE gatherer for managing ICE candidate gathering
     ice_gatherer: RTCIceGatherer,
     sockets: HashMap<SocketAddr, Arc<dyn AsyncUdpSocket>>,
+    /// TCP: per-connection write channels keyed by (local_addr, peer_addr)
+    tcp_write_txs: HashMap<(SocketAddr, SocketAddr), Sender<Vec<u8>>>,
+    /// TCP: inbound packet channel — all TCP read tasks send here
+    tcp_inbound_tx: Sender<TcpInbound>,
+    tcp_inbound_rx: Receiver<TcpInbound>,
+    /// TCP: new accepted connection channel — accept tasks send here
+    tcp_new_conn_tx: Sender<Arc<dyn AsyncTcpStream>>,
+    tcp_new_conn_rx: Receiver<Arc<dyn AsyncTcpStream>>,
+    /// Async runtime — needed to spawn per-connection tasks
+    runtime: Arc<dyn Runtime>,
 }
 
 impl<I> PeerConnectionDriver<I>
@@ -77,16 +91,102 @@ where
         inner: Arc<PeerConnectionRef<I>>,
         ice_gatherer: RTCIceGatherer,
         sockets: HashMap<SocketAddr, Arc<dyn AsyncUdpSocket>>,
+        tcp_listeners: Vec<Arc<dyn AsyncTcpListener>>,
+        runtime: Arc<dyn Runtime>,
     ) -> Result<Self> {
-        if sockets.is_empty() {
+        if sockets.is_empty() && tcp_listeners.is_empty() {
             return Err(Error::Other("no sockets available".to_owned()));
+        }
+
+        let (tcp_inbound_tx, tcp_inbound_rx) = channel::<TcpInbound>(256);
+        let (tcp_new_conn_tx, tcp_new_conn_rx) = channel::<Arc<dyn AsyncTcpStream>>(32);
+
+        // Spawn an accept loop for each passive TCP listener
+        for listener in tcp_listeners {
+            let new_conn_tx = tcp_new_conn_tx.clone();
+            runtime.spawn(Box::pin(async move {
+                loop {
+                    match listener.accept().await {
+                        Ok(stream) => {
+                            if new_conn_tx.try_send(stream).is_err() {
+                                break; // driver shut down
+                            }
+                        }
+                        Err(e) => {
+                            warn!("TCP accept error: {}", e);
+                            break;
+                        }
+                    }
+                }
+            }));
         }
 
         Ok(Self {
             inner,
             ice_gatherer,
             sockets,
+            tcp_write_txs: HashMap::new(),
+            tcp_inbound_tx,
+            tcp_inbound_rx,
+            tcp_new_conn_tx,
+            tcp_new_conn_rx,
+            runtime,
         })
+    }
+
+    /// Register a new TCP connection (accepted or dialed) and spawn its read task
+    fn register_tcp_connection(&mut self, stream: Arc<dyn AsyncTcpStream>) {
+        let local_addr = match stream.local_addr() {
+            Ok(a) => a,
+            Err(e) => { error!("TCP stream local_addr: {}", e); return; }
+        };
+        let peer_addr = match stream.peer_addr() {
+            Ok(a) => a,
+            Err(e) => { error!("TCP stream peer_addr: {}", e); return; }
+        };
+
+        let key = (local_addr, peer_addr);
+        if self.tcp_write_txs.contains_key(&key) {
+            return; // already registered
+        }
+
+        let (write_tx, mut write_rx) = channel::<Vec<u8>>(64);
+        self.tcp_write_txs.insert(key, write_tx);
+
+        // Read task: decode RFC 4571 frames and forward to driver
+        let read_stream = stream.clone();
+        let inbound_tx = self.tcp_inbound_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            let mut decoder = TcpFrameDecoder::new();
+            let mut buf = vec![0u8; 4096];
+            loop {
+                match read_stream.read(&mut buf).await {
+                    Ok(0) => break, // EOF
+                    Ok(n) => {
+                        decoder.extend_from_slice(&buf[..n]);
+                        while let Some(packet) = decoder.next_packet() {
+                            if inbound_tx.try_send((local_addr, peer_addr, BytesMut::from(packet.as_slice()))).is_err() {
+                                return;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        trace!("TCP read error ({}→{}): {}", local_addr, peer_addr, e);
+                        break;
+                    }
+                }
+            }
+        }));
+
+        // Write task: receive framed bytes and write to stream
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(data) = write_rx.recv().await {
+                if let Err(e) = stream.write_all(&data).await {
+                    trace!("TCP write error: {}", e);
+                    break;
+                }
+            }
+        }));
     }
 
     /// Run the driver event loop
@@ -221,7 +321,7 @@ where
                     }
                 }
 
-                // Incoming network packet from any socket
+                // Incoming network packet from any UDP socket
                 result = socket_recv_futures.next().fuse() => {
                     match result {
                         Some(Ok((n, local_addr, peer_addr, idx, buf))) => {
@@ -249,14 +349,40 @@ where
                         Some(Err(err)) => {
                             error!("Socket recv error: {}", err);
                             //TODO: better handling on socket recv error #777
-                            // On error, we lost the buffer, create a new one and restart this socket
-                            // This should be rare (only on actual socket errors)
-                            // For now, we return the error to stop the loop
                             return Err(err.into());
                         }
                         None => {
-                            // All socket futures completed (should never happen in normal operation)
-                            return Err(Error::Other("all socket futures completed".to_owned()));
+                            if socket_list.is_empty() {
+                                // TCP-only mode — this arm never fires, just keep looping
+                            } else {
+                                return Err(Error::Other("all socket futures completed".to_owned()));
+                            }
+                        }
+                    }
+                }
+
+                // New accepted TCP connection
+                stream = self.tcp_new_conn_rx.recv().fuse() => {
+                    if let Some(stream) = stream {
+                        self.register_tcp_connection(stream);
+                    }
+                }
+
+                // Decoded TCP frame from a read task
+                pkt = self.tcp_inbound_rx.recv().fuse() => {
+                    if let Some((local_addr, peer_addr, payload)) = pkt {
+                        trace!("TCP received {} bytes from {} to {}", payload.len(), peer_addr, local_addr);
+                        if let Err(err) = self.handle_read(TaggedBytesMut {
+                            now: Instant::now(),
+                            transport: TransportContext {
+                                local_addr,
+                                peer_addr,
+                                ecn: None,
+                                transport_protocol: TransportProtocol::TCP,
+                            },
+                            message: payload,
+                        }).await {
+                            error!("TCP handle_read error: {}", err);
                         }
                     }
                 }
@@ -264,20 +390,44 @@ where
         }
     }
 
-    async fn handle_write(&self, msg: TaggedBytesMut) {
-        if let Some(socket) = self.sockets.get(&msg.transport.local_addr) {
-            match socket.send_to(&msg.message, msg.transport.peer_addr).await {
-                Ok(n) => {
-                    trace!(
-                        "Sent {} bytes to {:?} from {:?}",
-                        n, msg.transport.peer_addr, msg.transport.local_addr
-                    );
+    async fn handle_write(&mut self, msg: TaggedBytesMut) {
+        match msg.transport.transport_protocol {
+            TransportProtocol::UDP => {
+                if let Some(socket) = self.sockets.get(&msg.transport.local_addr) {
+                    match socket.send_to(&msg.message, msg.transport.peer_addr).await {
+                        Ok(n) => {
+                            trace!(
+                                "Sent {} bytes to {:?} from {:?}",
+                                n, msg.transport.peer_addr, msg.transport.local_addr
+                            );
+                        }
+                        Err(e) => {
+                            error!(
+                                "Failed to send to {:?} from {:?}: {}",
+                                msg.transport.peer_addr, msg.transport.local_addr, e
+                            );
+                        }
+                    }
                 }
-                Err(e) => {
-                    error!(
-                        "Failed to send to {:?} from {:?}: {}",
-                        msg.transport.peer_addr, msg.transport.local_addr, e
-                    );
+            }
+            TransportProtocol::TCP => {
+                let key = (msg.transport.local_addr, msg.transport.peer_addr);
+                if !self.tcp_write_txs.contains_key(&key) {
+                    // Active TCP: dial out on first outbound packet
+                    let peer_addr = msg.transport.peer_addr;
+                    match self.runtime.connect_tcp(peer_addr).await {
+                        Ok(stream) => self.register_tcp_connection(stream),
+                        Err(e) => {
+                            error!("TCP connect to {} failed: {}", peer_addr, e);
+                            return;
+                        }
+                    }
+                }
+                if let Some(tx) = self.tcp_write_txs.get(&key) {
+                    let framed = frame_packet(&msg.message);
+                    if tx.try_send(framed).is_err() {
+                        self.tcp_write_txs.remove(&key);
+                    }
                 }
             }
         }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -11,7 +11,7 @@ use crate::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
 use crate::peer_connection::PeerConnectionRef;
 use crate::rtp_transceiver::rtp_receiver::RtpReceiverImpl;
 use crate::rtp_transceiver::{RtpReceiver, RtpTransceiverImpl};
-use crate::runtime::{AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, Receiver, Runtime, Sender, channel};
+use crate::runtime::{AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, JoinHandle, Receiver, Runtime, Sender, channel};
 use bytes::BytesMut;
 use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -80,6 +80,9 @@ where
     tcp_new_conn_rx: Receiver<Arc<dyn AsyncTcpStream>>,
     /// Async runtime — needed to spawn per-connection tasks
     runtime: Arc<dyn Runtime>,
+    /// Handles for all background TCP tasks (accept loops + per-connection read/write).
+    /// Stored so they can be aborted on clean shutdown rather than leaking.
+    tcp_task_handles: Vec<JoinHandle>,
 }
 
 impl<I> PeerConnectionDriver<I>
@@ -101,10 +104,11 @@ where
         let (tcp_inbound_tx, tcp_inbound_rx) = channel::<TcpInbound>(256);
         let (tcp_new_conn_tx, tcp_new_conn_rx) = channel::<Arc<dyn AsyncTcpStream>>(32);
 
-        // Spawn an accept loop for each passive TCP listener
+        // Spawn an accept loop for each passive TCP listener; store handles for clean shutdown.
+        let mut tcp_task_handles = Vec::new();
         for listener in tcp_listeners {
             let new_conn_tx = tcp_new_conn_tx.clone();
-            runtime.spawn(Box::pin(async move {
+            let handle = runtime.spawn(Box::pin(async move {
                 loop {
                     match listener.accept().await {
                         Ok(stream) => {
@@ -119,6 +123,7 @@ where
                     }
                 }
             }));
+            tcp_task_handles.push(handle);
         }
 
         Ok(Self {
@@ -131,6 +136,7 @@ where
             tcp_new_conn_tx,
             tcp_new_conn_rx,
             runtime,
+            tcp_task_handles,
         })
     }
 
@@ -156,7 +162,7 @@ where
         // Read task: decode RFC 4571 frames and forward to driver
         let read_stream = stream.clone();
         let inbound_tx = self.tcp_inbound_tx.clone();
-        self.runtime.spawn(Box::pin(async move {
+        let read_handle = self.runtime.spawn(Box::pin(async move {
             let mut decoder = TcpFrameDecoder::new();
             let mut buf = vec![0u8; 4096];
             loop {
@@ -177,9 +183,10 @@ where
                 }
             }
         }));
+        self.tcp_task_handles.push(read_handle);
 
         // Write task: receive framed bytes and write to stream
-        self.runtime.spawn(Box::pin(async move {
+        let write_handle = self.runtime.spawn(Box::pin(async move {
             while let Some(data) = write_rx.recv().await {
                 if let Err(e) = stream.write_all(&data).await {
                     trace!("TCP write error: {}", e);
@@ -187,6 +194,14 @@ where
                 }
             }
         }));
+        self.tcp_task_handles.push(write_handle);
+    }
+
+    /// Abort all background TCP tasks spawned by this driver.
+    fn abort_tcp_tasks(&mut self) {
+        for handle in self.tcp_task_handles.drain(..) {
+            handle.abort();
+        }
     }
 
     /// Run the driver event loop
@@ -196,6 +211,8 @@ where
         &mut self,
         mut driver_event_rx: Receiver<PeerConnectionDriverEvent>,
     ) -> Result<()> {
+        log::debug!("PeerConnectionDriver: event loop started");
+
         // Collect socket info into a vec for indexed access
         let socket_list: Vec<(SocketAddr, Arc<dyn AsyncUdpSocket>)> = self
             .sockets
@@ -316,6 +333,8 @@ where
                     if let Some(evt) = evt {
                         let is_closed = self.handle_driver_event(evt).await;
                         if is_closed {
+                            log::debug!("PeerConnectionDriver: clean shutdown");
+                            self.abort_tcp_tasks();
                             return Ok(());
                         }
                     }
@@ -349,12 +368,14 @@ where
                         Some(Err(err)) => {
                             error!("Socket recv error: {}", err);
                             //TODO: better handling on socket recv error #777
+                            self.abort_tcp_tasks();
                             return Err(err.into());
                         }
                         None => {
                             if socket_list.is_empty() {
                                 // TCP-only mode — this arm never fires, just keep looping
                             } else {
+                                self.abort_tcp_tasks();
                                 return Err(Error::Other("all socket futures completed".to_owned()));
                             }
                         }
@@ -426,6 +447,7 @@ where
                 if let Some(tx) = self.tcp_write_txs.get(&key) {
                     let framed = frame_packet(&msg.message);
                     if tx.try_send(framed).is_err() {
+                        warn!("TCP write channel full or closed for {}→{}; dropping connection", key.0, key.1);
                         self.tcp_write_txs.remove(&key);
                     }
                 }

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -6,6 +6,7 @@
 
 use crate::runtime;
 use rtc::ice::candidate::CandidateConfig;
+use rtc::ice::tcp_type::TcpType;
 use rtc::peer_connection::configuration::{RTCIceServer, RTCIceTransportPolicy};
 use rtc::peer_connection::transport::{
     CandidateHostConfig, CandidateServerReflexiveConfig, RTCIceCandidate, RTCIceCandidateInit,
@@ -48,6 +49,8 @@ pub enum RTCIceGathererEvent {
 /// This is a Sans-I/O configuration object that holds ICE servers and gathering state.
 pub(crate) struct RTCIceGatherer {
     local_addrs: Vec<SocketAddr>,
+    /// Addresses of bound TCP passive listeners (emitted as host TCP passive candidates)
+    tcp_local_addrs: Vec<SocketAddr>,
     ice_servers: Vec<RTCIceServer>,
     gather_policy: RTCIceTransportPolicy,
     state: RTCIceGatheringState,
@@ -61,9 +64,14 @@ pub(crate) struct RTCIceGatherer {
 
 impl RTCIceGatherer {
     /// Create a new ICE gatherer with ICE servers and gather policy
-    pub(crate) fn new(local_addrs: Vec<SocketAddr>, opts: RTCIceGatherOptions) -> Self {
+    pub(crate) fn new(
+        local_addrs: Vec<SocketAddr>,
+        tcp_local_addrs: Vec<SocketAddr>,
+        opts: RTCIceGatherOptions,
+    ) -> Self {
         Self {
             local_addrs,
+            tcp_local_addrs,
             ice_servers: opts.ice_servers,
             gather_policy: opts.ice_gather_policy,
             state: RTCIceGatheringState::New,
@@ -108,6 +116,7 @@ impl RTCIceGatherer {
     ///
     /// This is a pure function that creates host candidates without performing I/O.
     fn gather_host_candidates(&mut self) -> Result<(), Error> {
+        // UDP host candidates
         for local_addr in &self.local_addrs {
             let candidate = CandidateHostConfig {
                 base_config: CandidateConfig {
@@ -122,10 +131,29 @@ impl RTCIceGatherer {
             .new_candidate_host()?;
 
             let candidate_init = RTCIceCandidate::from(&candidate).to_json()?;
-
             self.events
                 .push_back(RTCIceGathererEvent::LocalIceCandidate(candidate_init));
         }
+
+        // TCP passive host candidates
+        for tcp_addr in &self.tcp_local_addrs {
+            let candidate = CandidateHostConfig {
+                base_config: CandidateConfig {
+                    network: "tcp".to_owned(),
+                    address: tcp_addr.ip().to_string(),
+                    port: tcp_addr.port(),
+                    component: 1,
+                    ..Default::default()
+                },
+                tcp_type: TcpType::Passive,
+            }
+            .new_candidate_host()?;
+
+            let candidate_init = RTCIceCandidate::from(&candidate).to_json()?;
+            self.events
+                .push_back(RTCIceGathererEvent::LocalIceCandidate(candidate_init));
+        }
+
         Ok(())
     }
 

--- a/src/peer_connection/ice_gatherer.rs
+++ b/src/peer_connection/ice_gatherer.rs
@@ -181,8 +181,19 @@ impl RTCIceGatherer {
 
         debug!("Resolving STUN server: {}", stun_server_addr_str);
 
-        // Resolve hostname to IP address using runtime-agnostic helper
-        let resolved_addrs = runtime::resolve_host(&stun_server_addr_str).await?;
+        // Resolve hostname to IP address with a 3-second timeout (#774)
+        let resolved_addrs = runtime::timeout(
+            std::time::Duration::from_secs(3),
+            runtime::resolve_host(&stun_server_addr_str),
+        )
+        .await
+        .map_err(|_| {
+            Error::Other(format!(
+                "DNS timeout resolving STUN server: {}",
+                stun_server_addr_str
+            ))
+        })?
+        .map_err(|e| Error::Other(e.to_string()))?;
 
         // Filter addresses to match the local_addr IP version (IPv4 or IPv6)
         let stun_server_addr: SocketAddr = resolved_addrs

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -23,6 +23,7 @@ use ice_gatherer::RTCIceGatherOptions;
 use ice_gatherer::RTCIceGatherer;
 
 use rtc::data_channel::{RTCDataChannelId, RTCDataChannelInit};
+use rtc::mdns::MulticastSocket;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::{RTCAnswerOptions, RTCOfferOptions};
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
@@ -36,6 +37,7 @@ use crate::media_stream::track_local::static_rtp::TrackLocalStaticRTP;
 use crate::media_stream::track_remote::TrackRemoteEvent;
 use crate::peer_connection::driver::PeerConnectionDriverEvent;
 use crate::rtp_transceiver::rtp_sender::RtpSenderImpl;
+pub use rtc::ice::mdns::MulticastDnsMode;
 pub use rtc::interceptor::{Interceptor, NoopInterceptor, Registry};
 use rtc::media_stream::MediaStreamTrackId;
 pub use rtc::peer_connection::{
@@ -117,6 +119,9 @@ where
     handler: Option<Arc<dyn PeerConnectionEventHandler>>,
     udp_addrs: Vec<A>,
     tcp_addrs: Vec<A>,
+    /// mDNS mode extracted from the SettingEngine so the async layer can
+    /// create the multicast socket before the driver starts.
+    mdns_mode: MulticastDnsMode,
 }
 
 impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
@@ -127,6 +132,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             handler: None,
             udp_addrs: vec![],
             tcp_addrs: vec![],
+            mdns_mode: MulticastDnsMode::Disabled,
         }
     }
 }
@@ -156,6 +162,25 @@ where
         self
     }
 
+    /// Set the mDNS mode for this peer connection.
+    ///
+    /// When using [`SettingEngine::set_multicast_dns_mode`], also call this method
+    /// so the async wrapper knows to create the multicast socket:
+    ///
+    /// ```no_run
+    /// # use webrtc::peer_connection::{PeerConnectionBuilder, MulticastDnsMode, SettingEngine};
+    /// let mut se = SettingEngine::default();
+    /// se.set_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+    ///
+    /// let builder = PeerConnectionBuilder::new()
+    ///     .with_setting_engine(se)
+    ///     .with_mdns_mode(MulticastDnsMode::QueryAndGather);
+    /// ```
+    pub fn with_mdns_mode(mut self, mode: MulticastDnsMode) -> Self {
+        self.mdns_mode = mode;
+        self
+    }
+
     pub fn with_interceptor_registry<P>(
         self,
         interceptor_registry: Registry<P>,
@@ -169,6 +194,7 @@ where
             handler: self.handler,
             udp_addrs: self.udp_addrs,
             tcp_addrs: self.tcp_addrs,
+            mdns_mode: self.mdns_mode,
         }
     }
 
@@ -212,6 +238,7 @@ where
             runtime,
             self.handler
                 .ok_or_else(|| std::io::Error::other("no event handler found"))?,
+            self.mdns_mode,
             opts,
             self.udp_addrs,
             self.tcp_addrs,
@@ -359,6 +386,7 @@ where
         core: RTCPeerConnection<I>,
         runtime: Arc<dyn Runtime>,
         handler: Arc<dyn PeerConnectionEventHandler>,
+        mdns_mode: MulticastDnsMode,
         opts: RTCIceGatherOptions,
         udp_addrs: Vec<A>,
         _tcp_addrs: Vec<A>,
@@ -375,6 +403,24 @@ where
                 .is_none()
             {
                 local_addrs.push(local_addr);
+            }
+        }
+
+        // If mDNS is enabled, create the multicast socket and add it to the socket map.
+        // Incoming mDNS packets will be routed through the normal handle_read path to the
+        // peer connection core; outgoing mDNS packets from poll_write (port 5353) will be
+        // sent via this socket by the driver's handle_write lookup.
+        if mdns_mode != MulticastDnsMode::Disabled {
+            match MulticastSocket::new().into_std() {
+                Ok(std_sock) => {
+                    let local_addr = std_sock.local_addr()?;
+                    let async_sock = runtime.wrap_udp_socket(std_sock)?;
+                    async_udp_sockets.insert(local_addr, async_sock);
+                    log::debug!("mDNS multicast socket bound to {}", local_addr);
+                }
+                Err(e) => {
+                    log::warn!("Failed to create mDNS multicast socket: {} — mDNS disabled", e);
+                }
             }
         }
 

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use crate::data_channel::{DataChannel, DataChannelEvent, DataChannelImpl};
 use crate::media_stream::{track_local::TrackLocal, track_remote::TrackRemote};
 use crate::rtp_transceiver::{RtpReceiver, RtpSender, RtpTransceiver, RtpTransceiverImpl};
-use crate::runtime::{JoinHandle, Runtime, default_runtime};
+use crate::runtime::{AsyncTcpListener, JoinHandle, Runtime, default_runtime};
 use crate::runtime::{Mutex, Sender, channel};
 
 use driver::{
@@ -361,7 +361,7 @@ where
         handler: Arc<dyn PeerConnectionEventHandler>,
         opts: RTCIceGatherOptions,
         udp_addrs: Vec<A>,
-        _tcp_addrs: Vec<A>,
+        tcp_addrs: Vec<A>,
     ) -> Result<Self> {
         let mut local_addrs = vec![];
         let mut async_udp_sockets = HashMap::new();
@@ -376,6 +376,17 @@ where
             {
                 local_addrs.push(local_addr);
             }
+        }
+
+        // Bind TCP passive listeners
+        let mut tcp_local_addrs = vec![];
+        let mut tcp_listeners: Vec<Arc<dyn AsyncTcpListener>> = vec![];
+        for addr in tcp_addrs {
+            let socket = std::net::TcpListener::bind(addr)?;
+            let listener = runtime.wrap_tcp_listener(socket)?;
+            let local_addr = listener.local_addr()?;
+            tcp_local_addrs.push(local_addr);
+            tcp_listeners.push(listener);
         }
 
         let (driver_event_tx, driver_event_rx) =
@@ -393,11 +404,13 @@ where
             driver_handle: Mutex::new(None),
         };
 
-        let ice_gatherer = RTCIceGatherer::new(local_addrs, opts);
+        let ice_gatherer = RTCIceGatherer::new(local_addrs, tcp_local_addrs, opts);
         let mut driver = PeerConnectionDriver::new(
             peer_connection.inner.clone(),
             ice_gatherer,
             async_udp_sockets,
+            tcp_listeners,
+            runtime.clone(),
         )
         .await?;
         let driver_handle = runtime.spawn(Box::pin(async move {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -57,14 +57,17 @@ pub trait Runtime: Send + Sync + Debug + 'static {
     /// The socket should be bound and configured before being wrapped.
     fn wrap_udp_socket(&self, socket: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>>;
 
-    /*
-    /// Create an async TCP socket from a standard socket
-    ///
-    /// The socket should be bound and configured before being wrapped.
+    /// Wrap a bound std TcpListener into an async listener
     fn wrap_tcp_listener(
         &self,
         socket: std::net::TcpListener,
-    ) -> io::Result<Box<dyn AsyncTcpListener>>;*/
+    ) -> io::Result<Arc<dyn AsyncTcpListener>>;
+
+    /// Open an outbound TCP connection to `addr`
+    fn connect_tcp(
+        &self,
+        addr: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn AsyncTcpStream>>> + Send>>;
 }
 
 /// Abstract implementation of a UDP socket for runtime independence
@@ -86,6 +89,41 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
 
     /// Get the local address this socket is bound to
     fn local_addr(&self) -> io::Result<SocketAddr>;
+}
+
+/// An async TCP listener — accepts incoming TCP connections
+pub trait AsyncTcpListener: Send + Sync + Debug + 'static {
+    /// Accept the next incoming connection
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn AsyncTcpStream>>> + Send + 'a>>;
+
+    /// Local address the listener is bound to
+    fn local_addr(&self) -> io::Result<SocketAddr>;
+}
+
+/// An async TCP stream — supports concurrent reads and writes
+///
+/// Implementations must allow `read` and `write_all` to be called
+/// concurrently from different tasks (e.g. by using split halves internally).
+pub trait AsyncTcpStream: Send + Sync + Debug + 'static {
+    /// Read bytes into `buf`, returning the number of bytes read (0 = EOF)
+    fn read<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>>;
+
+    /// Write all bytes in `buf` to the stream
+    fn write_all<'a>(
+        &'a self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>>;
+
+    /// Local address of this connection
+    fn local_addr(&self) -> io::Result<SocketAddr>;
+
+    /// Remote address of this connection
+    fn peer_addr(&self) -> io::Result<SocketAddr>;
 }
 
 /// An async mutex that works across different runtimes

--- a/src/runtime/smol.rs
+++ b/src/runtime/smol.rs
@@ -41,6 +41,104 @@ impl Runtime for SmolRuntime {
     fn wrap_udp_socket(&self, sock: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>> {
         Ok(Arc::new(UdpSocket::new(sock)?))
     }
+
+    fn wrap_tcp_listener(
+        &self,
+        socket: std::net::TcpListener,
+    ) -> io::Result<Arc<dyn super::AsyncTcpListener>> {
+        let listener = ::smol::net::TcpListener::try_from(socket)?;
+        let local_addr = listener.local_addr()?;
+        Ok(Arc::new(SmolTcpListener { io: Arc::new(listener), local_addr }))
+    }
+
+    fn connect_tcp(
+        &self,
+        addr: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn super::AsyncTcpStream>>> + Send>> {
+        Box::pin(async move {
+            let stream = ::smol::net::TcpStream::connect(addr).await?;
+            let local_addr = stream.local_addr()?;
+            let peer_addr = stream.peer_addr()?;
+            Ok(Arc::new(SmolTcpStream {
+                io: Arc::new(::futures::lock::Mutex::new(stream)),
+                local_addr,
+                peer_addr,
+            }) as Arc<dyn super::AsyncTcpStream>)
+        })
+    }
+}
+
+// ── TCP listener ──────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct SmolTcpListener {
+    io: Arc<::smol::net::TcpListener>,
+    local_addr: SocketAddr,
+}
+
+impl super::AsyncTcpListener for SmolTcpListener {
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn super::AsyncTcpStream>>> + Send + 'a>>
+    {
+        let io = self.io.clone();
+        Box::pin(async move {
+            let (stream, _peer) = io.accept().await?;
+            let local_addr = stream.local_addr()?;
+            let peer_addr = stream.peer_addr()?;
+            Ok(Arc::new(SmolTcpStream {
+                io: Arc::new(::futures::lock::Mutex::new(stream)),
+                local_addr,
+                peer_addr,
+            }) as Arc<dyn super::AsyncTcpStream>)
+        })
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+}
+
+// ── TCP stream ────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct SmolTcpStream {
+    io: Arc<::futures::lock::Mutex<::smol::net::TcpStream>>,
+    local_addr: SocketAddr,
+    peer_addr: SocketAddr,
+}
+
+impl super::AsyncTcpStream for SmolTcpStream {
+    fn read<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+        let io = self.io.clone();
+        Box::pin(async move {
+            use ::futures::io::AsyncReadExt;
+            io.lock().await.read(buf).await
+        })
+    }
+
+    fn write_all<'a>(
+        &'a self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>> {
+        let io = self.io.clone();
+        let buf = buf.to_vec();
+        Box::pin(async move {
+            use ::futures::io::AsyncWriteExt;
+            io.lock().await.write_all(&buf).await
+        })
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+
+    fn peer_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.peer_addr)
+    }
 }
 
 #[derive(Debug)]

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -37,6 +37,115 @@ impl Runtime for TokioRuntime {
             io: Arc::new(::tokio::net::UdpSocket::from_std(sock)?),
         }))
     }
+
+    fn wrap_tcp_listener(
+        &self,
+        socket: std::net::TcpListener,
+    ) -> io::Result<Arc<dyn super::AsyncTcpListener>> {
+        socket.set_nonblocking(true)?;
+        let listener = ::tokio::net::TcpListener::from_std(socket)?;
+        let local_addr = listener.local_addr()?;
+        Ok(Arc::new(TokioTcpListener { io: Arc::new(listener), local_addr }))
+    }
+
+    fn connect_tcp(
+        &self,
+        addr: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn super::AsyncTcpStream>>> + Send>> {
+        Box::pin(async move {
+            let stream = ::tokio::net::TcpStream::connect(addr).await?;
+            let local_addr = stream.local_addr()?;
+            let peer_addr = stream.peer_addr()?;
+            let (read_half, write_half) = stream.into_split();
+            Ok(Arc::new(TokioTcpStream {
+                read: ::tokio::sync::Mutex::new(read_half).into(),
+                write: ::tokio::sync::Mutex::new(write_half).into(),
+                local_addr,
+                peer_addr,
+            }) as Arc<dyn super::AsyncTcpStream>)
+        })
+    }
+}
+
+// ── TCP listener ──────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TokioTcpListener {
+    io: Arc<::tokio::net::TcpListener>,
+    local_addr: SocketAddr,
+}
+
+impl super::AsyncTcpListener for TokioTcpListener {
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn super::AsyncTcpStream>>> + Send + 'a>>
+    {
+        let io = self.io.clone();
+        Box::pin(async move {
+            let (stream, _peer) = io.accept().await?;
+            let local_addr = stream.local_addr()?;
+            let peer_addr = stream.peer_addr()?;
+            let (read_half, write_half) = stream.into_split();
+            Ok(Arc::new(TokioTcpStream {
+                read: ::tokio::sync::Mutex::new(read_half).into(),
+                write: ::tokio::sync::Mutex::new(write_half).into(),
+                local_addr,
+                peer_addr,
+            }) as Arc<dyn super::AsyncTcpStream>)
+        })
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+}
+
+// ── TCP stream ────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TokioTcpStream {
+    read: Arc<::tokio::sync::Mutex<::tokio::net::tcp::OwnedReadHalf>>,
+    write: Arc<::tokio::sync::Mutex<::tokio::net::tcp::OwnedWriteHalf>>,
+    local_addr: SocketAddr,
+    peer_addr: SocketAddr,
+}
+
+impl super::AsyncTcpStream for TokioTcpStream {
+    fn read<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+        use ::tokio::io::AsyncReadExt;
+        let read = self.read.clone();
+        let len = buf.len();
+        Box::pin(async move {
+            let mut tmp = vec![0u8; len];
+            let n = read.lock().await.read(&mut tmp).await?;
+            // Safety: n <= len
+            buf[..n].copy_from_slice(&tmp[..n]);
+            Ok(n)
+        })
+    }
+
+    fn write_all<'a>(
+        &'a self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + 'a>> {
+        use ::tokio::io::AsyncWriteExt;
+        let write = self.write.clone();
+        let buf = buf.to_vec();
+        Box::pin(async move {
+            write.lock().await.write_all(&buf).await
+        })
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+
+    fn peer_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.peer_addr)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/tests/datachannel_video_interop.rs
+++ b/tests/datachannel_video_interop.rs
@@ -1,0 +1,276 @@
+/// Integration test: DataChannel + Video transceiver on the same RTCPeerConnection (#784)
+///
+/// Verifies that a PeerConnection can simultaneously host:
+///   - An RTP video transceiver (m=video in SDP)
+///   - A data channel          (m=application / SCTP in SDP)
+///
+/// The test confirms:
+///   1. `create_offer()` succeeds and produces SDP containing both m-lines
+///   2. The answerer can parse the offer and generate a valid answer with both m-lines
+///   3. ICE + DTLS + SCTP establish successfully (data channel opens)
+///   4. A message can be sent/received over the data channel
+///
+/// Default codecs are registered so video m-lines have real codec payloads.
+/// No actual video RTP is sent — the transceivers are inactive (Recvonly on both sides).
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::RTCRtpTransceiverInit;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use webrtc::data_channel::{DataChannel, DataChannelEvent};
+use webrtc::peer_connection::*;
+use webrtc::peer_connection::{
+    MediaEngine, RTCIceGatheringState, RTCPeerConnectionState,
+};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const TEST_MESSAGE: &str = "DC over video+DC peer connection";
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+struct OffererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for OffererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct AnswererHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    msg_tx: Sender<String>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for AnswererHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        log::info!("Answerer received data channel: {}", label);
+        let msg_tx = self.msg_tx.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => log::info!("Answerer data channel opened"),
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        log::info!("Answerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_media_engine() -> MediaEngine {
+    let mut me = MediaEngine::default();
+    me.register_default_codecs()
+        .expect("register_default_codecs failed");
+    me
+}
+
+// ── Test entry point ──────────────────────────────────────────────────────────
+
+/// Verify that a video transceiver and a data channel coexist on the same PeerConnection.
+#[test]
+fn test_datachannel_and_video_transceiver() {
+    block_on(run_test()).unwrap();
+}
+
+async fn run_test() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    log::info!("Starting DataChannel + Video transceiver test (#784)");
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+    let (offerer_gather_tx, mut offerer_gather_rx) = channel::<()>(1);
+    let (offerer_connected_tx, mut offerer_connected_rx) = channel::<()>(1);
+    let (offerer_dc_open_tx, mut offerer_dc_open_rx) = channel::<()>(1);
+    let (offerer_msg_tx, mut offerer_msg_rx) = channel::<String>(8);
+    let (answerer_gather_tx, mut answerer_gather_rx) = channel::<()>(1);
+    let (answerer_connected_tx, mut answerer_connected_rx) = channel::<()>(1);
+    let (answerer_msg_tx, mut answerer_msg_rx) = channel::<String>(8);
+
+    let recvonly_init = || Some(RTCRtpTransceiverInit {
+        direction: RTCRtpTransceiverDirection::Recvonly,
+        send_encodings: vec![],
+        streams: vec![],
+    });
+
+    // ── Build offerer ──────────────────────────────────────────────────────────
+    let offerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine())
+        .with_handler(Arc::new(OffererHandler {
+            gather_tx: offerer_gather_tx,
+            connected_tx: offerer_connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    offerer_pc
+        .add_transceiver_from_kind(RtpCodecKind::Video, recvonly_init())
+        .await?;
+    log::info!("Offerer: added video transceiver (recvonly)");
+
+    let offerer_dc = offerer_pc.create_data_channel("test", None).await?;
+    log::info!("Offerer: created data channel");
+
+    {
+        let dc = offerer_dc.clone();
+        let dc_open_tx = offerer_dc_open_tx.clone();
+        let msg_tx = offerer_msg_tx.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        log::info!("Offerer data channel opened");
+                        dc_open_tx.try_send(()).ok();
+                    }
+                    DataChannelEvent::OnMessage(msg) => {
+                        let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();
+                        log::info!("Offerer received: '{}'", text);
+                        msg_tx.try_send(text).ok();
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = offerer_pc.create_offer(None).await?;
+    log::info!("Offerer created offer:\n{}", offer.sdp);
+
+    // Both m-lines must be present in the offer with valid ports
+    assert!(
+        offer.sdp.contains("m=video") && !offer.sdp.contains("m=video 0 "),
+        "Offer must contain active m=video (not rejected), got:\n{}",
+        offer.sdp
+    );
+    assert!(
+        offer.sdp.contains("m=application"),
+        "Offer must contain m=application (SCTP), got:\n{}",
+        offer.sdp
+    );
+    log::info!("✅ Offer SDP contains both m=video (active) and m=application");
+
+    offerer_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer_gather_rx.recv()).await;
+    let offer_sdp = offerer_pc
+        .local_description()
+        .await
+        .expect("offerer local description must be set");
+
+    // ── Build answerer (also has video + DC) ───────────────────────────────────
+    let answerer_pc = PeerConnectionBuilder::new()
+        .with_media_engine(make_media_engine())
+        .with_handler(Arc::new(AnswererHandler {
+            gather_tx: answerer_gather_tx,
+            connected_tx: answerer_connected_tx,
+            msg_tx: answerer_msg_tx,
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer_pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer_pc.create_answer(None).await?;
+    log::info!("Answerer created answer:\n{}", answer.sdp);
+
+    assert!(
+        answer.sdp.contains("m=video"),
+        "Answer must contain m=video, got:\n{}",
+        answer.sdp
+    );
+    assert!(
+        answer.sdp.contains("m=application"),
+        "Answer must contain m=application, got:\n{}",
+        answer.sdp
+    );
+    log::info!("✅ Answer SDP contains both m=video and m=application");
+
+    answerer_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer_gather_rx.recv()).await;
+    let answer_sdp = answerer_pc
+        .local_description()
+        .await
+        .expect("answerer local description must be set");
+
+    offerer_pc.set_remote_description(answer_sdp).await?;
+
+    // ── Wait for both to connect ───────────────────────────────────────────────
+    timeout(Duration::from_secs(15), offerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: offerer did not connect"))?;
+    log::info!("Offerer connected");
+
+    timeout(Duration::from_secs(5), answerer_connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: answerer did not connect"))?;
+    log::info!("Answerer connected");
+
+    // ── Send message over data channel ─────────────────────────────────────────
+    timeout(Duration::from_secs(10), offerer_dc_open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: offerer data channel did not open"))?;
+
+    log::info!("Offerer sending: '{}'", TEST_MESSAGE);
+    offerer_dc.send_text(TEST_MESSAGE).await?;
+
+    let received = timeout(Duration::from_secs(10), answerer_msg_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout: answerer did not receive message"))?
+        .ok_or_else(|| anyhow::anyhow!("Answerer message channel closed"))?;
+
+    assert_eq!(received, TEST_MESSAGE, "Answerer must receive the test message");
+    log::info!("✅ Data channel message received over video+DC peer connection");
+
+    // Offerer_msg_rx is intentionally unused — we only test one-way delivery here
+    drop(offerer_msg_rx);
+
+    sleep(Duration::from_millis(100)).await;
+    offerer_pc.close().await?;
+    answerer_pc.close().await?;
+
+    log::info!("✅ test_datachannel_and_video_transceiver passed");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

TCP accept loop tasks and per-connection read/write tasks were spawned with `runtime.spawn()` and the `JoinHandle` was immediately dropped (detached). On driver shutdown those tasks kept running indefinitely, accumulating OS file descriptors and memory.

**Changes:**
- Add `tcp_task_handles: Vec<JoinHandle>` to `PeerConnectionDriver`
- Store handles for all TCP accept loop, read, and write tasks at spawn time
- Add `abort_tcp_tasks()` helper that calls `.abort()` on each handle
- Call `abort_tcp_tasks()` on all driver exit paths (clean close, socket error, all-futures-completed)
- Log a `warn!` when a TCP write channel is full/closed so the connection deregistration is visible in production logs
- Add `log::debug!` at driver event loop start and clean shutdown for lifecycle observability

## Test Plan

- [x] `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)