### PR TITLE
Expose a DTLS ClientHello message hook

### DIFF
--- a/dtls/src/config.rs
+++ b/dtls/src/config.rs
@@ -8,13 +8,20 @@ use crate::cipher_suite::*;
 use crate::crypto::*;
 use crate::error::*;
 use crate::extension::extension_use_srtp::SrtpProtectionProfile;
+use crate::handshake::handshake_message_client_hello::HandshakeMessageClientHello;
 use crate::handshaker::VerifyPeerCertificateFn;
 use crate::signature_hash_algorithm::SignatureScheme;
+
+pub type ClientHelloMessageHook =
+    Arc<dyn Fn(HandshakeMessageClientHello) -> HandshakeMessageClientHello + Send + Sync>;
 
 /// Config is used to configure a DTLS client or server.
 /// After a Config is passed to a DTLS function it must not be modified.
 #[derive(Clone)]
 pub struct Config {
+    /// Replaces each generated ClientHello before it is sent.
+    pub client_hello_message_hook: Option<ClientHelloMessageHook>,
+
     /// certificates contains certificate chain to present to the other side of the connection.
     /// Server MUST set this if psk is non-nil
     /// client SHOULD sets this so CertificateRequests can be handled if psk is non-nil
@@ -107,6 +114,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
+            client_hello_message_hook: None,
             certificates: vec![],
             cipher_suites: vec![],
             signature_schemes: vec![],

--- a/dtls/src/conn/conn_test.rs
+++ b/dtls/src/conn/conn_test.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::SystemTime;
 
 use rand::Rng;
@@ -80,6 +81,40 @@ async fn pipe_conn(
     };
 
     Ok((client, sever))
+}
+
+#[tokio::test]
+async fn test_client_hello_message_hook() -> Result<()> {
+    let (ca, cb) = pipe();
+    let hook_calls = Arc::new(AtomicUsize::new(0));
+    let client_calls = hook_calls.clone();
+    let client = tokio::spawn(async move {
+        create_test_client(
+            Arc::new(ca),
+            Config {
+                client_hello_message_hook: Some(Arc::new(move |mut hello| {
+                    client_calls.fetch_add(1, Ordering::SeqCst);
+                    let mut cipher_suites = hello.cipher_suites().to_vec();
+                    cipher_suites.reverse();
+                    hello.set_cipher_suites(cipher_suites);
+                    let mut extensions = hello.extensions().to_vec();
+                    extensions.reverse();
+                    hello.set_extensions(extensions);
+                    hello
+                })),
+                ..Default::default()
+            },
+            true,
+        )
+        .await
+    });
+    let server = create_test_server(Arc::new(cb), Config::default(), true).await?;
+    let client = client.await.unwrap()?;
+
+    assert!(hook_calls.load(Ordering::SeqCst) >= 1);
+    client.close().await?;
+    server.close().await?;
+    Ok(())
 }
 
 fn psk_callback_client(hint: &[u8]) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send>> {

--- a/dtls/src/conn/mod.rs
+++ b/dtls/src/conn/mod.rs
@@ -215,6 +215,7 @@ impl DTLSConn {
         }
 
         let cfg = HandshakeConfig {
+            client_hello_message_hook: config.client_hello_message_hook.clone(),
             local_psk_callback: config.psk.take(),
             local_psk_identity_hint: config.psk_identity_hint.take(),
             local_cipher_suites,

--- a/dtls/src/flight/flight3.rs
+++ b/dtls/src/flight/flight3.rs
@@ -389,21 +389,23 @@ impl Flight for Flight3 {
             }));
         }
 
