### PR TITLE
ci: add git-cliff changelog generation on release tags

### DIFF
--- a/.cliff.toml
+++ b/.cliff.toml
@@ -1,0 +1,49 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}\
+          {% if commit.breaking %} [**BREAKING**]{% endif %} \
+          ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))\
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = []
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore|^ci|^build", group = "Miscellaneous" },
+  { message = "^revert", group = "Reverted Commits" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/.cliff.toml
+++ b/.cliff.toml
@@ -37,7 +37,9 @@ commit_parsers = [
   { message = "^refactor", group = "Refactoring" },
   { message = "^doc", group = "Documentation" },
   { message = "^test", group = "Testing" },
-  { message = "^chore|^ci|^build", group = "Miscellaneous" },
+  { message = "^ci", group = "CI" },
+  { message = "^build", group = "Build" },
+  { message = "^chore", group = "Miscellaneous" },
   { message = "^revert", group = "Reverted Commits" },
 ]
 protect_breaking_commits = false

--- a/.cliff.toml
+++ b/.cliff.toml
@@ -18,7 +18,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}\
           {% if commit.breaking %} [**BREAKING**]{% endif %} \
-          ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))\
+          ({{ commit.id | truncate(length=7, end="") }})\
     {% endfor %}
 {% endfor %}\n
 """

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Generate changelog for this release
+        run: |
+          git cliff --current --output CHANGELOG.md
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: CHANGELOG.md
+
+  publish:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: changelog
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Uncomment when ready to publish to crates.io:
+      # - name: Install stable toolchain
+      #   uses: dtolnay/rust-toolchain@stable
+      # - name: Publish
+      #   run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v*.*.*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +35,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: changelog
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Add `.cliff.toml` config for [git-cliff](https://github.com/orhun/git-cliff) with conventional commit categories
- Add `.github/workflows/release.yml` to auto-generate changelog on tag push and use it as the GitHub Release body (the changelog is not committed back to the repo)
- Generates clean, grouped changelogs (Features, Bug Fixes, CI, Build, etc.) for each release

## Test plan
- [x] Push a test tag and verify changelog is generated correctly
- [x] Verify conventional commit messages are categorized properly
- [x] Fix tag glob pattern to use valid fnmatch syntax
- [x] Add `permissions: contents: write` for release publishing
- [x] Remove broken markdown link on commit SHAs in cliff template
- [x] Add pre-release tag pattern (`v*.*.*-*`) so alpha/rc tags trigger releases
- [x] Split `ci` and `build` commits into dedicated changelog sections (CI, Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)