### PR TITLE
util: don't tear down UDP listener read_loop on WSAECONNRESET (Windows)

### DIFF
--- a/util/src/conn/conn_udp_listener.rs
+++ b/util/src/conn/conn_udp_listener.rs
@@ -176,6 +176,19 @@ impl ListenConfig {
                             }
                         }
                         Err(err) => {
+                            // On Windows, `recv_from` fails with `ErrorKind::ConnectionReset`
+                            // (WSAECONNRESET) when a previously *sent* datagram was answered
+                            // with an ICMP "Port Unreachable" message (e.g. because the
+                            // remote closed its socket). This does not affect the listening
+                            // socket itself, so it must not tear down the read loop -
+                            // otherwise the listener is left permanently unable to accept
+                            // packets while its socket remains bound. See e.g.
+                            // https://github.com/feschber/lan-mouse/issues/262
+                            if matches!(&err, Error::Io(io_err) if io_err.0.kind() == std::io::ErrorKind::ConnectionReset)
+                            {
+                                log::debug!("ListenConfig pconn.recv_from transient error: {err}");
+                                continue;
+                            }
                             log::warn!("ListenConfig pconn.recv_from error: {err}");
                             break;
                         }


### PR DESCRIPTION
## Problem

On Windows, `recv_from` on a UDP socket fails with an `ErrorKind::ConnectionReset` io error (`WSAECONNRESET`) when a previously **sent** datagram was answered with an ICMP "Port Unreachable" message — e.g. because the remote endpoint closed its socket. The error refers to an earlier send and says nothing about the health of the listening socket.

`ListenConfig`'s `read_loop` treats every `recv_from` error as fatal and breaks out of the loop. The result: the listener is left **permanently unable to accept packets or dispatch to existing conns, while its socket remains bound** — from the outside the service looks healthy but never answers another handshake until the process is restarted. Linux is unaffected (ICMP errors are not surfaced on unconnected UDP receives there), so this bites Windows peers of cross-platform apps.

## Real-world impact

This is the root cause of a long-standing lan-mouse bug (feschber/lan-mouse#262, open since early 2025): the Windows peer of the DTLS-based KVM goes permanently deaf within seconds of any counterpart disconnecting ungracefully, because the counterpart's closed socket bounces the Windows side's keepalives with ICMP Port Unreachable.

## Fix

Treat `ConnectionReset` as transient in `read_loop`: log at debug level and continue reading. All other errors keep the existing fatal behavior.

## Verification

Live A/B on the lan-mouse reproducer (Linux master ↔ Windows client):

- **Stock webrtc-util 0.11/0.17 code**: after any DTLS client connects and disconnects ungracefully (or even an `openssl s_client -dtls1_2` probe that comes and goes), the Windows listener logs `ListenConfig pconn.recv_from error: io error: An existing connection was forcibly closed by the remote host. (os error 10054)` and never accepts another handshake. Reproduced consistently, multiple times per hour of normal use.
- **With this patch** (applied to webrtc-util 0.11.0, lan-mouse rebuilt for Windows): five consecutive dirty connect/disconnect cycles against the same listener instance — all subsequent handshakes still answered; the KVM session survives peer disconnects indefinitely.

An alternative/complementary fix would be to disable this behavior at socket creation via `SIO_UDP_CONNRESET`; ignoring the error in the read loop was chosen as it is minimal and cross-platform.