+        let mut client_hello = HandshakeMessageClientHello {
+            version: PROTOCOL_VERSION1_2,
+            random: state.local_random.clone(),
+            cookie: state.cookie.clone(),
+            cipher_suites: cfg.local_cipher_suites.clone(),
+            compression_methods: default_compression_methods(),
+            extensions,
+        };
+        if let Some(hook) = &cfg.client_hello_message_hook {
+            client_hello = hook(client_hello);
+        }
+
         Ok(vec![Packet {
             record: RecordLayer::new(
                 PROTOCOL_VERSION1_2,
                 0,
-                Content::Handshake(Handshake::new(HandshakeMessage::ClientHello(
-                    HandshakeMessageClientHello {
-                        version: PROTOCOL_VERSION1_2,
-                        random: state.local_random.clone(),
-                        cookie: state.cookie.clone(),
-
-                        cipher_suites: cfg.local_cipher_suites.clone(),
-                        compression_methods: default_compression_methods(),
-                        extensions,
-                    },
-                ))),
+                Content::Handshake(Handshake::new(HandshakeMessage::ClientHello(client_hello))),
             ),
             should_encrypt: false,
             reset_local_sequence_number: false,

--- a/dtls/src/handshake/handshake_message_client_hello.rs
+++ b/dtls/src/handshake/handshake_message_client_hello.rs
@@ -74,6 +74,46 @@ impl fmt::Debug for HandshakeMessageClientHello {
 const HANDSHAKE_MESSAGE_CLIENT_HELLO_VARIABLE_WIDTH_START: usize = 34;
 
 impl HandshakeMessageClientHello {
+    pub fn random(&self) -> &HandshakeRandom {
+        &self.random
+    }
+
+    pub fn set_random(&mut self, random: HandshakeRandom) {
+        self.random = random;
+    }
+
+    pub fn cookie(&self) -> &[u8] {
+        &self.cookie
+    }
+
+    pub fn set_cookie(&mut self, cookie: Vec<u8>) {
+        self.cookie = cookie;
+    }
+
+    pub fn cipher_suites(&self) -> &[CipherSuiteId] {
+        &self.cipher_suites
+    }
+
+    pub fn set_cipher_suites(&mut self, cipher_suites: Vec<CipherSuiteId>) {
+        self.cipher_suites = cipher_suites;
+    }
+
+    pub fn compression_methods(&self) -> &CompressionMethods {
+        &self.compression_methods
+    }
+
+    pub fn set_compression_methods(&mut self, compression_methods: CompressionMethods) {
+        self.compression_methods = compression_methods;
+    }
+
+    pub fn extensions(&self) -> &[Extension] {
+        &self.extensions
+    }
+
+    pub fn set_extensions(&mut self, extensions: Vec<Extension>) {
+        self.extensions = extensions;
+    }
+
     pub fn handshake_type(&self) -> HandshakeType {
         HandshakeType::ClientHello
     }

--- a/dtls/src/handshaker.rs
+++ b/dtls/src/handshaker.rs
@@ -79,6 +79,7 @@ pub(crate) type VerifyPeerCertificateFn =
     Arc<dyn (Fn(&[Vec<u8>], &[CertificateDer<'static>]) -> Result<()>) + Send + Sync>;
 
 pub(crate) struct HandshakeConfig {
+    pub(crate) client_hello_message_hook: Option<ClientHelloMessageHook>,
     pub(crate) local_psk_callback: Option<PskCallback>,
     pub(crate) local_psk_identity_hint: Option<Vec<u8>>,
     pub(crate) local_cipher_suites: Vec<CipherSuiteId>, // Available CipherSuites
@@ -117,6 +118,7 @@ pub fn gen_self_signed_root_cert() -> rustls::RootCertStore {
 impl Default for HandshakeConfig {
     fn default() -> Self {
         HandshakeConfig {
+            client_hello_message_hook: None,
             local_psk_callback: None,
             local_psk_identity_hint: None,
             local_cipher_suites: vec![],

--- a/webrtc/src/api/setting_engine/mod.rs
+++ b/webrtc/src/api/setting_engine/mod.rs
@@ -3,6 +3,7 @@ mod setting_engine_test;
 
 use std::sync::Arc;
 
+use dtls::config::ClientHelloMessageHook;
 use dtls::extension::extension_use_srtp::SrtpProtectionProfile;
 use ice::agent::agent_config::{InterfaceFilterFn, IpFilterFn};
 use ice::mdns::MulticastDnsMode;
@@ -89,6 +90,7 @@ pub struct SettingEngine {
     pub(crate) replay_protection: ReplayProtection,
     pub(crate) sdp_media_level_fingerprints: bool,
     pub(crate) answering_dtls_role: DTLSRole,
+    pub(crate) dtls_client_hello_message_hook: Option<ClientHelloMessageHook>,
     pub(crate) disable_certificate_fingerprint_verification: bool,
     pub(crate) allow_insecure_verification_algorithm: bool,
     pub(crate) disable_srtp_replay_protection: bool,
@@ -109,6 +111,11 @@ pub struct SettingEngine {
 }
 
 impl SettingEngine {
+    /// Replaces each generated DTLS ClientHello before it is sent.
+    pub fn set_dtls_client_hello_message_hook(&mut self, hook: ClientHelloMessageHook) {
+        self.dtls_client_hello_message_hook = Some(hook);
+    }
+
     /// get_receive_mtu returns the configured MTU. If SettingEngine's MTU is configured to 0 it returns the default
     pub(crate) fn get_receive_mtu(&self) -> usize {
         if self.receive_mtu != 0 {

--- a/webrtc/src/dtls_transport/mod.rs
+++ b/webrtc/src/dtls_transport/mod.rs
@@ -348,6 +348,10 @@ impl RTCDtlsTransport {
         Ok((
             self.role().await,
             dtls::config::Config {
+                client_hello_message_hook: self
+                    .setting_engine
+                    .dtls_client_hello_message_hook
+                    .clone(),
                 certificates: vec![certificate],
                 srtp_protection_profiles: if !self
                     .setting_engine


### PR DESCRIPTION
## What changed

- adds a typed `ClientHelloMessageHook` to the DTLS configuration
- exposes focused getters and setters for the generated ClientHello fields
- applies the hook to every ClientHello flight, including cookie retries
- threads the hook through WebRTC's `SettingEngine`

## Why

Some applications need to change the observable DTLS ClientHello without
reimplementing the DTLS state machine. A concrete use case is censorship
resistance: the default Pion DTLS fingerprint has been filtered in deployed
networks, and Pion's Go implementation exposes the equivalent
`SetDTLSClientHelloMessageHook` through its setting engine.

The hook transforms the structured message before it enters the handshake
transcript, so sequence numbers, retransmission, HelloVerifyRequest cookies,
and transcript hashing remain owned by `dtls`.

## Call flow

```mermaid
sequenceDiagram
    autonumber
    participant App as Application
    participant SE as SettingEngine
    participant WT as WebRTC DTLS
    participant DC as DTLS config
    participant F3 as Flight 3

    App->>SE: setting_engine/mod.rs:115<br/>Install ClientHello hook
    SE->>WT: dtls_transport/mod.rs:350<br/>Build DTLS configuration
    WT->>DC: conn/mod.rs:217<br/>Build handshake configuration
    DC->>F3: flight3.rs:392<br/>Generate protocol-valid ClientHello
    rect rgba(255, 200, 200, 0.3)
        F3->>F3: flight3.rs:400<br/>Apply caller transformation
    end
    F3-->>WT: flight3.rs:404<br/>Continue normal DTLS flight
```

## Validation

- `cargo test -p dtls --lib` — 62 passed
- `cargo test -p webrtc --lib` — 156 passed, 1 ignored
- `cargo fmt --all -- --check`
- the new test reverses cipher-suite and extension ordering and completes a
  real DTLS client/server handshake

Clippy on the current local stable compiler reaches an unrelated pre-existing
`clippy::question_mark` warning in `util/src/vnet/conn_map.rs`.
