### PR TITLE
fix(ice): always send STUN consent checks (RFC 7675)

### DIFF
--- a/ice/src/agent/agent_internal.rs
+++ b/ice/src/agent/agent_internal.rs
@@ -81,6 +81,10 @@ pub struct AgentInternal {
     pub(crate) keepalive_interval: Duration,
     // How often should we run our internal taskLoop to check for state changes when connecting
     pub(crate) check_interval: Duration,
+
+    // Tracks the last time a STUN consent binding request was sent (nanos since UNIX_EPOCH).
+    // Used to enforce RFC 7675 consent freshness independently of media traffic.
+    pub(crate) last_consent_ping: AtomicU64,
 }
 
 impl AgentInternal {
@@ -157,6 +161,8 @@ impl AgentInternal {
 
             // AgentConn
             agent_conn: Arc::new(AgentConn::new()),
+
+            last_consent_ping: AtomicU64::new(0),
         };
 
         let chan_receivers = ChanReceivers {
@@ -473,9 +479,9 @@ impl AgentInternal {
         valid
     }
 
-    /// Sends STUN Binding Indications to the selected pair.
-    /// if no packet has been sent on that pair in the last keepaliveInterval.
-    /// Note: the caller should hold the agent lock.
+    /// Sends STUN Binding Requests to the selected pair on a fixed interval to maintain
+    /// ICE consent freshness per RFC 7675. Unlike the previous implementation, this fires
+    /// regardless of media traffic — SRTP/SRTCP packets do NOT satisfy consent.
     pub(crate) async fn check_keepalive(&self) {
         let (local, remote) = {
             let selected_pair = self.agent_conn.selected_pair.load();
@@ -490,21 +496,21 @@ impl AgentInternal {
         };
 
         if let (Some(local), Some(remote)) = (local, remote) {
-            let last_sent = SystemTime::now()
-                .duration_since(local.last_sent())
-                .unwrap_or_else(|_| Duration::from_secs(0));
+            if self.keepalive_interval != Duration::from_secs(0) {
+                let now_nanos = SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64;
+                let last_ping_nanos = self.last_consent_ping.load(Ordering::SeqCst);
+                let since_last_ping =
+                    Duration::from_nanos(now_nanos.saturating_sub(last_ping_nanos));
 
-            let last_received = SystemTime::now()
-                .duration_since(remote.last_received())
-                .unwrap_or_else(|_| Duration::from_secs(0));
-
-            if (self.keepalive_interval != Duration::from_secs(0))
-                && ((last_sent > self.keepalive_interval)
-                    || (last_received > self.keepalive_interval))
-            {
-                // we use binding request instead of indication to support refresh consent schemas
-                // see https://tools.ietf.org/html/rfc7675
-                self.ping_candidate(&local, &remote).await;
+                if since_last_ping >= self.keepalive_interval {
+                    self.last_consent_ping.store(now_nanos, Ordering::SeqCst);
+                    // Use binding request (not indication) to maintain consent freshness.
+                    // See https://tools.ietf.org/html/rfc7675
+                    self.ping_candidate(&local, &remote).await;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Backports https://github.com/webrtc-rs/rtc/pull/86 to the `v0.17.x` line of `webrtc-ice`.

`AgentInternal::check_keepalive()` previously gated STUN Binding Requests on `Candidate::last_sent` / `last_received`. Those timestamps are bumped by **all** traffic, including SRTP/SRTCP. When media is flowing, the timestamps stay fresh and consent pings never fire. Remote peers that enforce [RFC 7675](https://datatracker.ietf.org/doc/html/rfc7675) tear down the connection after ~30s of STUN silence.

This change tracks consent-ping timing independently of media:

- Adds `last_consent_ping: AtomicU64` to `AgentInternal`, stored as nanoseconds since `UNIX_EPOCH`.
- Replaces the `last_sent` / `last_received` guard in `check_keepalive` with an elapsed check against `last_consent_ping`, ensuring a STUN binding request is sent every `keepalive_interval` regardless of media flow.

Same bug, same fix as Pion (Go) https://github.com/pion/ice/pull/767 and the upstream `rtc-ice` PR https://github.com/webrtc-rs/rtc/pull/86.

## Why backport

We've been carrying this fix as a `[patch.crates-io]` against a vendored copy of `webrtc-ice 0.17.1` in production at Perplexity for our real-time voice stack. The new `rtc-ice` crate has the upstream fix on `master` but no stable release ships it yet, and migrating to the sans-I/O API surface is a larger project. A `webrtc-ice 0.17.2` with this change would let downstreams on the legacy crate drop their patches now.

## Changes

Single file: `ice/src/agent/agent_internal.rs` (+24 / -18).

## Test plan

- `cargo check -p webrtc-ice`
- `cargo clippy -p webrtc-ice`
- `cargo test -p webrtc-ice`
- Validated in production at Perplexity against peers enforcing RFC 7675 consent freshness.

The original PR at webrtc-rs/rtc#86 added a regression test that asserts a STUN ping is emitted via the sans-I/O `write_outs` queue. The legacy `webrtc-ice` doesn't have an equivalent hook — `ping_candidate` writes to a real socket via `agent_conn`, and existing keepalive tests rely on the `connect_with_vnet` harness. Happy to add a vnet-based regression test in a follow-up if you'd prefer.

## Asks

Would you be open to cutting `webrtc-ice 0.17.2` from `v0.17.x` after merging? That would let us drop our `[patch.crates-io]` and consume a clean release.
