### PR TITLE
ice: Release TURN allocation even if candidate was already closed

### DIFF
--- a/ice/src/candidate/candidate_base.rs
+++ b/ice/src/candidate/candidate_base.rs
@@ -237,23 +237,21 @@ impl Candidate for CandidateBase {
 
     /// Stops the recvLoop.
     async fn close(&self) -> Result<()> {
-        {
-            let mut closed_ch = self.closed_ch.lock().await;
-            if closed_ch.is_none() {
-                return Err(Error::ErrClosed);
-            }
-            closed_ch.take();
+        let already_closed = self.closed_ch.lock().await.take().is_none();
+
+        if let Some(conn) = &self.conn {
+            let _ = conn.close().await;
         }
 
         if let Some(relay_client) = &self.relay_client {
             let _ = relay_client.close().await;
         }
 
-        if let Some(conn) = &self.conn {
-            let _ = conn.close().await;
+        if already_closed {
+            Err(Error::ErrClosed)
+        } else {
+            Ok(())
         }
-
-        Ok(())
     }
 
     fn seen(&self, outbound: bool) {


### PR DESCRIPTION
Previously, candidate close() returned early when closed_ch was None, skipping conn.close() which sends the TURN Refresh with lifetime=0 to deallocate the relay (turn/src/client/relay_conn.rs:457). This left stale TURN allocations on the server, causing the remote peer to retry TURN channel binds for ~8s until the TURN client gave up.