### PR TITLE
perf(driver): burst-read the udp socket to batch the SCTP receive path

### DIFF
--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -175,6 +175,15 @@ where
             .collect();
         let mut active_socket_count = udp_socket_list.len();
 
+        // Batch-drain: after one datagram wakes the select, non-blockingly drain a
+        // bounded burst of additional ready datagrams from the same socket and feed
+        // them all to handle_read before the next flush. Paired with the SCTP
+        // handler's deferred flush, a burst of DATA coalesces into a single SACK and
+        // amortizes the per-iteration cost (poll_writes/events/reads core locks,
+        // timeout recompute, select setup).
+        const MAX_UDP_RECV_BURST: usize = 64;
+        let mut burst_buf = vec![0u8; UDP_RECV_BUF_LEN];
+
         loop {
             // Shutdown safety-net. `close()`/`Drop` set this flag and best-effort
             // wake the driver with a `Close` event. If that wake was dropped (a
@@ -275,9 +284,36 @@ where
 
                                 // Immediately create a new future for this socket and reuse the buffer
                                 let (socket_local_addr, socket) = &udp_socket_list[idx];
+                                let socket_local_addr = *socket_local_addr;
+                                let socket = socket.clone();
                                 udp_recv_futures.push(
-                                    create_udp_recv_future(idx, *socket_local_addr, socket.clone(), buf).boxed()
+                                    create_udp_recv_future(idx, socket_local_addr, socket.clone(), buf).boxed()
                                 );
+
+                                // Batch-drain: drain a bounded burst of additional
+                                // ready datagrams from this socket without blocking.
+                                let mut burst = 0;
+                                while burst < MAX_UDP_RECV_BURST {
+                                    match socket.recv_from(&mut burst_buf).now_or_never() {
+                                        Some(Ok((bn, bpeer))) => {
+                                            let bmsg = BytesMut::from(&burst_buf[..bn]);
+                                            if let Err(err) = self.handle_read(TaggedBytesMut {
+                                                now: Instant::now(),
+                                                transport: TransportContext {
+                                                    local_addr: socket_local_addr,
+                                                    peer_addr: bpeer,
+                                                    ecn: None,
+                                                    transport_protocol: TransportProtocol::UDP,
+                                                },
+                                                message: bmsg,
+                                            }).await {
+                                                error!("handle_read error (burst): {}", err);
+                                            }
+                                            burst += 1;
+                                        }
+                                        _ => break, // would-block (pending) or error
+                                    }
+                                }
                             }
                             Some(SocketRecvResult::Error { err, local_addr, idx, buf }) => {
                                 if is_retryable_socket_recv_error(&err) {


### PR DESCRIPTION
## Summary

Burst-read the UDP socket: after a datagram wakes the `udp_recv` arm and the persistent
recv future is re-armed, drain a bounded burst (`MAX_UDP_RECV_BURST = 64`) of further
ready datagrams without blocking via `recv_from(&mut scratch).now_or_never()`, feeding each
to `handle_read`. No new socket API (recv_from borrows the buffer; one reused scratch Vec);
cancel-safe on both the tokio and smol sockets.

Previously the event loop handled one datagram per `select!` iteration, so every datagram
paid the full per-iteration cost and the SCTP layer emitted a SACK about every two DATA
packets.

## Pairs with a companion webrtc-rs/rtc handler change

Burst-read alone is a **modest standalone win** (+24%). Its full effect is unlocked by the
SCTP handler's deferred flush (companion PR **webrtc-rs/rtc#124**): with the burst
delivering N datagrams per iteration and
the flush deferred to once per iteration, the ack machine coalesces them into **one** SACK
instead of one per two packets. Together they roughly double throughput. The submodule bump
to pick up the rtc change will follow once that PR merges.

## Benchmark

AMD Ryzen 7 1700 (8c/16t), Linux, loopback, measured on **current upstream master**
(webrtc `3f37c264` + rtc `de84c7c`). Matched flow-control harness across stacks: 1 KB
messages, 512 KB / 1 MB buffered-amount watermarks, ordered, dedicated reactor; per-interval
steady state. webrtc via [`poop`](https://github.com/andrewrk/poop) over a fixed 128 MB
transfer (15–28 samples/combo); pion v4.2.16 via its own `data-channels-flow-control`
example. poop significance markers preserved (⚡ = significant improvement, 💩 = significant
regression, no marker = noise).

**N=1 — single connection** (deltas vs `neither`):

| metric | neither | burst-read | deferred-flush | both | pion v4.2.16 |
|---|---|---|---|---|---|
| throughput | 289 Mbps | 359 (+24%) | 296 (~0%) | **633 (2.19×)** | 396 |
| vs pion | 0.73× | 0.91× | 0.75× | **1.60×** | 1.0× |
| wall_time | 4.27 s | ⚡ −15.5% | ⚡ −6.7% | ⚡ −49.7% | — |
| instructions | 19.3 G | ⚡ −13.1% | +0.1% | ⚡ −44.2% | — |
| cpu_cycles | 14.7 G | ⚡ −34.3% | ⚡ −3.9% | ⚡ −59.9% | — |
| cache_references | 2.29 G | ⚡ −46.9% | −0.1% | ⚡ −69.9% | — |
| cache_misses | 593 M | ⚡ −81.8% | ⚡ −7.7% | ⚡ −90.5% | — |
| branch_misses | 106 M | ⚡ −67.6% | ⚡ −7.2% | ⚡ −83.6% | — |
| peak_rss | 25.0 MB | 💩 +27.5% | −2.8% | 💩 +29.2% | — |

**N=10 — ten concurrent connections, aggregate:**

| | neither | burst-read | deferred-flush | both | pion v4.2.16 |
|---|---|---|---|---|---|
| aggregate | 1470 Mbps | 1822 (+24%) | 1452 (~0%) | **2980 (2.03×)** | 1443 |
| vs pion | 1.02× | 1.26× | 1.01× | **2.06×** | 1.0× |

Burst-read alone: +24% and −13% instructions / −82% cache misses. With the companion rtc
flush: ~2× throughput, −44% instructions, −90% cache misses, flipping webrtc-rs from behind
pion (0.73×) to ahead of it (1.60× at N=1, 2.06× at N=10). Only regression: peak_rss
(💩 +28% single connection).

## Test plan

- Builds clean against current upstream master (`cargo check`).
- Adversarially reviewed: the deferred flush is guaranteed each event-loop iteration
  (`poll_writes` runs unconditionally at the loop top), receive-path timing is unchanged,
  and the burst read loses no datagram or wakeup on either runtime.
