### PR TITLE
feat(datachannel): opt-in send back-pressure (writable / try_send) to bound peak RSS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ path = "examples/data-channels-flow-control/data-channels-flow-control.rs"
 bench = false
 
 [[example]]
+name = "data-channels-flow-control-multi"
+path = "examples/data-channels-flow-control-multi/data-channels-flow-control-multi.rs"
+bench = false
+
+[[example]]
 name = "data-channels-stress-bench"
 path = "examples/data-channels-stress-bench/data-channels-stress-bench.rs"
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ path = "examples/data-channels-flow-control/data-channels-flow-control.rs"
 bench = false
 
 [[example]]
+name = "data-channels-stress-bench"
+path = "examples/data-channels-stress-bench/data-channels-stress-bench.rs"
+bench = false
+
+[[example]]
 name = "data-channels-offer"
 path = "examples/data-channels-offer-answer/data-channels-offer.rs"
 bench = false

--- a/examples/data-channels-flow-control-multi/data-channels-flow-control-multi.rs
+++ b/examples/data-channels-flow-control-multi/data-channels-flow-control-multi.rs
@@ -1,0 +1,287 @@
+//! Multi-pair data-channel flow-control bench for a single-`poop` N-connection run.
+//!
+//! Spawns `FLOW_PAIRS` in-process connection pairs, each running the unordered/no-retransmit,
+//! 1 KB / 512 KB-1 MB-watermark, `bufferedAmount`-flow-controlled transfer of the stock
+//! `data-channels-flow-control` example. Each pair skips `FLOW_WARMUP_MB` of ramp, then
+//! measures per-interval steady-state throughput over `FLOW_STOP_MB`; once every pair has
+//! finished its measured window the process prints an aggregate `FINAL` line and exits.
+//! Fixed work per run ⇒ a clean `poop` command:
+//!
+//!   FLOW_PAIRS=10 FLOW_WARMUP_MB=64 FLOW_STOP_MB=128 FLOW_DEDICATED_REACTOR=1 \
+//!     poop ./multi-master ./multi-backpressure ./pion-multi
+//!
+//! Uses ONLY public APIs, so the same source builds on upstream master and on the
+//! send-back-pressure branch (no `outstanding_bytes()` dependency).
+
+use bytes::BytesMut;
+use futures::FutureExt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{
+    MediaEngine, RTCConfigurationBuilder, RTCIceGatheringState, Registry,
+    register_default_interceptors,
+};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime};
+
+const BUFFERED_LOW: u32 = 512 * 1024; // 512 KB
+const BUFFERED_HIGH: u32 = 1024 * 1024; // 1 MB
+const CHUNK: usize = 1024; // 1 KB messages
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Clone)]
+struct GatherHandler {
+    gather_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for GatherHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ResponderHandler {
+    runtime: Arc<dyn Runtime>,
+    gather_tx: Sender<()>,
+    warmup_bytes: usize,
+    stop_bytes: usize,
+    stop: Arc<AtomicBool>,
+    mbps_tx: Sender<f64>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for ResponderHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let warmup = self.warmup_bytes;
+        let stop_bytes = self.stop_bytes;
+        let stop = self.stop.clone();
+        let mbps_tx = self.mbps_tx.clone();
+        // Must spawn: returning from on_data_channel unblocks the driver.
+        self.runtime.spawn(Box::pin(async move {
+            let mut got = 0usize;
+            let mut measure_start: Option<Instant> = None;
+            let mut measure_start_bytes = 0usize;
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        got += msg.data.len();
+                        // Start the clock once past the warmup threshold.
+                        if measure_start.is_none() && got >= warmup {
+                            measure_start = Some(Instant::now());
+                            measure_start_bytes = got;
+                        }
+                        if let Some(start) = measure_start
+                            && got - measure_start_bytes >= stop_bytes
+                        {
+                            let secs = start.elapsed().as_secs_f64();
+                            let measured = got - measure_start_bytes;
+                            let mbps = (measured * 8) as f64 / secs / (1024.0 * 1024.0);
+                            let _ = mbps_tx.try_send(mbps);
+                            stop.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                    }
+                    DataChannelEvent::OnClose | DataChannelEvent::OnError => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+async fn build_pc(
+    runtime: Arc<dyn Runtime>,
+    dedicated: bool,
+    handler: Arc<dyn PeerConnectionEventHandler>,
+) -> anyhow::Result<Arc<dyn PeerConnection>> {
+    let mut media = MediaEngine::default();
+    media.register_default_codecs()?;
+    let registry = register_default_interceptors(Registry::new(), &mut media)?;
+    let pc = PeerConnectionBuilder::new()
+        .with_configuration(RTCConfigurationBuilder::new().build())
+        .with_media_engine(media)
+        .with_interceptor_registry(registry)
+        .with_handler(handler)
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_dedicated_reactor_thread(dedicated)
+        .build()
+        .await?;
+    Ok(Arc::new(pc) as Arc<dyn PeerConnection>)
+}
+
+/// Build + connect one unordered/no-retransmit pair; spawn its flow-controlled send loop and a
+/// measuring receive loop. Returns both peer connections so the caller keeps them alive.
+async fn run_pair(
+    runtime: Arc<dyn Runtime>,
+    dedicated: bool,
+    warmup_bytes: usize,
+    stop_bytes: usize,
+    mbps_tx: Sender<f64>,
+) -> anyhow::Result<[Arc<dyn PeerConnection>; 2]> {
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Requester
+    let (req_gather_tx, mut req_gather_rx) = channel::<()>(1);
+    let requester = build_pc(
+        runtime.clone(),
+        dedicated,
+        Arc::new(GatherHandler {
+            gather_tx: req_gather_tx,
+        }),
+    )
+    .await?;
+
+    // Unordered / no-retransmit — matches the stock data-channels-flow-control example
+    // (and pion's), so each stack's N-pair bench uses that stack's own example config.
+    let dc = requester
+        .create_data_channel(
+            "data",
+            Some(RTCDataChannelInit {
+                ordered: false,
+                max_retransmits: Some(0),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    dc.set_buffered_amount_low_threshold(BUFFERED_LOW).await?;
+    dc.set_buffered_amount_high_threshold(BUFFERED_HIGH).await?;
+
+    // Flow-controlled send loop (single-task; mirrors data-channels-flow-control).
+    {
+        let stop = stop.clone();
+        runtime.spawn(Box::pin(async move {
+            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let mut dc_open = false;
+            let mut paused = false;
+            loop {
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                if dc_open && !paused {
+                    futures::select! {
+                        maybe_event = dc.poll().fuse() => match maybe_event {
+                            Some(DataChannelEvent::OnBufferedAmountHigh) => paused = true,
+                            Some(DataChannelEvent::OnBufferedAmountLow) => paused = false,
+                            Some(DataChannelEvent::OnClose) | None => break,
+                            _ => {}
+                        },
+                        result = dc.send(buf.clone()).fuse() => { let _ = result; }
+                    }
+                } else {
+                    match dc.poll().await {
+                        Some(DataChannelEvent::OnOpen) => dc_open = true,
+                        Some(DataChannelEvent::OnBufferedAmountHigh) => paused = true,
+                        Some(DataChannelEvent::OnBufferedAmountLow) => paused = false,
+                        Some(DataChannelEvent::OnClose) | None => break,
+                        _ => {}
+                    }
+                }
+            }
+        }));
+    }
+
+    let offer = requester.create_offer(None).await?;
+    requester.set_local_description(offer).await?;
+    req_gather_rx.recv().await;
+    let offer_sdp = requester
+        .local_description()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("requester has no local description"))?;
+
+    // Responder
+    let (resp_gather_tx, mut resp_gather_rx) = channel::<()>(1);
+    let responder = build_pc(
+        runtime.clone(),
+        dedicated,
+        Arc::new(ResponderHandler {
+            runtime: runtime.clone(),
+            gather_tx: resp_gather_tx,
+            warmup_bytes,
+            stop_bytes,
+            stop,
+            mbps_tx,
+        }),
+    )
+    .await?;
+
+    responder.set_remote_description(offer_sdp).await?;
+    let answer = responder.create_answer(None).await?;
+    responder.set_local_description(answer).await?;
+    resp_gather_rx.recv().await;
+    let answer_sdp = responder
+        .local_description()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("responder has no local description"))?;
+    requester.set_remote_description(answer_sdp).await?;
+
+    Ok([requester, responder])
+}
+
+fn main() -> anyhow::Result<()> {
+    block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
+    let pairs = env_usize("FLOW_PAIRS", 10);
+    let warmup_bytes = env_usize("FLOW_WARMUP_MB", 64) * 1024 * 1024;
+    let stop_bytes = env_usize("FLOW_STOP_MB", 128) * 1024 * 1024;
+    let dedicated = std::env::var("FLOW_DEDICATED_REACTOR")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+    let (mbps_tx, mut mbps_rx) = channel::<f64>(pairs.max(1));
+
+    let start = Instant::now();
+
+    // Set up all pairs (sequential handshake; transfers run concurrently once open).
+    let mut held: Vec<Arc<dyn PeerConnection>> = Vec::with_capacity(pairs * 2);
+    for _ in 0..pairs {
+        let [a, b] = run_pair(
+            runtime.clone(),
+            dedicated,
+            warmup_bytes,
+            stop_bytes,
+            mbps_tx.clone(),
+        )
+        .await?;
+        held.push(a);
+        held.push(b);
+    }
+
+    // Wait for every pair to finish its measured window, summing per-pair steady-state.
+    let mut agg_mbps = 0.0f64;
+    for _ in 0..pairs {
+        if let Some(mbps) = mbps_rx.recv().await {
+            agg_mbps += mbps;
+        }
+    }
+
+    let secs = start.elapsed().as_secs_f64();
+    println!(
+        "FINAL {agg_mbps:.3} Mbps aggregate over {pairs} pairs (dedicated={dedicated}) in {secs:.3}s",
+    );
+
+    drop(held);
+    Ok(())
+}

--- a/examples/data-channels-stress-bench/data-channels-stress-bench.rs
+++ b/examples/data-channels-stress-bench/data-channels-stress-bench.rs
@@ -11,24 +11,28 @@
 //! * `STRESS_DEDICATED_REACTOR=1` — run each peer's driver on a dedicated reactor
 //!   thread (issue #101).
 //! * `STRESS_NAIVE_SENDER=1` — sender does NO app-level `bufferedAmount` flow
-//!   control; it floods `send()` as fast as it is accepted. This is the realistic
-//!   "app that never checks bufferedAmount" case that send back-pressure defends
-//!   against (a slow reactor/peer would otherwise let the send pipeline grow without
-//!   bound). Without it, the sender self-throttles on `bufferedAmount`.
+//!   control; it floods `send()` as fast as it is accepted, retrying (with a brief
+//!   back-off) on `ErrSendBufferFull`. This is the realistic "app that never checks
+//!   bufferedAmount" case that the send-buffer cap defends against (a slow reactor/peer
+//!   would otherwise let the send pipeline grow without bound). Without it, the sender
+//!   self-throttles on `bufferedAmount`.
 //! * `STRESS_DRAIN_CHECK=1` — after the transfer, poll each channel's
 //!   `outstanding_bytes()` and print it, verifying the send counter drains to ~0
 //!   (conservation, including `max_retransmits: 0` abandonment).
 //!
-//! ## A/B'ing the back-pressure gate
-//! The gate's limits are read once from `WEBRTC_SEND_HIGH_WATER_BYTES` /
-//! `WEBRTC_SEND_HARD_CEILING_BYTES` (`0` = unbounded), so the SAME binary serves as
-//! both arms — only the fix differs:
+//! ## A/B'ing the send-buffer cap
+//! `STRESS_SEND_BUFFER_LIMIT` sets the per-channel send-buffer cap in bytes (`0` =
+//! unbounded); unset uses the library default (16 MiB). The SAME binary serves as both
+//! arms — only the cap differs:
 //!
 //!   STRESS_NAIVE_SENDER=1 STRESS_PAIRS=30 STRESS_MB_PER_PAIR=32 poop \
-//!     'env WEBRTC_SEND_HIGH_WATER_BYTES=0 WEBRTC_SEND_HARD_CEILING_BYTES=0 ./stress' \
+//!     'env STRESS_SEND_BUFFER_LIMIT=0 ./stress' \
 //!     './stress'
 //!
-//! (unbounded → bounded: peak_rss drops ~4×, and stays flat as the transfer grows).
+//! (unbounded → bounded: at the 16 MiB default `peak_rss` drops ~2× (≈−50%); with a
+//! smaller `STRESS_SEND_BUFFER_LIMIT` — e.g. 4 MiB — ~4–5× (≈−78%). Either way the
+//! bounded arm's peak_rss stays flat as the transfer grows, whereas the unbounded arm's
+//! scales with total bytes in flight.)
 
 use bytes::BytesMut;
 use futures::FutureExt;
@@ -155,16 +159,22 @@ async fn build_pc(
     let mut media = MediaEngine::default();
     media.register_default_codecs()?;
     let registry = register_default_interceptors(Registry::new(), &mut media)?;
-    let pc = PeerConnectionBuilder::new()
+    let mut builder = PeerConnectionBuilder::new()
         .with_configuration(RTCConfigurationBuilder::new().build())
         .with_media_engine(media)
         .with_interceptor_registry(registry)
         .with_handler(handler)
         .with_runtime(runtime.clone())
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
-        .with_dedicated_reactor_thread(dedicated)
-        .build()
-        .await?;
+        .with_dedicated_reactor_thread(dedicated);
+    // A/B knob for the send-buffer cap: `STRESS_SEND_BUFFER_LIMIT` (bytes; `0` = unbounded).
+    // Unset ⇒ the library default (16 MiB). This is what toggles the two arms of the bench.
+    if let Ok(v) = std::env::var("STRESS_SEND_BUFFER_LIMIT") {
+        if let Ok(limit) = v.parse::<usize>() {
+            builder = builder.with_data_channel_send_buffer_limit(limit);
+        }
+    }
+    let pc = builder.build().await?;
     Ok(Arc::new(pc) as Arc<dyn PeerConnection>)
 }
 
@@ -208,11 +218,11 @@ async fn run_pair(
     //  * default: single-task app-level flow control on `bufferedAmount`
     //    (mirrors data-channels-flow-control).
     //  * STRESS_NAIVE_SENDER: NO manual flow control — push exactly `target` bytes as
-    //    fast as `send()` accepts them. This is the realistic "app that never checks
-    //    bufferedAmount" case: with send back-pressure, `send()` blocks at the
-    //    high-water mark so peak queued memory stays bounded; without it, the whole
-    //    transfer piles into the unbounded send pipeline (peak RSS ∝ target). Both
-    //    modes send the same total work, so peak RSS isolates the queue bound.
+    //    fast as `send()` accepts them, retrying on `ErrSendBufferFull`. This is the
+    //    realistic "app that never checks bufferedAmount" case: with the send-buffer cap,
+    //    `send()` rejects past the limit so peak queued memory stays bounded; without it,
+    //    the whole transfer piles into the unbounded send pipeline (peak RSS ∝ target).
+    //    Both modes send the same total work, so peak RSS isolates the queue bound.
     let naive = std::env::var("STRESS_NAIVE_SENDER").is_ok();
     {
         let stop = stop.clone();
@@ -229,7 +239,7 @@ async fn run_pair(
                     // until the responder has received `target` and sets `stop`. Keeping
                     // the send loop running (rather than stopping at exactly `target`
                     // bytes) guarantees termination even if the unreliable channel drops
-                    // a chunk. With back-pressure, `send()` blocks at the high-water mark
+                    // a chunk. With the send-buffer cap, `send()` rejects past the limit
                     // so peak queued memory stays bounded; without it, the sender races
                     // far ahead of the receiver and the pipeline balloons.
                     if !dc_open {
@@ -241,7 +251,7 @@ async fn run_pair(
                         continue;
                     }
                     if dc.send(buf.clone()).await.is_err() {
-                        // Hard-ceiling rejection — brief back-off before retrying.
+                        // ErrSendBufferFull — brief back-off before retrying.
                         webrtc::runtime::sleep(std::time::Duration::from_millis(1)).await;
                     }
                     continue;

--- a/examples/data-channels-stress-bench/data-channels-stress-bench.rs
+++ b/examples/data-channels-stress-bench/data-channels-stress-bench.rs
@@ -11,28 +11,29 @@
 //! * `STRESS_DEDICATED_REACTOR=1` — run each peer's driver on a dedicated reactor
 //!   thread (issue #101).
 //! * `STRESS_NAIVE_SENDER=1` — sender does NO app-level `bufferedAmount` flow
-//!   control; it floods `send()` as fast as it is accepted, retrying (with a brief
-//!   back-off) on `ErrSendBufferFull`. This is the realistic "app that never checks
-//!   bufferedAmount" case that the send-buffer cap defends against (a slow reactor/peer
-//!   would otherwise let the send pipeline grow without bound). Without it, the sender
-//!   self-throttles on `bufferedAmount`.
+//!   control; it just floods the blocking `send()` in a loop. This is the realistic
+//!   "app that never checks bufferedAmount" case: with a send-buffer limit configured,
+//!   `send()` blocks once the channel is at the limit so peak queued memory stays
+//!   bounded; with no limit (the default) it never blocks and the whole transfer piles
+//!   into the send pipeline. Without this knob, the sender self-throttles on
+//!   `bufferedAmount`.
 //! * `STRESS_DRAIN_CHECK=1` — after the transfer, poll each channel's
 //!   `outstanding_bytes()` and print it, verifying the send counter drains to ~0
 //!   (conservation, including `max_retransmits: 0` abandonment).
 //!
-//! ## A/B'ing the send-buffer cap
-//! `STRESS_SEND_BUFFER_LIMIT` sets the per-channel send-buffer cap in bytes (`0` =
-//! unbounded); unset uses the library default (16 MiB). The SAME binary serves as both
-//! arms — only the cap differs:
+//! ## A/B'ing the send-buffer limit
+//! `STRESS_SEND_BUFFER_LIMIT` sets the per-channel send-buffer limit in bytes (`0` or
+//! unset = unbounded, the library default). The SAME binary serves as both arms — only
+//! the limit differs. Arm A is the unbounded default; arm B opts into a limit:
 //!
 //!   STRESS_NAIVE_SENDER=1 STRESS_PAIRS=30 STRESS_MB_PER_PAIR=32 poop \
-//!     'env STRESS_SEND_BUFFER_LIMIT=0 ./stress' \
-//!     './stress'
+//!     './stress' \
+//!     'env STRESS_SEND_BUFFER_LIMIT=4194304 ./stress'
 //!
-//! (unbounded → bounded: at the 16 MiB default `peak_rss` drops ~2× (≈−50%); with a
-//! smaller `STRESS_SEND_BUFFER_LIMIT` — e.g. 4 MiB — ~4–5× (≈−78%). Either way the
-//! bounded arm's peak_rss stays flat as the transfer grows, whereas the unbounded arm's
-//! scales with total bytes in flight.)
+//! (unbounded → bounded: the bounded arm's `peak_rss` stays flat as the transfer grows,
+//! whereas the unbounded arm's scales with total bytes in flight. A 16 MiB limit —
+//! Chromium's cap — roughly halves peak RSS on this workload; a smaller 4 MiB limit cuts
+//! it further. See the PR description for the measured numbers.)
 
 use bytes::BytesMut;
 use futures::FutureExt;
@@ -217,12 +218,12 @@ async fn run_pair(
     // Send loop. Two modes:
     //  * default: single-task app-level flow control on `bufferedAmount`
     //    (mirrors data-channels-flow-control).
-    //  * STRESS_NAIVE_SENDER: NO manual flow control — push exactly `target` bytes as
-    //    fast as `send()` accepts them, retrying on `ErrSendBufferFull`. This is the
-    //    realistic "app that never checks bufferedAmount" case: with the send-buffer cap,
-    //    `send()` rejects past the limit so peak queued memory stays bounded; without it,
-    //    the whole transfer piles into the unbounded send pipeline (peak RSS ∝ target).
-    //    Both modes send the same total work, so peak RSS isolates the queue bound.
+    //  * STRESS_NAIVE_SENDER: NO manual flow control — just flood the blocking `send()`.
+    //    This is the realistic "app that never checks bufferedAmount" case: with a
+    //    send-buffer limit configured, `send()` blocks once the channel is at the limit so
+    //    peak queued memory stays bounded; with no limit (the default) it never blocks and
+    //    the whole transfer piles into the send pipeline (peak RSS ∝ target). Both modes
+    //    send the same total work, so peak RSS isolates the queue bound.
     let naive = std::env::var("STRESS_NAIVE_SENDER").is_ok();
     {
         let stop = stop.clone();
@@ -235,13 +236,13 @@ async fn run_pair(
                     break;
                 }
                 if naive {
-                    // Drive to OnOpen first, then flood without consulting bufferedAmount
-                    // until the responder has received `target` and sets `stop`. Keeping
-                    // the send loop running (rather than stopping at exactly `target`
-                    // bytes) guarantees termination even if the unreliable channel drops
-                    // a chunk. With the send-buffer cap, `send()` rejects past the limit
-                    // so peak queued memory stays bounded; without it, the sender races
-                    // far ahead of the receiver and the pipeline balloons.
+                    // Drive to OnOpen first, then flood the blocking `send()` without
+                    // consulting bufferedAmount until the responder has received `target`
+                    // and sets `stop`. Keeping the send loop running (rather than stopping
+                    // at exactly `target` bytes) guarantees termination even if the
+                    // unreliable channel drops a chunk. With a send-buffer limit, `send()`
+                    // blocks at the limit so peak queued memory stays bounded; without one,
+                    // the sender races far ahead of the receiver and the pipeline balloons.
                     if !dc_open {
                         match dc.poll().await {
                             Some(DataChannelEvent::OnOpen) => dc_open = true,
@@ -250,9 +251,10 @@ async fn run_pair(
                         }
                         continue;
                     }
+                    // Blocking send: the library paces us when a limit is set. A real error
+                    // means the channel closed — stop.
                     if dc.send(buf.clone()).await.is_err() {
-                        // ErrSendBufferFull — brief back-off before retrying.
-                        webrtc::runtime::sleep(std::time::Duration::from_millis(1)).await;
+                        break;
                     }
                     continue;
                 }

--- a/examples/data-channels-stress-bench/data-channels-stress-bench.rs
+++ b/examples/data-channels-stress-bench/data-channels-stress-bench.rs
@@ -1,0 +1,393 @@
+//! Multi-pair data-channel stress bench — the reproducible A/B harness for
+//! **send back-pressure** (peak RSS / throughput under N concurrent transfers).
+//!
+//! Creates `STRESS_PAIRS` in-process connection pairs concurrently and pushes
+//! `STRESS_MB_PER_PAIR` MB over an unordered / no-retransmit data channel per pair
+//! (1 KB chunks), then prints an aggregate line (throughput + VmRSS + drain) and
+//! EXITS. Fixed work per run ⇒ a clean `poop` command.
+//!
+//! ## Environment knobs
+//! * `STRESS_PAIRS` (default 10), `STRESS_MB_PER_PAIR` (default 64) — the workload.
+//! * `STRESS_DEDICATED_REACTOR=1` — run each peer's driver on a dedicated reactor
+//!   thread (issue #101).
+//! * `STRESS_NAIVE_SENDER=1` — sender does NO app-level `bufferedAmount` flow
+//!   control; it floods `send()` as fast as it is accepted. This is the realistic
+//!   "app that never checks bufferedAmount" case that send back-pressure defends
+//!   against (a slow reactor/peer would otherwise let the send pipeline grow without
+//!   bound). Without it, the sender self-throttles on `bufferedAmount`.
+//! * `STRESS_DRAIN_CHECK=1` — after the transfer, poll each channel's
+//!   `outstanding_bytes()` and print it, verifying the send counter drains to ~0
+//!   (conservation, including `max_retransmits: 0` abandonment).
+//!
+//! ## A/B'ing the back-pressure gate
+//! The gate's limits are read once from `WEBRTC_SEND_HIGH_WATER_BYTES` /
+//! `WEBRTC_SEND_HARD_CEILING_BYTES` (`0` = unbounded), so the SAME binary serves as
+//! both arms — only the fix differs:
+//!
+//!   STRESS_NAIVE_SENDER=1 STRESS_PAIRS=30 STRESS_MB_PER_PAIR=32 poop \
+//!     'env WEBRTC_SEND_HIGH_WATER_BYTES=0 WEBRTC_SEND_HARD_CEILING_BYTES=0 ./stress' \
+//!     './stress'
+//!
+//! (unbounded → bounded: peak_rss drops ~4×, and stays flat as the transfer grows).
+
+use bytes::BytesMut;
+use futures::FutureExt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{
+    MediaEngine, RTCConfigurationBuilder, RTCIceGatheringState, Registry,
+    register_default_interceptors,
+};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime};
+
+const BUFFERED_LOW: u32 = 512 * 1024; // 512 KB
+const BUFFERED_HIGH: u32 = 1024 * 1024; // 1 MB
+const CHUNK: usize = 1024; // 1 KB messages (max per-message reactor pressure)
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(target_os = "linux")]
+fn vm_rss_kb() -> u64 {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse().ok())
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(target_os = "linux")]
+fn reactor_threads() -> usize {
+    std::fs::read_dir("/proc/self/task")
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| {
+            std::fs::read_to_string(e.path().join("comm"))
+                .map(|c| c.trim() == "webrtc-reactor")
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct GatherHandler {
+    gather_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for GatherHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ResponderHandler {
+    runtime: Arc<dyn Runtime>,
+    gather_tx: Sender<()>,
+    target: usize,
+    received_total: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    done_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for ResponderHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let target = self.target;
+        let received_total = self.received_total.clone();
+        let stop = self.stop.clone();
+        let done_tx = self.done_tx.clone();
+        // Must spawn: returning from on_data_channel unblocks the driver.
+        self.runtime.spawn(Box::pin(async move {
+            let mut got = 0usize;
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        got += msg.data.len();
+                        received_total.fetch_add(msg.data.len(), Ordering::Relaxed);
+                        if got >= target {
+                            stop.store(true, Ordering::Relaxed);
+                            let _ = done_tx.try_send(());
+                            break;
+                        }
+                    }
+                    DataChannelEvent::OnClose | DataChannelEvent::OnError => {
+                        let _ = done_tx.try_send(());
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+// ── Pair setup ────────────────────────────────────────────────────────────────
+
+async fn build_pc(
+    runtime: Arc<dyn Runtime>,
+    dedicated: bool,
+    handler: Arc<dyn PeerConnectionEventHandler>,
+) -> anyhow::Result<Arc<dyn PeerConnection>> {
+    let mut media = MediaEngine::default();
+    media.register_default_codecs()?;
+    let registry = register_default_interceptors(Registry::new(), &mut media)?;
+    let pc = PeerConnectionBuilder::new()
+        .with_configuration(RTCConfigurationBuilder::new().build())
+        .with_media_engine(media)
+        .with_interceptor_registry(registry)
+        .with_handler(handler)
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_dedicated_reactor_thread(dedicated)
+        .build()
+        .await?;
+    Ok(Arc::new(pc) as Arc<dyn PeerConnection>)
+}
+
+/// Build + connect one pair; spawn its flow-controlled send loop and receive-count
+/// loop. Returns both peer connections so the caller keeps them alive.
+async fn run_pair(
+    runtime: Arc<dyn Runtime>,
+    dedicated: bool,
+    target: usize,
+    received_total: Arc<AtomicUsize>,
+    done_tx: Sender<()>,
+) -> anyhow::Result<([Arc<dyn PeerConnection>; 2], Arc<dyn DataChannel>)> {
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Requester
+    let (req_gather_tx, mut req_gather_rx) = channel::<()>(1);
+    let requester = build_pc(
+        runtime.clone(),
+        dedicated,
+        Arc::new(GatherHandler {
+            gather_tx: req_gather_tx,
+        }),
+    )
+    .await?;
+
+    let dc = requester
+        .create_data_channel(
+            "data",
+            Some(RTCDataChannelInit {
+                ordered: false,
+                max_retransmits: Some(0),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    dc.set_buffered_amount_low_threshold(BUFFERED_LOW).await?;
+    dc.set_buffered_amount_high_threshold(BUFFERED_HIGH).await?;
+    let dc_handle = dc.clone();
+
+    // Send loop. Two modes:
+    //  * default: single-task app-level flow control on `bufferedAmount`
+    //    (mirrors data-channels-flow-control).
+    //  * STRESS_NAIVE_SENDER: NO manual flow control — push exactly `target` bytes as
+    //    fast as `send()` accepts them. This is the realistic "app that never checks
+    //    bufferedAmount" case: with send back-pressure, `send()` blocks at the
+    //    high-water mark so peak queued memory stays bounded; without it, the whole
+    //    transfer piles into the unbounded send pipeline (peak RSS ∝ target). Both
+    //    modes send the same total work, so peak RSS isolates the queue bound.
+    let naive = std::env::var("STRESS_NAIVE_SENDER").is_ok();
+    {
+        let stop = stop.clone();
+        runtime.spawn(Box::pin(async move {
+            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let mut dc_open = false;
+            let mut paused = false;
+            loop {
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                if naive {
+                    // Drive to OnOpen first, then flood without consulting bufferedAmount
+                    // until the responder has received `target` and sets `stop`. Keeping
+                    // the send loop running (rather than stopping at exactly `target`
+                    // bytes) guarantees termination even if the unreliable channel drops
+                    // a chunk. With back-pressure, `send()` blocks at the high-water mark
+                    // so peak queued memory stays bounded; without it, the sender races
+                    // far ahead of the receiver and the pipeline balloons.
+                    if !dc_open {
+                        match dc.poll().await {
+                            Some(DataChannelEvent::OnOpen) => dc_open = true,
+                            Some(DataChannelEvent::OnClose) | None => break,
+                            _ => {}
+                        }
+                        continue;
+                    }
+                    if dc.send(buf.clone()).await.is_err() {
+                        // Hard-ceiling rejection — brief back-off before retrying.
+                        webrtc::runtime::sleep(std::time::Duration::from_millis(1)).await;
+                    }
+                    continue;
+                }
+                if dc_open && !paused {
+                    futures::select! {
+                        maybe_event = dc.poll().fuse() => match maybe_event {
+                            Some(DataChannelEvent::OnBufferedAmountHigh) => paused = true,
+                            Some(DataChannelEvent::OnBufferedAmountLow) => paused = false,
+                            Some(DataChannelEvent::OnClose) | None => break,
+                            _ => {}
+                        },
+                        result = dc.send(buf.clone()).fuse() => { let _ = result; }
+                    }
+                } else {
+                    match dc.poll().await {
+                        Some(DataChannelEvent::OnOpen) => dc_open = true,
+                        Some(DataChannelEvent::OnBufferedAmountHigh) => paused = true,
+                        Some(DataChannelEvent::OnBufferedAmountLow) => paused = false,
+                        Some(DataChannelEvent::OnClose) | None => break,
+                        _ => {}
+                    }
+                }
+            }
+        }));
+    }
+
+    let offer = requester.create_offer(None).await?;
+    requester.set_local_description(offer).await?;
+    req_gather_rx.recv().await;
+    let offer_sdp = requester
+        .local_description()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("requester has no local description"))?;
+
+    // Responder
+    let (resp_gather_tx, mut resp_gather_rx) = channel::<()>(1);
+    let responder = build_pc(
+        runtime.clone(),
+        dedicated,
+        Arc::new(ResponderHandler {
+            runtime: runtime.clone(),
+            gather_tx: resp_gather_tx,
+            target,
+            received_total,
+            stop,
+            done_tx,
+        }),
+    )
+    .await?;
+
+    responder.set_remote_description(offer_sdp).await?;
+    let answer = responder.create_answer(None).await?;
+    responder.set_local_description(answer).await?;
+    resp_gather_rx.recv().await;
+    let answer_sdp = responder
+        .local_description()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("responder has no local description"))?;
+    requester.set_remote_description(answer_sdp).await?;
+
+    Ok(([requester, responder], dc_handle))
+}
+
+fn main() -> anyhow::Result<()> {
+    block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
+    let pairs = env_usize("STRESS_PAIRS", 10);
+    let mb_per_pair = env_usize("STRESS_MB_PER_PAIR", 64);
+    let dedicated = std::env::var("STRESS_DEDICATED_REACTOR")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+    let target = mb_per_pair * 1024 * 1024;
+
+    let runtime =
+        default_runtime().ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+    let received_total = Arc::new(AtomicUsize::new(0));
+    let (done_tx, mut done_rx) = channel::<()>(pairs.max(1));
+
+    let start = Instant::now();
+
+    // Set up all pairs (sequential handshake; transfers run concurrently once open).
+    let mut held: Vec<Arc<dyn PeerConnection>> = Vec::with_capacity(pairs * 2);
+    let mut senders: Vec<Arc<dyn DataChannel>> = Vec::with_capacity(pairs);
+    for _ in 0..pairs {
+        let ([a, b], dc) = run_pair(
+            runtime.clone(),
+            dedicated,
+            target,
+            received_total.clone(),
+            done_tx.clone(),
+        )
+        .await?;
+        held.push(a);
+        held.push(b);
+        senders.push(dc);
+    }
+
+    // Wait for every pair to receive its full target.
+    for _ in 0..pairs {
+        done_rx.recv().await;
+    }
+
+    // Conservation check: after the transfer stops, the per-channel send counter
+    // must drain toward 0 as SCTP acks/abandons the last in-flight bytes. A leak
+    // (e.g. abandoned no-retransmit bytes not decremented) would plateau instead.
+    if std::env::var("STRESS_DRAIN_CHECK").is_ok() {
+        for _ in 0..50 {
+            let mut sum = 0usize;
+            for dc in &senders {
+                sum += dc.outstanding_bytes().await.unwrap_or(0);
+            }
+            eprintln!(
+                "DRAIN outstanding_total_MB={:.2}",
+                sum as f64 / (1024.0 * 1024.0)
+            );
+            if sum < 2 * 1024 * 1024 {
+                break;
+            }
+            webrtc::runtime::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    let secs = start.elapsed().as_secs_f64();
+    let total = received_total.load(Ordering::Relaxed);
+    let agg_mbps = (total * 8) as f64 / secs / (1024.0 * 1024.0);
+    let mbytes = total as f64 / (1024.0 * 1024.0);
+
+    #[cfg(target_os = "linux")]
+    eprintln!(
+        "STRESS pairs={pairs} mb_per_pair={mb_per_pair} dedicated={dedicated} \
+         total_MB={mbytes:.1} secs={secs:.3} agg_Mbps={agg_mbps:.1} \
+         reactor_threads={} VmRSS_MB={:.1}",
+        reactor_threads(),
+        vm_rss_kb() as f64 / 1024.0
+    );
+    #[cfg(not(target_os = "linux"))]
+    eprintln!(
+        "STRESS pairs={pairs} mb_per_pair={mb_per_pair} dedicated={dedicated} \
+         total_MB={mbytes:.1} secs={secs:.3} agg_Mbps={agg_mbps:.1}"
+    );
+
+    // Exit without close(): peak RSS/threads reflect the full concurrent footprint,
+    // and we avoid confounding the transfer measurement with teardown.
+    drop(held);
+    Ok(())
+}

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -477,3 +477,83 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::block_on;
+
+    /// A minimal external `DataChannel` implementation that intentionally does **not**
+    /// override [`DataChannel::outstanding_bytes`], so it exercises the trait's default body.
+    ///
+    /// This locks in the compatibility contract the send back-pressure work relies on: adding
+    /// `outstanding_bytes()` to the public trait must not break a downstream `impl DataChannel`
+    /// that predates it, and the default must report `0` — i.e. "no back-pressure signal" — so
+    /// those channels keep compiling and behaving. Every other method is unreachable in this
+    /// test and left `unimplemented!()`.
+    struct DefaultDataChannel;
+
+    #[async_trait::async_trait]
+    impl DataChannel for DefaultDataChannel {
+        async fn label(&self) -> Result<String> {
+            unimplemented!()
+        }
+        async fn ordered(&self) -> Result<bool> {
+            unimplemented!()
+        }
+        async fn max_packet_life_time(&self) -> Result<Option<u16>> {
+            unimplemented!()
+        }
+        async fn max_retransmits(&self) -> Result<Option<u16>> {
+            unimplemented!()
+        }
+        async fn protocol(&self) -> Result<String> {
+            unimplemented!()
+        }
+        async fn negotiated(&self) -> Result<bool> {
+            unimplemented!()
+        }
+        fn id(&self) -> RTCDataChannelId {
+            unimplemented!()
+        }
+        async fn ready_state(&self) -> Result<RTCDataChannelState> {
+            unimplemented!()
+        }
+        async fn buffered_amount_high_threshold(&self) -> Result<u32> {
+            unimplemented!()
+        }
+        async fn set_buffered_amount_high_threshold(&self, _threshold: u32) -> Result<()> {
+            unimplemented!()
+        }
+        async fn buffered_amount_low_threshold(&self) -> Result<u32> {
+            unimplemented!()
+        }
+        async fn set_buffered_amount_low_threshold(&self, _threshold: u32) -> Result<()> {
+            unimplemented!()
+        }
+        // outstanding_bytes(): deliberately NOT overridden — this is the whole point of the test.
+        async fn send(&self, _data: BytesMut) -> Result<()> {
+            unimplemented!()
+        }
+        async fn send_text(&self, _text: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn poll(&self) -> Option<DataChannelEvent> {
+            unimplemented!()
+        }
+        async fn close(&self) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn outstanding_bytes_trait_default_is_zero() {
+        let dc = DefaultDataChannel;
+        let n =
+            block_on(dc.outstanding_bytes()).expect("default outstanding_bytes() must return Ok");
+        assert_eq!(
+            n, 0,
+            "the DataChannel::outstanding_bytes default must report 0 outstanding bytes"
+        );
+    }
+}

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -50,6 +50,7 @@ use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::shared::error::{Error, Result};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 pub use rtc::data_channel::{
@@ -90,13 +91,16 @@ fn send_limits() -> (usize, usize) {
                 None => default,
             }
         };
-        (
-            resolve("WEBRTC_SEND_HIGH_WATER_BYTES", DATA_CHANNEL_SEND_HIGH_WATER),
-            resolve(
-                "WEBRTC_SEND_HARD_CEILING_BYTES",
-                DATA_CHANNEL_SEND_HARD_CEILING,
-            ),
-        )
+        let high_water = resolve("WEBRTC_SEND_HIGH_WATER_BYTES", DATA_CHANNEL_SEND_HIGH_WATER);
+        let hard_ceiling = resolve(
+            "WEBRTC_SEND_HARD_CEILING_BYTES",
+            DATA_CHANNEL_SEND_HARD_CEILING,
+        );
+        // The hard ceiling must never sit below the high-water mark: the admit check
+        // (`outstanding + len <= high_water`) runs before the reject check, so a ceiling
+        // below the mark would admit sends it was meant to reject, silently defeating the
+        // backstop. Clamp so `hard_ceiling >= high_water` regardless of misconfiguration.
+        (high_water, hard_ceiling.max(high_water))
     })
 }
 
@@ -135,7 +139,12 @@ pub trait DataChannel: Send + Sync + 'static {
     /// that SCTP has not yet released (acknowledged or abandoned) — the true
     /// outstanding send-side memory, including bytes still queued in the send
     /// pipeline (unlike `bufferedAmount`, which counts only post-packetization).
-    async fn outstanding_bytes(&self) -> Result<usize>;
+    ///
+    /// Defaults to `0` so external implementors of this trait keep compiling; the
+    /// built-in channel overrides it with the real counter that drives send back-pressure.
+    async fn outstanding_bytes(&self) -> Result<usize> {
+        Ok(0)
+    }
     /// Sends raw binary data on this data channel.
     async fn send(&self, data: BytesMut) -> Result<()>;
     /// Sends text data on this data channel.
@@ -425,6 +434,14 @@ where
         let (high_water, hard_ceiling) = send_limits();
         let len = data.len();
         loop {
+            // Bail if the connection is closing/dropped. Once the driver stops (on the
+            // `Close` event) it no longer drains `outstanding_bytes` or wakes us, and the
+            // channel is not removed from the core map on close, so the re-check below
+            // stays `Some`. Without this a sender parked at the high-water mark would spin
+            // on the 50 ms liveness timer forever; `close()`/`Drop` wake us immediately.
+            if self.inner.closing.load(Ordering::Acquire) {
+                return Err(Error::ErrDataChannelClosed);
+            }
             {
                 let mut peer_connection = self.inner.core.lock().await;
                 let mut dc = peer_connection
@@ -470,6 +487,10 @@ where
         let (high_water, hard_ceiling) = send_limits();
         let len = text.len();
         loop {
+            // See `send`: bail if closing so a parked sender can't hang past teardown.
+            if self.inner.closing.load(Ordering::Acquire) {
+                return Err(Error::ErrDataChannelClosed);
+            }
             {
                 let mut peer_connection = self.inner.core.lock().await;
                 let mut dc = peer_connection

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -46,63 +46,14 @@
 use crate::peer_connection::PeerConnectionRef;
 use crate::runtime::{Mutex, Receiver};
 use bytes::BytesMut;
-use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::shared::error::{Error, Result};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 pub use rtc::data_channel::{
     RTCDataChannelId, RTCDataChannelInit, RTCDataChannelMessage, RTCDataChannelState,
 };
-
-/// Default high-water mark for synchronous data-channel send back-pressure:
-/// [`DataChannel::send`] blocks once this many bytes are outstanding (handed to
-/// `send`/`send_text` but not yet acknowledged or abandoned by SCTP) on the channel.
-/// Chosen well above the ~1 MiB SCTP receive window so steady-state throughput is
-/// unaffected, yet far below the tens-of-MiB/connection an unbounded send path can
-/// otherwise accumulate under a slow reactor or a slow/malicious peer advertising a
-/// tiny receive window. Override with `WEBRTC_SEND_HIGH_WATER_BYTES` (`0` = unbounded).
-const DATA_CHANNEL_SEND_HIGH_WATER: usize = 4 * 1024 * 1024;
-
-/// Default hard ceiling backstop: above this, [`DataChannel::send`] returns
-/// [`Error::ErrSendBufferFull`] instead of blocking, so a counter that ever drifts
-/// upward (a bug, or a torn-down channel) can never hang a sender indefinitely.
-/// Override with `WEBRTC_SEND_HARD_CEILING_BYTES` (`0` = unbounded).
-const DATA_CHANNEL_SEND_HARD_CEILING: usize = 16 * 1024 * 1024;
-
-/// Resolved `(high_water, hard_ceiling)` send back-pressure limits, read once from the
-/// environment (falling back to the defaults above). A value of `0` in either env var
-/// means "unbounded" and is mapped to `usize::MAX`, disabling that gate — this is the
-/// escape hatch for the send-backpressure A/B benchmark and for callers that do their
-/// own flow control. `WEBRTC_SEND_HIGH_WATER_BYTES` / `WEBRTC_SEND_HARD_CEILING_BYTES`.
-fn send_limits() -> (usize, usize) {
-    use std::sync::OnceLock;
-    static LIMITS: OnceLock<(usize, usize)> = OnceLock::new();
-    *LIMITS.get_or_init(|| {
-        let resolve = |key: &str, default: usize| -> usize {
-            match std::env::var(key)
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-            {
-                Some(0) => usize::MAX, // 0 = unbounded
-                Some(n) => n,
-                None => default,
-            }
-        };
-        let high_water = resolve("WEBRTC_SEND_HIGH_WATER_BYTES", DATA_CHANNEL_SEND_HIGH_WATER);
-        let hard_ceiling = resolve(
-            "WEBRTC_SEND_HARD_CEILING_BYTES",
-            DATA_CHANNEL_SEND_HARD_CEILING,
-        );
-        // The hard ceiling must never sit below the high-water mark: the admit check
-        // (`outstanding + len <= high_water`) runs before the reject check, so a ceiling
-        // below the mark would admit sends it was meant to reject, silently defeating the
-        // backstop. Clamp so `hard_ceiling >= high_water` regardless of misconfiguration.
-        (high_water, hard_ceiling.max(high_water))
-    })
-}
 
 /// Object-safe trait exposing all public DataChannel operations.
 ///
@@ -237,22 +188,6 @@ where
             id,
             inner,
             evt_rx: Mutex::new(evt_rx),
-        }
-    }
-
-    /// Park until the channel's send buffer has room under the high-water mark, called
-    /// only on the slow path when a `send` finds the buffer already over the mark.
-    ///
-    /// Holds no lock while waiting: the driver applies SCTP buffer releases
-    /// (acknowledged or abandoned bytes) to the per-channel `outstanding_bytes`
-    /// counter and then wakes `data_channel_backpressure`, so a blocked sender
-    /// re-checks and proceeds as soon as the peer acknowledges data. The 50 ms
-    /// timeout is a lost-wakeup / liveness backstop (and, for a peer that never
-    /// acks, the sender correctly stays blocked rather than buffering unboundedly).
-    async fn await_send_capacity(&self) {
-        futures::select! {
-            _ = self.inner.data_channel_backpressure.notified().fuse() => {}
-            _ = crate::runtime::sleep(Duration::from_millis(50)).fuse() => {}
         }
     }
 }
@@ -411,7 +346,27 @@ where
         Ok(())
     }
 
-    /// Send binary data
+    /// Send binary data.
+    ///
+    /// Non-blocking, like the browser `RTCDataChannel.send()`: it queues the message and
+    /// returns; it never waits for the peer to acknowledge. To bound send-side memory it
+    /// applies a **non-blocking** back-pressure gate — see *Errors*.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::ErrSendBufferFull`] if this message would push the channel's outstanding
+    ///   send bytes (handed to `send`/`send_text` but not yet acknowledged or abandoned by
+    ///   SCTP) past the configured send-buffer limit
+    ///   ([`PeerConnectionBuilder::with_data_channel_send_buffer_limit`], default 16 MiB;
+    ///   set `0` to disable). This mirrors the browser's "throw when the send queue is
+    ///   full". It is **retryable**, but only *after* the buffer drains — an application
+    ///   should pace on the [`OnBufferedAmountLow`](DataChannelEvent::OnBufferedAmountLow)
+    ///   event (see `examples/data-channels-flow-control`) or poll
+    ///   [`outstanding_bytes`](Self::outstanding_bytes) rather than spin. Note `data` is
+    ///   **consumed** on rejection, so retain a clone if you intend to retry.
+    /// - [`Error::ErrDataChannelClosed`] if the channel/connection is closed or closing.
+    ///
+    /// [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`]: crate::peer_connection::PeerConnectionBuilder::with_data_channel_send_buffer_limit
     ///
     /// # Example
     ///
@@ -426,41 +381,36 @@ where
     /// # }
     /// ```
     async fn send(&self, data: BytesMut) -> Result<()> {
-        // Synchronous send back-pressure, folded into the send's own core-lock so the
-        // fast path takes the lock exactly ONCE: check the outstanding-bytes counter
-        // and enqueue atomically. A sender that outruns the drain (slow reactor or
-        // slow/malicious peer) blocks here rather than growing send-side memory without
-        // bound. Only the over-high-water slow path releases the lock and parks.
-        let (high_water, hard_ceiling) = send_limits();
-        let len = data.len();
-        loop {
-            // Bail if the connection is closing/dropped. Once the driver stops (on the
-            // `Close` event) it no longer drains `outstanding_bytes` or wakes us, and the
-            // channel is not removed from the core map on close, so the re-check below
-            // stays `Some`. Without this a sender parked at the high-water mark would spin
-            // on the 50 ms liveness timer forever; `close()`/`Drop` wake us immediately.
-            if self.inner.closing.load(Ordering::Acquire) {
-                return Err(Error::ErrDataChannelClosed);
+        // A closing/closed connection must fail TERMINALLY, not with a retryable
+        // ErrSendBufferFull: once close()/Drop stops the driver it no longer drains
+        // outstanding_bytes, and the channel is not removed from the core map, so an app
+        // retrying on ErrSendBufferFull would loop forever. Return ErrDataChannelClosed at
+        // once (mirrors send()-after-close in the browser).
+        if self.inner.closing.load(Ordering::Acquire) {
+            return Err(Error::ErrDataChannelClosed);
+        }
+        // Non-blocking send back-pressure, folded into the send's own core-lock so the fast
+        // path takes the lock exactly ONCE: check the channel's outstanding-bytes counter
+        // and enqueue atomically. A caller that outruns the drain (a slow reactor, or a
+        // slow/malicious peer advertising a tiny receive window) is rejected with
+        // ErrSendBufferFull rather than growing send-side memory without bound — never
+        // blocking. The limit is applied per-channel and configured connection-wide via
+        // PeerConnectionBuilder::with_data_channel_send_buffer_limit (usize::MAX = unbounded).
+        let limit = self.inner.data_channel_send_buffer_limit;
+        {
+            let mut peer_connection = self.inner.core.lock().await;
+            let mut dc = peer_connection
+                .data_channel(self.id)
+                .ok_or(Error::ErrDataChannelClosed)?;
+            let outstanding = dc.outstanding_bytes();
+            // Reject once the message would push outstanding bytes past the limit — but
+            // always admit onto an empty buffer, so a lone message larger than the limit
+            // can still be sent rather than being permanently rejected. saturating_add so
+            // an unbounded (`usize::MAX`) limit can't overflow.
+            if outstanding != 0 && outstanding.saturating_add(data.len()) > limit {
+                return Err(Error::ErrSendBufferFull);
             }
-            {
-                let mut peer_connection = self.inner.core.lock().await;
-                let mut dc = peer_connection
-                    .data_channel(self.id)
-                    .ok_or(Error::ErrDataChannelClosed)?;
-                let outstanding = dc.outstanding_bytes();
-                // Admit if the buffer is empty (never deadlock a lone oversized message)
-                // or the message fits under the high-water mark, and enqueue under the
-                // same lock. saturating_add so an unbounded (usize::MAX) limit can't overflow.
-                if outstanding == 0 || outstanding.saturating_add(len) <= high_water {
-                    dc.send(data)?;
-                    break;
-                }
-                // Hard ceiling: reject rather than block unboundedly.
-                if outstanding > hard_ceiling {
-                    return Err(Error::ErrSendBufferFull);
-                }
-            }
-            self.await_send_capacity().await;
+            dc.send(data)?;
         }
 
         // Wake the driver so it flushes SCTP output (poll_write) and checks
@@ -469,7 +419,12 @@ where
         Ok(())
     }
 
-    /// Send text data
+    /// Send text data.
+    ///
+    /// Non-blocking. Same back-pressure and error contract as [`send`](Self::send):
+    /// returns [`Error::ErrSendBufferFull`] (retryable, after the buffer drains) once the
+    /// message would exceed the configured send-buffer limit, and
+    /// [`Error::ErrDataChannelClosed`] on a closing/closed channel.
     ///
     /// # Example
     ///
@@ -483,29 +438,22 @@ where
     /// # }
     /// ```
     async fn send_text(&self, text: &str) -> Result<()> {
-        // Same single-lock back-pressure as `send` (see there).
-        let (high_water, hard_ceiling) = send_limits();
-        let len = text.len();
-        loop {
-            // See `send`: bail if closing so a parked sender can't hang past teardown.
-            if self.inner.closing.load(Ordering::Acquire) {
-                return Err(Error::ErrDataChannelClosed);
+        // Same single-lock, non-blocking back-pressure as `send` (see there), including the
+        // terminal-error-on-close guard so a retry loop can't livelock past teardown.
+        if self.inner.closing.load(Ordering::Acquire) {
+            return Err(Error::ErrDataChannelClosed);
+        }
+        let limit = self.inner.data_channel_send_buffer_limit;
+        {
+            let mut peer_connection = self.inner.core.lock().await;
+            let mut dc = peer_connection
+                .data_channel(self.id)
+                .ok_or(Error::ErrDataChannelClosed)?;
+            let outstanding = dc.outstanding_bytes();
+            if outstanding != 0 && outstanding.saturating_add(text.len()) > limit {
+                return Err(Error::ErrSendBufferFull);
             }
-            {
-                let mut peer_connection = self.inner.core.lock().await;
-                let mut dc = peer_connection
-                    .data_channel(self.id)
-                    .ok_or(Error::ErrDataChannelClosed)?;
-                let outstanding = dc.outstanding_bytes();
-                if outstanding == 0 || outstanding.saturating_add(len) <= high_water {
-                    dc.send_text(text)?;
-                    break;
-                }
-                if outstanding > hard_ceiling {
-                    return Err(Error::ErrSendBufferFull);
-                }
-            }
-            self.await_send_capacity().await;
+            dc.send_text(text)?;
         }
 
         self.inner.wake_writes().await;

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -46,13 +46,59 @@
 use crate::peer_connection::PeerConnectionRef;
 use crate::runtime::{Mutex, Receiver};
 use bytes::BytesMut;
+use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::shared::error::{Error, Result};
 use std::sync::Arc;
+use std::time::Duration;
 
 pub use rtc::data_channel::{
     RTCDataChannelId, RTCDataChannelInit, RTCDataChannelMessage, RTCDataChannelState,
 };
+
+/// Default high-water mark for synchronous data-channel send back-pressure:
+/// [`DataChannel::send`] blocks once this many bytes are outstanding (handed to
+/// `send`/`send_text` but not yet acknowledged or abandoned by SCTP) on the channel.
+/// Chosen well above the ~1 MiB SCTP receive window so steady-state throughput is
+/// unaffected, yet far below the tens-of-MiB/connection an unbounded send path can
+/// otherwise accumulate under a slow reactor or a slow/malicious peer advertising a
+/// tiny receive window. Override with `WEBRTC_SEND_HIGH_WATER_BYTES` (`0` = unbounded).
+const DATA_CHANNEL_SEND_HIGH_WATER: usize = 4 * 1024 * 1024;
+
+/// Default hard ceiling backstop: above this, [`DataChannel::send`] returns
+/// [`Error::ErrSendBufferFull`] instead of blocking, so a counter that ever drifts
+/// upward (a bug, or a torn-down channel) can never hang a sender indefinitely.
+/// Override with `WEBRTC_SEND_HARD_CEILING_BYTES` (`0` = unbounded).
+const DATA_CHANNEL_SEND_HARD_CEILING: usize = 16 * 1024 * 1024;
+
+/// Resolved `(high_water, hard_ceiling)` send back-pressure limits, read once from the
+/// environment (falling back to the defaults above). A value of `0` in either env var
+/// means "unbounded" and is mapped to `usize::MAX`, disabling that gate — this is the
+/// escape hatch for the send-backpressure A/B benchmark and for callers that do their
+/// own flow control. `WEBRTC_SEND_HIGH_WATER_BYTES` / `WEBRTC_SEND_HARD_CEILING_BYTES`.
+fn send_limits() -> (usize, usize) {
+    use std::sync::OnceLock;
+    static LIMITS: OnceLock<(usize, usize)> = OnceLock::new();
+    *LIMITS.get_or_init(|| {
+        let resolve = |key: &str, default: usize| -> usize {
+            match std::env::var(key)
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+            {
+                Some(0) => usize::MAX, // 0 = unbounded
+                Some(n) => n,
+                None => default,
+            }
+        };
+        (
+            resolve("WEBRTC_SEND_HIGH_WATER_BYTES", DATA_CHANNEL_SEND_HIGH_WATER),
+            resolve(
+                "WEBRTC_SEND_HARD_CEILING_BYTES",
+                DATA_CHANNEL_SEND_HARD_CEILING,
+            ),
+        )
+    })
+}
 
 /// Object-safe trait exposing all public DataChannel operations.
 ///
@@ -85,6 +131,11 @@ pub trait DataChannel: Send + Sync + 'static {
     async fn buffered_amount_low_threshold(&self) -> Result<u32>;
     /// Sets the buffered amount low threshold in bytes.
     async fn set_buffered_amount_low_threshold(&self, threshold: u32) -> Result<()>;
+    /// Returns the bytes handed to [`send`](Self::send)/[`send_text`](Self::send_text)
+    /// that SCTP has not yet released (acknowledged or abandoned) — the true
+    /// outstanding send-side memory, including bytes still queued in the send
+    /// pipeline (unlike `bufferedAmount`, which counts only post-packetization).
+    async fn outstanding_bytes(&self) -> Result<usize>;
     /// Sends raw binary data on this data channel.
     async fn send(&self, data: BytesMut) -> Result<()>;
     /// Sends text data on this data channel.
@@ -177,6 +228,22 @@ where
             id,
             inner,
             evt_rx: Mutex::new(evt_rx),
+        }
+    }
+
+    /// Park until the channel's send buffer has room under the high-water mark, called
+    /// only on the slow path when a `send` finds the buffer already over the mark.
+    ///
+    /// Holds no lock while waiting: the driver applies SCTP buffer releases
+    /// (acknowledged or abandoned bytes) to the per-channel `outstanding_bytes`
+    /// counter and then wakes `data_channel_backpressure`, so a blocked sender
+    /// re-checks and proceeds as soon as the peer acknowledges data. The 50 ms
+    /// timeout is a lost-wakeup / liveness backstop (and, for a peer that never
+    /// acks, the sender correctly stays blocked rather than buffering unboundedly).
+    async fn await_send_capacity(&self) {
+        futures::select! {
+            _ = self.inner.data_channel_backpressure.notified().fuse() => {}
+            _ = crate::runtime::sleep(Duration::from_millis(50)).fuse() => {}
         }
     }
 }
@@ -312,6 +379,14 @@ where
             .buffered_amount_low_threshold())
     }
 
+    async fn outstanding_bytes(&self) -> Result<usize> {
+        let mut peer_connection = self.inner.core.lock().await;
+        Ok(peer_connection
+            .data_channel(self.id)
+            .ok_or(Error::ErrDataChannelClosed)?
+            .outstanding_bytes())
+    }
+
     /// set_buffered_amount_low_threshold sets the threshold at which the
     /// bufferedAmount is considered to be low.
     async fn set_buffered_amount_low_threshold(&self, threshold: u32) -> Result<()> {
@@ -342,12 +417,33 @@ where
     /// # }
     /// ```
     async fn send(&self, data: BytesMut) -> Result<()> {
-        {
-            let mut peer_connection = self.inner.core.lock().await;
-            peer_connection
-                .data_channel(self.id)
-                .ok_or(Error::ErrDataChannelClosed)?
-                .send(data)?;
+        // Synchronous send back-pressure, folded into the send's own core-lock so the
+        // fast path takes the lock exactly ONCE: check the outstanding-bytes counter
+        // and enqueue atomically. A sender that outruns the drain (slow reactor or
+        // slow/malicious peer) blocks here rather than growing send-side memory without
+        // bound. Only the over-high-water slow path releases the lock and parks.
+        let (high_water, hard_ceiling) = send_limits();
+        let len = data.len();
+        loop {
+            {
+                let mut peer_connection = self.inner.core.lock().await;
+                let mut dc = peer_connection
+                    .data_channel(self.id)
+                    .ok_or(Error::ErrDataChannelClosed)?;
+                let outstanding = dc.outstanding_bytes();
+                // Admit if the buffer is empty (never deadlock a lone oversized message)
+                // or the message fits under the high-water mark, and enqueue under the
+                // same lock. saturating_add so an unbounded (usize::MAX) limit can't overflow.
+                if outstanding == 0 || outstanding.saturating_add(len) <= high_water {
+                    dc.send(data)?;
+                    break;
+                }
+                // Hard ceiling: reject rather than block unboundedly.
+                if outstanding > hard_ceiling {
+                    return Err(Error::ErrSendBufferFull);
+                }
+            }
+            self.await_send_capacity().await;
         }
 
         // Wake the driver so it flushes SCTP output (poll_write) and checks
@@ -370,12 +466,25 @@ where
     /// # }
     /// ```
     async fn send_text(&self, text: &str) -> Result<()> {
-        {
-            let mut peer_connection = self.inner.core.lock().await;
-            peer_connection
-                .data_channel(self.id)
-                .ok_or(Error::ErrDataChannelClosed)?
-                .send_text(text)?;
+        // Same single-lock back-pressure as `send` (see there).
+        let (high_water, hard_ceiling) = send_limits();
+        let len = text.len();
+        loop {
+            {
+                let mut peer_connection = self.inner.core.lock().await;
+                let mut dc = peer_connection
+                    .data_channel(self.id)
+                    .ok_or(Error::ErrDataChannelClosed)?;
+                let outstanding = dc.outstanding_bytes();
+                if outstanding == 0 || outstanding.saturating_add(len) <= high_water {
+                    dc.send_text(text)?;
+                    break;
+                }
+                if outstanding > hard_ceiling {
+                    return Err(Error::ErrSendBufferFull);
+                }
+            }
+            self.await_send_capacity().await;
         }
 
         self.inner.wake_writes().await;

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -46,10 +46,12 @@
 use crate::peer_connection::PeerConnectionRef;
 use crate::runtime::{Mutex, Receiver};
 use bytes::BytesMut;
+use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::shared::error::{Error, Result};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 pub use rtc::data_channel::{
     RTCDataChannelId, RTCDataChannelInit, RTCDataChannelMessage, RTCDataChannelState,
@@ -97,9 +99,51 @@ pub trait DataChannel: Send + Sync + 'static {
         Ok(0)
     }
     /// Sends raw binary data on this data channel.
+    ///
+    /// If a send-buffer limit is configured
+    /// ([`PeerConnectionBuilder::with_data_channel_send_buffer_limit`](crate::peer_connection::PeerConnectionBuilder::with_data_channel_send_buffer_limit)),
+    /// this **blocks** until the channel's outstanding bytes are below the limit, then
+    /// enqueues — mirroring `tokio::mpsc::Sender::send`. With no limit (the default) it
+    /// never blocks. Use [`try_send`](Self::try_send) for the non-blocking variant.
     async fn send(&self, data: BytesMut) -> Result<()>;
     /// Sends text data on this data channel.
+    ///
+    /// Blocking/non-blocking behaviour matches [`send`](Self::send); see there.
     async fn send_text(&self, text: &str) -> Result<()>;
+    /// Waits until this channel can accept more data — its outstanding send bytes are
+    /// below the configured send-buffer limit.
+    ///
+    /// Resolves immediately when no limit is configured (the default) or the buffer is
+    /// already below it. Returns [`Error::ErrDataChannelClosed`] if the channel or
+    /// connection is closing. This is the await-for-capacity primitive that blocking
+    /// [`send`](Self::send) uses internally; call it directly to pace your own sends.
+    ///
+    /// Level-triggered, not a reserved permit: with multiple concurrent senders on one
+    /// channel the limit is a soft bound (each admitted sender may add one in-flight
+    /// message over it) — the same semantics as `bufferedAmount`-based flow control.
+    ///
+    /// Defaults to `Ok(())` so external implementors of this trait keep compiling.
+    async fn writable(&self) -> Result<()> {
+        Ok(())
+    }
+    /// Non-blocking [`send`](Self::send): enqueues `data` and returns at once, or fails
+    /// fast with [`Error::ErrSendBufferFull`] when a send-buffer limit is configured and
+    /// this message would push the channel's outstanding bytes past it. Never waits for
+    /// capacity. Mirrors `tokio::mpsc::Sender::try_send`.
+    ///
+    /// `data` is **consumed** on rejection, so retain a clone if you intend to retry.
+    ///
+    /// Defaults to delegating to [`send`](Self::send) — correct for implementors that do
+    /// not impose a blocking limit, since there `send` is already non-blocking.
+    async fn try_send(&self, data: BytesMut) -> Result<()> {
+        self.send(data).await
+    }
+    /// Non-blocking [`send_text`](Self::send_text); see [`try_send`](Self::try_send).
+    ///
+    /// Defaults to delegating to [`send_text`](Self::send_text).
+    async fn try_send_text(&self, text: &str) -> Result<()> {
+        self.send_text(text).await
+    }
     /// Polls for the next event on this data channel.
     async fn poll(&self) -> Option<DataChannelEvent>;
     /// Closes the data channel.
@@ -188,6 +232,23 @@ where
             id,
             inner,
             evt_rx: Mutex::new(evt_rx),
+        }
+    }
+
+    /// Park until the driver signals send-buffer progress, or a 50 ms liveness backstop
+    /// fires. Called only on the slow path, when [`writable`](DataChannel::writable) finds
+    /// the buffer at/over the limit.
+    ///
+    /// Holds no lock while waiting: the driver applies SCTP buffer releases (acknowledged
+    /// or abandoned bytes) to the per-channel `outstanding_bytes` counter and then wakes
+    /// `data_channel_backpressure`, so a blocked sender re-checks and proceeds as soon as
+    /// the peer acknowledges data. The 50 ms timeout is a lost-wakeup / liveness backstop
+    /// — and, for a peer that never acks, the sender correctly stays blocked (bounding
+    /// send-side memory) while still re-checking `closing` so `close()`/`Drop` release it.
+    async fn await_send_capacity(&self) {
+        futures::select! {
+            _ = self.inner.data_channel_backpressure.notified().fuse() => {}
+            _ = crate::runtime::sleep(Duration::from_millis(50)).fuse() => {}
         }
     }
 }
@@ -348,23 +409,18 @@ where
 
     /// Send binary data.
     ///
-    /// Non-blocking, like the browser `RTCDataChannel.send()`: it queues the message and
-    /// returns; it never waits for the peer to acknowledge. To bound send-side memory it
-    /// applies a **non-blocking** back-pressure gate — see *Errors*.
+    /// Queues the message and returns; it never waits for the peer to acknowledge. When a
+    /// send-buffer limit is configured
+    /// ([`PeerConnectionBuilder::with_data_channel_send_buffer_limit`]) it first **blocks**
+    /// until the channel's outstanding bytes are below the limit — mirroring
+    /// `tokio::mpsc::Sender::send`. With no limit (the default) it never blocks, like the
+    /// browser `RTCDataChannel.send()`. For a non-blocking send that fails fast when the
+    /// buffer is full, use [`try_send`](Self::try_send).
     ///
     /// # Errors
     ///
-    /// - [`Error::ErrSendBufferFull`] if this message would push the channel's outstanding
-    ///   send bytes (handed to `send`/`send_text` but not yet acknowledged or abandoned by
-    ///   SCTP) past the configured send-buffer limit
-    ///   ([`PeerConnectionBuilder::with_data_channel_send_buffer_limit`], default 16 MiB;
-    ///   set `0` to disable). This mirrors the browser's "throw when the send queue is
-    ///   full". It is **retryable**, but only *after* the buffer drains — an application
-    ///   should pace on the [`OnBufferedAmountLow`](DataChannelEvent::OnBufferedAmountLow)
-    ///   event (see `examples/data-channels-flow-control`) or poll
-    ///   [`outstanding_bytes`](Self::outstanding_bytes) rather than spin. Note `data` is
-    ///   **consumed** on rejection, so retain a clone if you intend to retry.
-    /// - [`Error::ErrDataChannelClosed`] if the channel/connection is closed or closing.
+    /// - [`Error::ErrDataChannelClosed`] if the channel/connection is closed or closing —
+    ///   including a caller blocked awaiting capacity when `close()`/`Drop` runs.
     ///
     /// [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`]: crate::peer_connection::PeerConnectionBuilder::with_data_channel_send_buffer_limit
     ///
@@ -381,35 +437,17 @@ where
     /// # }
     /// ```
     async fn send(&self, data: BytesMut) -> Result<()> {
-        // A closing/closed connection must fail TERMINALLY, not with a retryable
-        // ErrSendBufferFull: once close()/Drop stops the driver it no longer drains
-        // outstanding_bytes, and the channel is not removed from the core map, so an app
-        // retrying on ErrSendBufferFull would loop forever. Return ErrDataChannelClosed at
-        // once (mirrors send()-after-close in the browser).
-        if self.inner.closing.load(Ordering::Acquire) {
-            return Err(Error::ErrDataChannelClosed);
-        }
-        // Non-blocking send back-pressure, folded into the send's own core-lock so the fast
-        // path takes the lock exactly ONCE: check the channel's outstanding-bytes counter
-        // and enqueue atomically. A caller that outruns the drain (a slow reactor, or a
-        // slow/malicious peer advertising a tiny receive window) is rejected with
-        // ErrSendBufferFull rather than growing send-side memory without bound — never
-        // blocking. The limit is applied per-channel and configured connection-wide via
-        // PeerConnectionBuilder::with_data_channel_send_buffer_limit (usize::MAX = unbounded).
-        let limit = self.inner.data_channel_send_buffer_limit;
+        // Await capacity, then enqueue. `writable()` is a no-op unless a send-buffer limit
+        // is configured; when one is, it blocks until the channel's outstanding bytes fall
+        // below it. It also returns ErrDataChannelClosed terminally on a closing connection,
+        // so a caller blocked on a stalled peer is released by close()/Drop rather than
+        // buffering unboundedly. Mirrors tokio::mpsc::Sender::send.
+        self.writable().await?;
         {
             let mut peer_connection = self.inner.core.lock().await;
             let mut dc = peer_connection
                 .data_channel(self.id)
                 .ok_or(Error::ErrDataChannelClosed)?;
-            let outstanding = dc.outstanding_bytes();
-            // Reject once the message would push outstanding bytes past the limit — but
-            // always admit onto an empty buffer, so a lone message larger than the limit
-            // can still be sent rather than being permanently rejected. saturating_add so
-            // an unbounded (`usize::MAX`) limit can't overflow.
-            if outstanding != 0 && outstanding.saturating_add(data.len()) > limit {
-                return Err(Error::ErrSendBufferFull);
-            }
             dc.send(data)?;
         }
 
@@ -421,10 +459,10 @@ where
 
     /// Send text data.
     ///
-    /// Non-blocking. Same back-pressure and error contract as [`send`](Self::send):
-    /// returns [`Error::ErrSendBufferFull`] (retryable, after the buffer drains) once the
-    /// message would exceed the configured send-buffer limit, and
-    /// [`Error::ErrDataChannelClosed`] on a closing/closed channel.
+    /// Blocking/non-blocking behaviour and error contract match [`send`](Self::send): with a
+    /// configured send-buffer limit it blocks until the buffer is below the limit, and
+    /// returns [`Error::ErrDataChannelClosed`] on a closing/closed channel. Use
+    /// [`try_send_text`](Self::try_send_text) for the non-blocking variant.
     ///
     /// # Example
     ///
@@ -438,8 +476,86 @@ where
     /// # }
     /// ```
     async fn send_text(&self, text: &str) -> Result<()> {
-        // Same single-lock, non-blocking back-pressure as `send` (see there), including the
-        // terminal-error-on-close guard so a retry loop can't livelock past teardown.
+        // Await capacity, then enqueue — see `send` for the rationale.
+        self.writable().await?;
+        {
+            let mut peer_connection = self.inner.core.lock().await;
+            let mut dc = peer_connection
+                .data_channel(self.id)
+                .ok_or(Error::ErrDataChannelClosed)?;
+            dc.send_text(text)?;
+        }
+
+        self.inner.wake_writes().await;
+        Ok(())
+    }
+
+    async fn writable(&self) -> Result<()> {
+        // Terminal on a closing/closed connection: once close()/Drop stops the driver it no
+        // longer drains outstanding_bytes, so waiting could never make progress. Return
+        // ErrDataChannelClosed at once (mirrors send()-after-close in the browser).
+        if self.inner.closing.load(Ordering::Acquire) {
+            return Err(Error::ErrDataChannelClosed);
+        }
+        let limit = self.inner.data_channel_send_buffer_limit;
+        // Unbounded (the default): every send is admitted, so the channel is always
+        // writable — skip locking the core entirely. This is what keeps `send`/`send_text`
+        // non-blocking and lock-once on the default path.
+        if limit == usize::MAX {
+            return Ok(());
+        }
+        loop {
+            if self.inner.closing.load(Ordering::Acquire) {
+                return Err(Error::ErrDataChannelClosed);
+            }
+            {
+                let mut peer_connection = self.inner.core.lock().await;
+                let outstanding = peer_connection
+                    .data_channel(self.id)
+                    .ok_or(Error::ErrDataChannelClosed)?
+                    .outstanding_bytes();
+                // Below the limit ⇒ writable. An empty buffer (`0 < limit`) also passes, so
+                // a lone message larger than the limit can still be sent rather than
+                // blocking forever.
+                if outstanding < limit {
+                    return Ok(());
+                }
+            } // release the core lock before parking
+            self.await_send_capacity().await;
+        }
+    }
+
+    async fn try_send(&self, data: BytesMut) -> Result<()> {
+        // Non-blocking peer of `send`: same terminal-on-close guard, but instead of awaiting
+        // capacity it fails fast. Back-pressure is folded into the send's own core-lock so
+        // the fast path takes the lock exactly ONCE: peek outstanding_bytes and enqueue
+        // atomically.
+        if self.inner.closing.load(Ordering::Acquire) {
+            return Err(Error::ErrDataChannelClosed);
+        }
+        let limit = self.inner.data_channel_send_buffer_limit;
+        {
+            let mut peer_connection = self.inner.core.lock().await;
+            let mut dc = peer_connection
+                .data_channel(self.id)
+                .ok_or(Error::ErrDataChannelClosed)?;
+            let outstanding = dc.outstanding_bytes();
+            // Reject once the message would push outstanding bytes past the limit — but
+            // always admit onto an empty buffer, so a lone message larger than the limit can
+            // still be sent. saturating_add so an unbounded (`usize::MAX`) limit can't
+            // overflow.
+            if outstanding != 0 && outstanding.saturating_add(data.len()) > limit {
+                return Err(Error::ErrSendBufferFull);
+            }
+            dc.send(data)?;
+        }
+
+        self.inner.wake_writes().await;
+        Ok(())
+    }
+
+    async fn try_send_text(&self, text: &str) -> Result<()> {
+        // Non-blocking peer of `send_text`; see `try_send`.
         if self.inner.closing.load(Ordering::Acquire) {
             return Err(Error::ErrDataChannelClosed);
         }
@@ -482,16 +598,23 @@ where
 mod tests {
     use super::*;
     use crate::runtime::block_on;
+    use std::sync::atomic::AtomicUsize;
 
-    /// A minimal external `DataChannel` implementation that intentionally does **not**
-    /// override [`DataChannel::outstanding_bytes`], so it exercises the trait's default body.
+    /// A minimal external `DataChannel` that overrides only `send`/`send_text` (to record that
+    /// they ran) and leaves `outstanding_bytes`, `writable`, `try_send` and `try_send_text` to
+    /// the trait's **default bodies**.
     ///
-    /// This locks in the compatibility contract the send back-pressure work relies on: adding
-    /// `outstanding_bytes()` to the public trait must not break a downstream `impl DataChannel`
-    /// that predates it, and the default must report `0` — i.e. "no back-pressure signal" — so
-    /// those channels keep compiling and behaving. Every other method is unreachable in this
-    /// test and left `unimplemented!()`.
-    struct DefaultDataChannel;
+    /// This locks in the backward-compatibility contract the send back-pressure work relies on:
+    /// a downstream `impl DataChannel` that predates these methods must keep compiling and get
+    /// sensible defaults — `outstanding_bytes` reports `0` ("no back-pressure signal"),
+    /// `writable` resolves `Ok(())`, and `try_send`/`try_send_text` delegate to `send`/`send_text`
+    /// (correct where `send` is already non-blocking). Every other method is unreachable here and
+    /// left `unimplemented!()`.
+    #[derive(Default)]
+    struct DefaultDataChannel {
+        sends: AtomicUsize,
+        text_sends: AtomicUsize,
+    }
 
     #[async_trait::async_trait]
     impl DataChannel for DefaultDataChannel {
@@ -531,12 +654,15 @@ mod tests {
         async fn set_buffered_amount_low_threshold(&self, _threshold: u32) -> Result<()> {
             unimplemented!()
         }
-        // outstanding_bytes(): deliberately NOT overridden — this is the whole point of the test.
+        // outstanding_bytes(), writable(), try_send(), try_send_text(): deliberately NOT
+        // overridden — exercising the trait defaults is the whole point of this test.
         async fn send(&self, _data: BytesMut) -> Result<()> {
-            unimplemented!()
+            self.sends.fetch_add(1, Ordering::Relaxed);
+            Ok(())
         }
         async fn send_text(&self, _text: &str) -> Result<()> {
-            unimplemented!()
+            self.text_sends.fetch_add(1, Ordering::Relaxed);
+            Ok(())
         }
         async fn poll(&self) -> Option<DataChannelEvent> {
             unimplemented!()
@@ -548,12 +674,42 @@ mod tests {
 
     #[test]
     fn outstanding_bytes_trait_default_is_zero() {
-        let dc = DefaultDataChannel;
+        let dc = DefaultDataChannel::default();
         let n =
             block_on(dc.outstanding_bytes()).expect("default outstanding_bytes() must return Ok");
         assert_eq!(
             n, 0,
             "the DataChannel::outstanding_bytes default must report 0 outstanding bytes"
         );
+    }
+
+    #[test]
+    fn writable_trait_default_is_ok() {
+        let dc = DefaultDataChannel::default();
+        block_on(dc.writable()).expect("the DataChannel::writable default must resolve Ok(())");
+    }
+
+    #[test]
+    fn try_send_trait_default_delegates_to_send() {
+        let dc = DefaultDataChannel::default();
+        block_on(dc.try_send(BytesMut::new())).expect("default try_send() must return Ok");
+        assert_eq!(
+            dc.sends.load(Ordering::Relaxed),
+            1,
+            "the DataChannel::try_send default must delegate to send()"
+        );
+        assert_eq!(dc.text_sends.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn try_send_text_trait_default_delegates_to_send_text() {
+        let dc = DefaultDataChannel::default();
+        block_on(dc.try_send_text("x")).expect("default try_send_text() must return Ok");
+        assert_eq!(
+            dc.text_sends.load(Ordering::Relaxed),
+            1,
+            "the DataChannel::try_send_text default must delegate to send_text()"
+        );
+        assert_eq!(dc.sends.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -204,6 +204,10 @@ where
             self.poll_writes().await?;
             self.poll_events().await;
             self.poll_reads().await?;
+            // Wake senders blocked on send back-pressure: the poll_* passes above
+            // applied any SCTP buffer releases (acks/abandonment) to the per-channel
+            // outstanding_bytes counters, so a blocked send() can re-check and proceed.
+            self.inner.data_channel_backpressure.notify_waiters();
 
             // 4.a poll next timeout
             let timeout = self.poll_timeout().await;

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -116,6 +116,21 @@ where
         })
     }
 
+    /// Mark the connection closing and wake any sender parked in send back-pressure.
+    ///
+    /// Called once the driver's [`event_loop`](Self::event_loop) has returned for ANY reason
+    /// — a clean `close()`/`Drop` (where `closing` is already set) OR an abnormal error exit
+    /// (a fatal SCTP/DTLS error on a timer tick, all UDP sockets gone, …), where nothing has
+    /// set `closing`. Once the driver stops it no longer drains `outstanding_bytes` nor wakes
+    /// `data_channel_backpressure`, so without this a blocking `send()` parked at the
+    /// send-buffer limit would re-park forever. Setting `closing` makes the parked
+    /// [`writable`](crate::data_channel::DataChannel::writable) loop return `ErrDataChannelClosed`
+    /// on its next re-check; the wake makes that immediate. Idempotent on the clean path.
+    pub(crate) fn signal_stopped(&self) {
+        self.inner.closing.store(true, Ordering::Release);
+        self.inner.data_channel_backpressure.notify_waiters();
+    }
+
     /// Run the driver event loop
     ///
     /// This follows rtc Event Loop pattern exactly with select!
@@ -204,6 +219,16 @@ where
             self.poll_writes().await?;
             self.poll_events().await;
             self.poll_reads().await?;
+
+            // Wake senders blocked in `DataChannel::writable()`: the poll_* passes above
+            // applied any SCTP buffer releases (acked/abandoned bytes) to the per-channel
+            // `outstanding_bytes` counters, so a blocked `send()` can re-check and proceed.
+            // Skipped entirely on the default unbounded path — `writable()` never parks when
+            // the limit is `usize::MAX`, so there can be no waiter, and this keeps the
+            // (throughput-sensitive) hot loop free of the per-iteration `Notify` lock.
+            if self.inner.data_channel_send_buffer_limit != usize::MAX {
+                self.inner.data_channel_backpressure.notify_waiters();
+            }
 
             // 4.a poll next timeout
             let timeout = self.poll_timeout().await;

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -204,10 +204,6 @@ where
             self.poll_writes().await?;
             self.poll_events().await;
             self.poll_reads().await?;
-            // Wake senders blocked on send back-pressure: the poll_* passes above
-            // applied any SCTP buffer releases (acks/abandonment) to the per-channel
-            // outstanding_bytes counters, so a blocked send() can re-check and proceed.
-            self.inner.data_channel_backpressure.notify_waiters();
 
             // 4.a poll next timeout
             let timeout = self.poll_timeout().await;

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -161,6 +161,17 @@ pub trait PeerConnectionEventHandler: Send + Sync + 'static {
     async fn on_track(&self, _track: Arc<dyn TrackRemote>) {}
 }
 
+/// Default per-channel data-channel send-buffer limit: [`DataChannel::send`] and
+/// [`DataChannel::send_text`] reject with [`Error::ErrSendBufferFull`] once more than
+/// this many bytes are outstanding (handed to send but not yet acknowledged or
+/// abandoned by SCTP) on a single channel. `16 MiB` matches the browser
+/// `RTCDataChannel` send-queue cap (`webrtc::DataChannelInterface::MaxSendQueueSize`),
+/// well above the ~1 MiB SCTP receive window so a well-behaved sender that paces on
+/// `OnBufferedAmountLow` never hits it, yet a bound against the unbounded send-side
+/// growth a naive or throttled sender would otherwise accumulate. Override (or disable
+/// with `0`) via [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`].
+pub const DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT: usize = 16 * 1024 * 1024;
+
 /// Builder for constructing a [`PeerConnection`].
 ///
 /// Configures the configuration, media engine, setting engine, interceptor registry,
@@ -176,6 +187,7 @@ where
     udp_addrs: Vec<A>,
     tcp_addrs: Vec<A>,
     dedicated_reactor: bool,
+    data_channel_send_buffer_limit: usize,
 }
 
 impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
@@ -188,6 +200,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             udp_addrs: vec![],
             tcp_addrs: vec![],
             dedicated_reactor: false,
+            data_channel_send_buffer_limit: DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT,
         }
     }
 }
@@ -238,6 +251,7 @@ where
             udp_addrs: self.udp_addrs,
             tcp_addrs: self.tcp_addrs,
             dedicated_reactor: self.dedicated_reactor,
+            data_channel_send_buffer_limit: self.data_channel_send_buffer_limit,
         }
     }
 
@@ -289,6 +303,27 @@ where
         self
     }
 
+    /// Sets the data-channel send-buffer limit, in bytes.
+    ///
+    /// [`DataChannel::send`] / [`DataChannel::send_text`] reject with
+    /// [`Error::ErrSendBufferFull`] once a message would push a channel's outstanding
+    /// send bytes (handed to send but not yet acknowledged or abandoned by SCTP) past
+    /// this limit — a non-blocking bound on send-side memory growth, mirroring the
+    /// browser `RTCDataChannel.send()` "throw when the send queue is full" behaviour.
+    /// It never blocks: an application that wants to *wait* for capacity paces on the
+    /// `OnBufferedAmountLow` event or polls [`DataChannel::outstanding_bytes`].
+    ///
+    /// The limit is applied to **each data channel independently**, so a connection
+    /// with `N` channels can hold up to `N × limit` outstanding across all of them —
+    /// size it for a per-channel budget, not a whole-connection cap.
+    ///
+    /// Defaults to [`DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT`] (16 MiB). Pass `0` to
+    /// disable the gate entirely (unbounded) for callers doing their own flow control.
+    pub fn with_data_channel_send_buffer_limit(mut self, bytes: usize) -> Self {
+        self.data_channel_send_buffer_limit = bytes;
+        self
+    }
+
     /// Builds the [`PeerConnection`] and starts the background event loop driver.
     pub async fn build(self) -> Result<impl PeerConnection> {
         let runtime = if let Some(runtime) = self.runtime {
@@ -299,6 +334,14 @@ where
 
         let core = self.builder.build()?;
 
+        // `0` = unbounded; map it to `usize::MAX` so the (never-empty) `saturating_add`
+        // capacity check in `send`/`send_text` becomes a no-op.
+        let data_channel_send_buffer_limit = if self.data_channel_send_buffer_limit == 0 {
+            usize::MAX
+        } else {
+            self.data_channel_send_buffer_limit
+        };
+
         PeerConnectionImpl::new(
             core,
             runtime,
@@ -308,6 +351,7 @@ where
             self.udp_addrs,
             self.tcp_addrs,
             self.dedicated_reactor,
+            data_channel_send_buffer_limit,
         )
         .await
     }
@@ -459,11 +503,12 @@ where
     /// that closes the reactor-thread leak window; the `Close` event is only the
     /// fast wake.
     pub(crate) closing: AtomicBool,
-    /// Woken by the driver once per event-loop iteration after it applies SCTP
-    /// buffer releases (acknowledged/abandoned bytes) to each channel's
-    /// `outstanding_bytes`. A `send()` blocked on the send back-pressure high-water
-    /// waits on this and retries, so it unblocks as soon as the peer acknowledges data.
-    pub(crate) data_channel_backpressure: crate::runtime::Notify,
+    /// Per-channel data-channel send-buffer limit in bytes (`usize::MAX` = unbounded).
+    /// [`DataChannel::send`]/[`send_text`](DataChannel::send_text) reject with
+    /// `ErrSendBufferFull` once a message would push a channel's `outstanding_bytes`
+    /// past this — a non-blocking bound on send-side memory. Set once at build time via
+    /// [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`].
+    pub(crate) data_channel_send_buffer_limit: usize,
     /// Channels for incoming data channel events
     pub(crate) data_channel_events_tx: Mutex<HashMap<RTCDataChannelId, Sender<DataChannelEvent>>>,
     /// Channels for incoming track remote events
@@ -520,6 +565,7 @@ where
     I: Interceptor,
 {
     /// Create a new peer connection with a custom runtime
+    #[allow(clippy::too_many_arguments)] // private constructor fanned out from the builder
     async fn new<A: ToSocketAddrs>(
         core: RTCPeerConnection<I>,
         runtime: Arc<dyn Runtime>,
@@ -528,6 +574,7 @@ where
         udp_addrs: Vec<A>,
         tcp_addrs: Vec<A>,
         dedicated_reactor: bool,
+        data_channel_send_buffer_limit: usize,
     ) -> Result<Self> {
         // Bind the std sockets up front (synchronous, and needed to compute the
         // local addresses used for ICE gathering / SDP). Wrapping them into async
@@ -576,7 +623,7 @@ where
                 write_pending: AtomicBool::new(false),
                 write_backpressure: std::sync::atomic::AtomicUsize::new(0),
                 closing: AtomicBool::new(false),
-                data_channel_backpressure: crate::runtime::Notify::new(),
+                data_channel_send_buffer_limit,
             }),
             driver_handle: Mutex::new(None),
             dedicated_reactor,
@@ -685,9 +732,6 @@ where
         // default lifecycle.)
         if self.dedicated_reactor {
             self.inner.closing.store(true, Ordering::Release);
-            // Wake a sender parked in send back-pressure so it returns promptly instead
-            // of hanging past teardown (mirrors `close`; see the park loop in `send`).
-            self.inner.data_channel_backpressure.notify_waiters();
             let _ = self
                 .inner
                 .driver_event_tx
@@ -709,10 +753,6 @@ where
         // Mark closing before waking the driver, so it stops even if the wake is
         // ever dropped (mirrors `Drop`; see `PeerConnectionRef::closing`).
         self.inner.closing.store(true, Ordering::Release);
-        // Wake any sender parked in data-channel send back-pressure so it observes
-        // `closing` and returns `ErrDataChannelClosed` at once, rather than waiting out
-        // its 50 ms liveness timer — the driver has stopped draining `outstanding_bytes`.
-        self.inner.data_channel_backpressure.notify_waiters();
         // Best-effort wake. A send failure here is benign, not an error:
         // `closing` already guarantees the driver terminates, and it may already
         // have observed the flag and dropped the receiver via its independent

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -685,6 +685,9 @@ where
         // default lifecycle.)
         if self.dedicated_reactor {
             self.inner.closing.store(true, Ordering::Release);
+            // Wake a sender parked in send back-pressure so it returns promptly instead
+            // of hanging past teardown (mirrors `close`; see the park loop in `send`).
+            self.inner.data_channel_backpressure.notify_waiters();
             let _ = self
                 .inner
                 .driver_event_tx
@@ -706,6 +709,10 @@ where
         // Mark closing before waking the driver, so it stops even if the wake is
         // ever dropped (mirrors `Drop`; see `PeerConnectionRef::closing`).
         self.inner.closing.store(true, Ordering::Release);
+        // Wake any sender parked in data-channel send back-pressure so it observes
+        // `closing` and returns `ErrDataChannelClosed` at once, rather than waiting out
+        // its 50 ms liveness timer — the driver has stopped draining `outstanding_bytes`.
+        self.inner.data_channel_backpressure.notify_waiters();
         // Best-effort wake. A send failure here is benign, not an error:
         // `closing` already guarantees the driver terminates, and it may already
         // have observed the flag and dropped the receiver via its independent

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -459,6 +459,11 @@ where
     /// that closes the reactor-thread leak window; the `Close` event is only the
     /// fast wake.
     pub(crate) closing: AtomicBool,
+    /// Woken by the driver once per event-loop iteration after it applies SCTP
+    /// buffer releases (acknowledged/abandoned bytes) to each channel's
+    /// `outstanding_bytes`. A `send()` blocked on the send back-pressure high-water
+    /// waits on this and retries, so it unblocks as soon as the peer acknowledges data.
+    pub(crate) data_channel_backpressure: crate::runtime::Notify,
     /// Channels for incoming data channel events
     pub(crate) data_channel_events_tx: Mutex<HashMap<RTCDataChannelId, Sender<DataChannelEvent>>>,
     /// Channels for incoming track remote events
@@ -571,6 +576,7 @@ where
                 write_pending: AtomicBool::new(false),
                 write_backpressure: std::sync::atomic::AtomicUsize::new(0),
                 closing: AtomicBool::new(false),
+                data_channel_backpressure: crate::runtime::Notify::new(),
             }),
             driver_handle: Mutex::new(None),
             dedicated_reactor,

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -161,17 +161,6 @@ pub trait PeerConnectionEventHandler: Send + Sync + 'static {
     async fn on_track(&self, _track: Arc<dyn TrackRemote>) {}
 }
 
-/// Default per-channel data-channel send-buffer limit: [`DataChannel::send`] and
-/// [`DataChannel::send_text`] reject with [`Error::ErrSendBufferFull`] once more than
-/// this many bytes are outstanding (handed to send but not yet acknowledged or
-/// abandoned by SCTP) on a single channel. `16 MiB` matches the browser
-/// `RTCDataChannel` send-queue cap (`webrtc::DataChannelInterface::MaxSendQueueSize`),
-/// well above the ~1 MiB SCTP receive window so a well-behaved sender that paces on
-/// `OnBufferedAmountLow` never hits it, yet a bound against the unbounded send-side
-/// growth a naive or throttled sender would otherwise accumulate. Override (or disable
-/// with `0`) via [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`].
-pub const DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT: usize = 16 * 1024 * 1024;
-
 /// Builder for constructing a [`PeerConnection`].
 ///
 /// Configures the configuration, media engine, setting engine, interceptor registry,
@@ -200,7 +189,10 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             udp_addrs: vec![],
             tcp_addrs: vec![],
             dedicated_reactor: false,
-            data_channel_send_buffer_limit: DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT,
+            // `usize::MAX` = unbounded: no send back-pressure unless the application
+            // opts in via `with_data_channel_send_buffer_limit`. This keeps `send`/
+            // `send_text` non-blocking by default (zero behaviour change).
+            data_channel_send_buffer_limit: usize::MAX,
         }
     }
 }
@@ -303,22 +295,29 @@ where
         self
     }
 
-    /// Sets the data-channel send-buffer limit, in bytes.
+    /// Sets the per-channel data-channel send-buffer limit, in bytes, opting into send
+    /// back-pressure.
     ///
-    /// [`DataChannel::send`] / [`DataChannel::send_text`] reject with
-    /// [`Error::ErrSendBufferFull`] once a message would push a channel's outstanding
-    /// send bytes (handed to send but not yet acknowledged or abandoned by SCTP) past
-    /// this limit — a non-blocking bound on send-side memory growth, mirroring the
-    /// browser `RTCDataChannel.send()` "throw when the send queue is full" behaviour.
-    /// It never blocks: an application that wants to *wait* for capacity paces on the
-    /// `OnBufferedAmountLow` event or polls [`DataChannel::outstanding_bytes`].
+    /// Once set, a channel's outstanding send bytes (handed to `send`/`send_text` but
+    /// not yet acknowledged or abandoned by SCTP) are bounded by this limit:
     ///
-    /// The limit is applied to **each data channel independently**, so a connection
-    /// with `N` channels can hold up to `N × limit` outstanding across all of them —
-    /// size it for a per-channel budget, not a whole-connection cap.
+    /// - [`DataChannel::send`] / [`DataChannel::send_text`] **block** until the buffer
+    ///   is below the limit, then enqueue — mirroring `tokio::mpsc::Sender::send`.
+    /// - [`DataChannel::try_send`] / [`DataChannel::try_send_text`] instead **fail fast**
+    ///   with [`Error::ErrSendBufferFull`] — mirroring `tokio::mpsc::Sender::try_send`.
+    /// - [`DataChannel::writable`] resolves once the buffer is below the limit.
     ///
-    /// Defaults to [`DEFAULT_DATA_CHANNEL_SEND_BUFFER_LIMIT`] (16 MiB). Pass `0` to
-    /// disable the gate entirely (unbounded) for callers doing their own flow control.
+    /// The limit is applied to **each data channel independently**, so a connection with
+    /// `N` channels can hold up to `N × limit` outstanding across all of them — size it
+    /// for a per-channel budget, not a whole-connection cap.
+    ///
+    /// **Default: `usize::MAX` (unbounded)** — no back-pressure, and `send`/`send_text`
+    /// never block, matching the historical behaviour and Safari/Firefox (which impose no
+    /// send-queue cap). Passing `0` is also treated as unbounded. As a reference point,
+    /// Chromium caps its `RTCDataChannel` send queue at 16 MiB
+    /// (`webrtc::DataChannelInterface::MaxSendQueueSize`); `16 * 1024 * 1024` is a
+    /// reasonable browser-like value, well above the ~1 MiB SCTP receive window so a
+    /// sender pacing on `OnBufferedAmountLow` never hits it.
     pub fn with_data_channel_send_buffer_limit(mut self, bytes: usize) -> Self {
         self.data_channel_send_buffer_limit = bytes;
         self
@@ -334,8 +333,8 @@ where
 
         let core = self.builder.build()?;
 
-        // `0` = unbounded; map it to `usize::MAX` so the (never-empty) `saturating_add`
-        // capacity check in `send`/`send_text` becomes a no-op.
+        // `0` = unbounded (same as the `usize::MAX` default); normalise it to `usize::MAX`
+        // so the send-buffer gate (and `writable()`) short-circuits to a no-op.
         let data_channel_send_buffer_limit = if self.data_channel_send_buffer_limit == 0 {
             usize::MAX
         } else {
@@ -503,12 +502,21 @@ where
     /// that closes the reactor-thread leak window; the `Close` event is only the
     /// fast wake.
     pub(crate) closing: AtomicBool,
-    /// Per-channel data-channel send-buffer limit in bytes (`usize::MAX` = unbounded).
-    /// [`DataChannel::send`]/[`send_text`](DataChannel::send_text) reject with
-    /// `ErrSendBufferFull` once a message would push a channel's `outstanding_bytes`
-    /// past this — a non-blocking bound on send-side memory. Set once at build time via
+    /// Per-channel data-channel send-buffer limit in bytes (`usize::MAX` = unbounded,
+    /// the default). When a limit is configured, [`DataChannel::send`]/[`send_text`](DataChannel::send_text)
+    /// block until a channel's `outstanding_bytes` drops below it, and
+    /// [`DataChannel::try_send`]/[`try_send_text`](DataChannel::try_send_text) fail fast with
+    /// `ErrSendBufferFull` — an opt-in bound on send-side memory. Set once at build time via
     /// [`PeerConnectionBuilder::with_data_channel_send_buffer_limit`].
     pub(crate) data_channel_send_buffer_limit: usize,
+    /// Woken by the driver once per event-loop iteration after it applies SCTP buffer
+    /// releases (acknowledged/abandoned bytes) to each channel's `outstanding_bytes`,
+    /// and by `close()`/`Drop`. A [`DataChannel::writable`] future blocked on the
+    /// send-buffer limit waits on this and re-checks, so it unblocks as soon as the
+    /// peer acknowledges data (or the connection closes). Dormant unless a
+    /// `data_channel_send_buffer_limit` is configured — a `usize::MAX` (default) limit
+    /// never parks on it.
+    pub(crate) data_channel_backpressure: crate::runtime::Notify,
     /// Channels for incoming data channel events
     pub(crate) data_channel_events_tx: Mutex<HashMap<RTCDataChannelId, Sender<DataChannelEvent>>>,
     /// Channels for incoming track remote events
@@ -624,6 +632,7 @@ where
                 write_backpressure: std::sync::atomic::AtomicUsize::new(0),
                 closing: AtomicBool::new(false),
                 data_channel_send_buffer_limit,
+                data_channel_backpressure: crate::runtime::Notify::new(),
             }),
             driver_handle: Mutex::new(None),
             dedicated_reactor,
@@ -694,6 +703,11 @@ where
             if let Err(e) = driver.event_loop(driver_event_rx).await {
                 error!("I/O error: {}", e);
             }
+            // The driver has stopped for good (clean shutdown OR an abnormal error exit).
+            // Mark closing and wake any sender parked in send back-pressure, so a blocking
+            // send() cannot hang waiting for a drain that will never come — the driver no
+            // longer drains outstanding_bytes. Idempotent when close()/Drop already set it.
+            driver.signal_stopped();
         };
 
         let driver_handle = if dedicated_reactor {
@@ -732,6 +746,9 @@ where
         // default lifecycle.)
         if self.dedicated_reactor {
             self.inner.closing.store(true, Ordering::Release);
+            // Wake a sender blocked in `DataChannel::writable()` so it returns promptly
+            // instead of waiting out its 50 ms backstop past teardown (mirrors `close`).
+            self.inner.data_channel_backpressure.notify_waiters();
             let _ = self
                 .inner
                 .driver_event_tx
@@ -753,6 +770,10 @@ where
         // Mark closing before waking the driver, so it stops even if the wake is
         // ever dropped (mirrors `Drop`; see `PeerConnectionRef::closing`).
         self.inner.closing.store(true, Ordering::Release);
+        // Wake any sender blocked in `DataChannel::writable()` so it observes `closing`
+        // and returns `ErrDataChannelClosed` at once, rather than waiting out its 50 ms
+        // liveness backstop — the driver has stopped draining `outstanding_bytes`.
+        self.inner.data_channel_backpressure.notify_waiters();
         // Best-effort wake. A send failure here is benign, not an error:
         // `closing` already guarantees the driver terminates, and it may already
         // have observed the flag and dropped the receiver via its independent

--- a/tests/data_channel_close_wakes_send.rs
+++ b/tests/data_channel_close_wakes_send.rs
@@ -1,45 +1,30 @@
-//! Integration test for data-channel send back-pressure (the `outstanding_bytes`
-//! accounting + high-water/hard-ceiling gate in `DataChannel::send`).
+//! Regression test for the send back-pressure close/drop liveness hang.
 //!
-//! A "naive" sender floods a fixed amount over an **unordered / no-retransmit**
-//! (`max_retransmits: 0`) channel — no `bufferedAmount` flow control — while a
-//! normally-draining receiver reads. The test asserts three properties of the
-//! per-channel send counter that the back-pressure fix introduces:
-//!
-//!   1. **Bounded** — `outstanding_bytes()` stays near the high-water mark while the app
-//!      floods (the send gate keeps the pipeline from growing without limit). The flood
-//!      total exceeds the hard ceiling, so an unbounded path would visibly blow the bound;
-//!      the assertion is set below a disabled gate's peak, so it actually guards the gate.
-//!   2. **Conservation** — after the transfer, `outstanding_bytes()` drains back to
-//!      ~0. This is the key correctness property: the counter is decremented both on
-//!      SCTP acknowledgement *and* on `max_retransmits: 0` abandonment (forward-TSN),
-//!      so no path can leak and wedge a sender permanently.
-//!   3. **Delivery** — a substantial fraction of the bytes actually arrive (sanity
-//!      that the flood really flowed, not that `send()` silently no-op'd).
+//! A `DataChannel::send` that is parked in send back-pressure (outstanding bytes at the
+//! high-water mark, waiting for the driver to release SCTP-acked bytes) must be woken and
+//! must return `ErrDataChannelClosed` when the `PeerConnection` is closed — because once
+//! the driver stops on the `Close` event it no longer drains `outstanding_bytes` nor wakes
+//! blocked senders, and the channel is not removed from the core map on close. Without the
+//! fix (a `closing` check in the send park loop + a `notify_waiters()` from `close`/`Drop`)
+//! the parked send spins on its 50 ms liveness timer forever, leaking the producing task
+//! and ~4 MiB. This test floods until a send is parked, closes the PC, and asserts the
+//! send returns promptly rather than hanging.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::error::Error;
 use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
 use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
 const CHUNK: usize = 1024; // 1 KB messages
-// 32 MB naive flood — deliberately larger than the 16 MiB hard ceiling so an *unbounded*
-// (gate-disabled) send path would blow well past any bound, giving Property 1 real teeth.
-const TOTAL_BYTES: usize = 32 * 1024 * 1024;
-// Must match the library defaults in `src/data_channel/mod.rs` (this test does not override
-// the `WEBRTC_SEND_*` env vars, so the defaults are in force).
+// Library default high-water mark (this test does not override `WEBRTC_SEND_*`). A flood
+// of 1 KB chunks over a lossy channel outruns the drain and parks at this mark.
 const HIGH_WATER: usize = 4 * 1024 * 1024;
-// The gate admits only while `outstanding + len <= HIGH_WATER`, so with a 1 KB chunk
-// `outstanding_bytes()` can never exceed HIGH_WATER once the gate is engaged; a small slack
-// covers sampling. Crucially this bound is BELOW the peak a disabled gate reaches (~5 MB+
-// measured), so a regression that removes the back-pressure gate makes this assertion FAIL
-// — unlike a bound at the 16 MiB hard ceiling, which a 32 MB flood never reaches gate-or-not.
-const OUTSTANDING_BOUND: usize = HIGH_WATER + 256 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -81,7 +66,6 @@ impl PeerConnectionEventHandler for ReceiverHandler {
     }
     async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
         let received = self.received.clone();
-        // Must spawn: returning from on_data_channel unblocks the driver.
         self.runtime.spawn(Box::pin(async move {
             while let Some(event) = dc.poll().await {
                 match event {
@@ -97,7 +81,7 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 }
 
 #[test]
-fn test_data_channel_send_backpressure_bounded_and_conserved() {
+fn test_close_wakes_parked_backpressured_send() {
     block_on(run()).unwrap();
 }
 
@@ -138,7 +122,6 @@ async fn run() -> Result<()> {
         )
         .await?;
 
-    // Drive the sender channel to OnOpen.
     let (open_tx, mut open_rx) = channel::<()>(1);
     {
         let dc = dc.clone();
@@ -196,72 +179,59 @@ async fn run() -> Result<()> {
         .await
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
-    // ── Naive flood: push TOTAL_BYTES with NO bufferedAmount flow control ───────
-    let flood_done = Arc::new(AtomicBool::new(false));
+    // ── Flood forever until send() errors ───────────────────────────────────────
+    // Signal is `true` when the terminating error was ErrDataChannelClosed (the expected
+    // wake-on-close), `false` for any other error. If close() fails to wake a parked send,
+    // this task never signals and the timeout below fires — the regression.
+    let (done_tx, mut done_rx) = channel::<bool>(1);
     {
         let dc = dc.clone();
-        let flood_done = flood_done.clone();
         runtime.spawn(Box::pin(async move {
             let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
-            let mut sent = 0usize;
-            while sent < TOTAL_BYTES {
-                if dc.send(buf.clone()).await.is_ok() {
-                    sent += CHUNK;
+            loop {
+                if let Err(e) = dc.send(buf.clone()).await {
+                    let _ = done_tx.try_send(matches!(e, Error::ErrDataChannelClosed));
+                    break;
                 }
             }
-            flood_done.store(true, Ordering::Relaxed);
         }));
     }
 
-    // Sample outstanding_bytes() concurrently: the gate must hold it near the high-water
-    // mark for the whole flood (Property 1 — bounded). This is the assertion that guards
-    // the gate: it is below what a disabled gate reaches, so removing the gate fails here.
-    let mut max_outstanding = 0usize;
-    let deadline_ticks = 600; // 600 * 100ms = 60s cap
-    let mut ticks = 0;
-    while !flood_done.load(Ordering::Relaxed) {
-        let o = dc.outstanding_bytes().await?;
-        max_outstanding = max_outstanding.max(o);
-        assert!(
-            o <= OUTSTANDING_BOUND,
-            "outstanding_bytes {o} exceeded the high-water bound {OUTSTANDING_BOUND} \
-             during flood — the send back-pressure gate is not enforcing the bound"
-        );
-        ticks += 1;
-        assert!(ticks < deadline_ticks, "flood did not complete within 60s");
-        sleep(Duration::from_millis(100)).await;
-    }
-
-    // Property 2 — conservation: after the flood, the counter must drain toward 0
-    // as SCTP acks/abandons the last in-flight bytes. A decrement bug (e.g. abandoned
-    // no-retransmit bytes never released) would plateau here instead of draining.
-    let mut final_outstanding = dc.outstanding_bytes().await?;
-    for _ in 0..100 {
-        final_outstanding = dc.outstanding_bytes().await?;
-        if final_outstanding < 512 * 1024 {
+    // Wait until the sender is parked at the high-water mark. The gate admits only while
+    // `outstanding + CHUNK <= HIGH_WATER`, so a parked sender sits within one chunk of the
+    // mark; require it to climb to there so a send is genuinely blocked when we close.
+    let park_threshold = HIGH_WATER - CHUNK;
+    let mut parked = false;
+    for _ in 0..200 {
+        if dc.outstanding_bytes().await? >= park_threshold {
+            parked = true;
             break;
         }
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(50)).await;
     }
     assert!(
-        final_outstanding < 512 * 1024,
-        "outstanding_bytes did not drain (leak?): {final_outstanding} bytes still outstanding"
+        parked,
+        "sender never reached the high-water mark; the back-pressure path was not exercised"
     );
 
-    // Property 3 — delivery sanity: real bytes flowed (send() wasn't a silent no-op).
-    // This is only a floor: an *unordered / no-retransmit* naive flood legitimately
-    // abandons a large fraction (here ~5 MB of 8 MB was dropped, which is exactly what
-    // exercised the forward-TSN abandonment decrement checked by Property 2), so we do
-    // not assert near-complete delivery — only that a meaningful amount arrived.
-    let got = received.load(Ordering::Relaxed);
-    assert!(
-        got >= TOTAL_BYTES / 8,
-        "receiver only got {got} of {TOTAL_BYTES} bytes (send appears to have no-op'd)"
-    );
-
-    log::info!("send-backpressure: max_outstanding={max_outstanding} received={got}");
-
+    // Close the sender PC. A parked send() must wake and return within the timeout; without
+    // the fix it spins on its 50 ms liveness timer forever and this recv times out.
     sender_pc.close().await?;
+
+    let was_closed_err = timeout(Duration::from_secs(5), done_rx.recv())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "BUG: a back-pressured send() did not return after close() — liveness hang"
+            )
+        })?
+        .ok_or_else(|| anyhow::anyhow!("flood task ended without reporting an error"))?;
+
+    assert!(
+        was_closed_err,
+        "parked send() returned an error other than ErrDataChannelClosed after close()"
+    );
+
     receiver_pc.close().await?;
     Ok(())
 }

--- a/tests/data_channel_close_wakes_send.rs
+++ b/tests/data_channel_close_wakes_send.rs
@@ -7,8 +7,9 @@
 //! blocked senders, and the channel is not removed from the core map on close. Without the
 //! fix (a `closing` check in the send park loop + a `notify_waiters()` from `close`/`Drop`)
 //! the parked send spins on its 50 ms liveness timer forever, leaking the producing task
-//! and ~4 MiB. This test floods until a send is parked, closes the PC, and asserts the
-//! send returns promptly rather than hanging.
+//! and the outstanding send bytes (~4 MiB at the default high-water mark). This test forces
+//! a small high-water so a send parks deterministically, closes the PC, and asserts the send
+//! returns promptly rather than hanging.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;

--- a/tests/data_channel_close_wakes_send.rs
+++ b/tests/data_channel_close_wakes_send.rs
@@ -22,9 +22,12 @@ use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
 const CHUNK: usize = 1024; // 1 KB messages
-// Library default high-water mark (this test does not override `WEBRTC_SEND_*`). A flood
-// of 1 KB chunks over a lossy channel outruns the drain and parks at this mark.
-const HIGH_WATER: usize = 4 * 1024 * 1024;
+// Small send high-water forced via `WEBRTC_SEND_HIGH_WATER_BYTES` in the test entry point
+// (must match). A low mark makes the gate engage — and a send genuinely PARK — deterministically
+// on every runtime: with the 4 MiB default the smol runtime self-limits the send pipeline to
+// ~3.4 MiB, so the sender never reaches the mark and never parks, and this test can't exercise
+// the wake-on-close path it exists to guard.
+const HIGH_WATER: usize = 256 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -82,6 +85,13 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 
 #[test]
 fn test_close_wakes_parked_backpressured_send() {
+    // Force a low send high-water so the gate engages and a send deterministically PARKS on every
+    // runtime (see the HIGH_WATER note). `send_limits()` reads this once, on the first send(), so
+    // setting it before `block_on` is in force. Safe: this is the only test in this binary, so no
+    // other thread is reading the environment concurrently.
+    unsafe {
+        std::env::set_var("WEBRTC_SEND_HIGH_WATER_BYTES", HIGH_WATER.to_string());
+    }
     block_on(run()).unwrap();
 }
 
@@ -197,10 +207,10 @@ async fn run() -> Result<()> {
         }));
     }
 
-    // Wait until the sender is parked at the high-water mark. The gate admits only while
-    // `outstanding + CHUNK <= HIGH_WATER`, so a parked sender sits within one chunk of the
-    // mark; require it to climb to there so a send is genuinely blocked when we close.
-    let park_threshold = HIGH_WATER - CHUNK;
+    // Wait until the send pipeline has climbed into the gated band (within a couple of chunks of
+    // the low high-water mark), so the gate is engaged and a send is parked (or one send away from
+    // it) when we close — the state whose wake-on-close this test guards.
+    let park_threshold = HIGH_WATER - 2 * CHUNK;
     let mut parked = false;
     for _ in 0..200 {
         if dc.outstanding_bytes().await? >= park_threshold {

--- a/tests/data_channel_close_wakes_send.rs
+++ b/tests/data_channel_close_wakes_send.rs
@@ -1,24 +1,20 @@
-//! Regression test for the send-cap **terminal-error-on-close** property across every send
-//! method.
+//! Regression test for the blocking send back-pressure close/drop liveness hang.
 //!
-//! After `PeerConnection::close()` the driver stops draining each channel's
-//! `outstanding_bytes`, and the core does not remove the channel from its map — so if a
-//! channel's outstanding bytes are pinned at the send-buffer limit (the steady state of a
-//! naive flood), a `try_send()` that only checked the capacity gate would return the
-//! *retryable* `ErrSendBufferFull` forever, and an application retrying on it (the documented
-//! pattern) would livelock as a leaked task; likewise a blocking `send()`/`writable()` would
-//! wait for a drain that never comes. All of `send`/`send_text`/`try_send`/`try_send_text`/
-//! `writable` therefore check the `closing` flag first and fail *terminally* with
-//! `ErrDataChannelClosed`.
+//! When a send-buffer limit is configured, a `DataChannel::send` that is parked in
+//! back-pressure (outstanding bytes at the limit, waiting via `writable()` for the driver
+//! to release SCTP-acked bytes) must be woken and must return `ErrDataChannelClosed` when
+//! the `PeerConnection` is closed — because once the driver stops on the `Close` event it no
+//! longer drains `outstanding_bytes` nor wakes blocked senders, and the channel is not
+//! removed from the core map on close. Without the fix (a `closing` check in `writable()`'s
+//! park loop + a `notify_waiters()` from `close`/`Drop`) the parked send spins on its 50 ms
+//! liveness backstop forever, leaking the producing task and the outstanding send bytes.
 //!
-//! This is the fresh-call companion to `data_channel_close_wakes_send.rs`, which covers a
-//! send *already parked* in back-pressure when close runs.
-//!
-//! The test floods (via the non-blocking `try_send`) until the cap engages
-//! (`ErrSendBufferFull` observed ⇒ outstanding pinned at the limit), closes the connection,
-//! then asserts a subsequent `send`, `send_text`, `try_send`, `try_send_text` and `writable`
-//! all return `ErrDataChannelClosed` — NOT `ErrSendBufferFull` (which a retry loop would spin
-//! on) and NOT `Ok`. Deleting the `closing` guard makes this FAIL.
+//! This test builds the connection with a small `with_data_channel_send_buffer_limit` so a
+//! send parks deterministically on every runtime (a low limit — below the ~1 MiB SCTP
+//! window — makes the gate engage regardless of scheduling; with an unbounded limit `send`
+//! never parks and this path can't be exercised), floods with the blocking `send()`, waits
+//! until outstanding has climbed into the gated band, closes the PC, and asserts the send
+//! returns `ErrDataChannelClosed` promptly rather than hanging.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
@@ -29,12 +25,15 @@ use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
 use webrtc::error::Error;
 use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
 use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
-use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, timeout};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
-const CHUNK: usize = 1024;
-// Tiny send-buffer limit so a short naive flood deterministically fills it and the cap
-// engages (a send returns ErrSendBufferFull), pinning outstanding at the limit.
-const SEND_LIMIT: usize = 64 * 1024;
+const CHUNK: usize = 1024; // 1 KB messages
+// Small per-channel send-buffer limit, forced via the builder. A low limit — below the
+// ~1 MiB SCTP receive window — makes the gate engage and a `send()` genuinely PARK
+// deterministically on every runtime: with an unbounded (default) limit the sender never
+// reaches the mark and never parks, so this test could not exercise the wake-on-close path
+// it exists to guard.
+const SEND_LIMIT: usize = 256 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -91,7 +90,7 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 }
 
 #[test]
-fn test_data_channel_send_after_close_is_terminal() {
+fn test_close_wakes_parked_backpressured_send() {
     block_on(run()).unwrap();
 }
 
@@ -110,6 +109,7 @@ async fn run() -> Result<()> {
     let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
     let received = Arc::new(AtomicUsize::new(0));
 
+    // ── Sender (with a small send-buffer limit so send() parks deterministically) ─
     let sender_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(GatherHandler {
             gather_tx: snd_gather_tx,
@@ -123,7 +123,7 @@ async fn run() -> Result<()> {
 
     let dc = sender_pc
         .create_data_channel(
-            "after-close",
+            "backpressure",
             Some(RTCDataChannelInit {
                 ordered: false,
                 max_retransmits: Some(0),
@@ -156,6 +156,7 @@ async fn run() -> Result<()> {
         .await
         .expect("sender local description");
 
+    // ── Receiver ──────────────────────────────────────────────────────────────
     let receiver_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(ReceiverHandler {
             gather_tx: rcv_gather_tx,
@@ -188,68 +189,58 @@ async fn run() -> Result<()> {
         .await
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
-    // Flood (non-blocking) until the cap engages: a try_send returning ErrSendBufferFull
-    // proves outstanding is pinned at SEND_LIMIT — the exact state in which, post-close, a
-    // capacity-only gate would keep returning ErrSendBufferFull forever. (Uses try_send, not
-    // the blocking send, so a full buffer rejects here rather than parking.)
-    let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
-    let mut hit_full = false;
-    for _ in 0..200_000 {
-        match dc.try_send(buf.clone()).await {
-            Ok(()) => {}
-            Err(Error::ErrSendBufferFull) => {
-                hit_full = true;
-                break;
+    // ── Flood forever with the BLOCKING send() until it errors ──────────────────
+    // Signal is `true` when the terminating error was ErrDataChannelClosed (the expected
+    // wake-on-close), `false` for any other error. If close() fails to wake a parked send,
+    // this task never signals and the timeout below fires — the regression.
+    let (done_tx, mut done_rx) = channel::<bool>(1);
+    {
+        let dc = dc.clone();
+        runtime.spawn(Box::pin(async move {
+            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            loop {
+                if let Err(e) = dc.send(buf.clone()).await {
+                    let _ = done_tx.try_send(matches!(e, Error::ErrDataChannelClosed));
+                    break;
+                }
             }
-            Err(e) => return Err(anyhow::anyhow!("unexpected send error before close: {e:?}")),
+        }));
+    }
+
+    // Wait until the send pipeline has climbed into the gated band (within a couple of chunks
+    // of the limit), so the gate is engaged and a send is parked (or one send away from it)
+    // when we close — the state whose wake-on-close this test guards.
+    let park_threshold = SEND_LIMIT - 2 * CHUNK;
+    let mut parked = false;
+    for _ in 0..200 {
+        if dc.outstanding_bytes().await? >= park_threshold {
+            parked = true;
+            break;
         }
+        sleep(Duration::from_millis(50)).await;
     }
     assert!(
-        hit_full,
-        "cap never engaged during the pre-close flood — cannot exercise the pinned-buffer \
-         terminal-close path"
+        parked,
+        "sender never reached the send-buffer limit; the back-pressure path was not exercised"
     );
 
-    // Close the sender. The driver stops draining outstanding_bytes; the channel stays in
-    // the core map, so a capacity-only gate would still see outstanding pinned at the limit.
+    // Close the sender PC. A parked send() must wake and return within the timeout; without
+    // the fix it spins on its 50 ms liveness backstop forever and this recv times out.
     sender_pc.close().await?;
 
-    // Every send method after close must fail TERMINALLY with ErrDataChannelClosed — not the
-    // retryable ErrSendBufferFull (which a retry loop would spin on forever), not a park that
-    // never wakes, and not Ok.
-    match dc.send(buf.clone()).await {
-        Err(Error::ErrDataChannelClosed) => {}
-        Err(Error::ErrSendBufferFull) => panic!(
-            "send() after close returned the retryable ErrSendBufferFull (outstanding is \
-             pinned and never drains post-close ⇒ a retry loop livelocks); expected the \
-             terminal ErrDataChannelClosed"
-        ),
-        other => panic!("send() after close returned {other:?}; expected ErrDataChannelClosed"),
-    }
-    match dc.send_text("x").await {
-        Err(Error::ErrDataChannelClosed) => {}
-        other => {
-            panic!("send_text() after close returned {other:?}; expected ErrDataChannelClosed")
-        }
-    }
-    match dc.try_send(buf.clone()).await {
-        Err(Error::ErrDataChannelClosed) => {}
-        other => {
-            panic!("try_send() after close returned {other:?}; expected ErrDataChannelClosed")
-        }
-    }
-    match dc.try_send_text("x").await {
-        Err(Error::ErrDataChannelClosed) => {}
-        other => {
-            panic!("try_send_text() after close returned {other:?}; expected ErrDataChannelClosed")
-        }
-    }
-    // writable() must also fail terminally rather than block forever waiting for a drain that
-    // the stopped driver will never deliver.
-    match dc.writable().await {
-        Err(Error::ErrDataChannelClosed) => {}
-        other => panic!("writable() after close returned {other:?}; expected ErrDataChannelClosed"),
-    }
+    let was_closed_err = timeout(Duration::from_secs(5), done_rx.recv())
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "BUG: a back-pressured send() did not return after close() — liveness hang"
+            )
+        })?
+        .ok_or_else(|| anyhow::anyhow!("flood task ended without reporting an error"))?;
+
+    assert!(
+        was_closed_err,
+        "parked send() returned an error other than ErrDataChannelClosed after close()"
+    );
 
     receiver_pc.close().await?;
     Ok(())

--- a/tests/data_channel_send_after_close.rs
+++ b/tests/data_channel_send_after_close.rs
@@ -1,15 +1,20 @@
-//! Regression test for the send back-pressure close/drop liveness hang.
+//! Regression test for the non-blocking send-cap **terminal-error-on-close** property.
 //!
-//! A `DataChannel::send` that is parked in send back-pressure (outstanding bytes at the
-//! high-water mark, waiting for the driver to release SCTP-acked bytes) must be woken and
-//! must return `ErrDataChannelClosed` when the `PeerConnection` is closed — because once
-//! the driver stops on the `Close` event it no longer drains `outstanding_bytes` nor wakes
-//! blocked senders, and the channel is not removed from the core map on close. Without the
-//! fix (a `closing` check in the send park loop + a `notify_waiters()` from `close`/`Drop`)
-//! the parked send spins on its 50 ms liveness timer forever, leaking the producing task
-//! and the outstanding send bytes (~4 MiB at the default high-water mark). This test forces
-//! a small high-water so a send parks deterministically, closes the PC, and asserts the send
-//! returns promptly rather than hanging.
+//! After `PeerConnection::close()` the driver stops draining each channel's
+//! `outstanding_bytes`, and the core does not remove the channel from its map — so if a
+//! channel's outstanding bytes are pinned at the send-buffer limit (the steady state of a
+//! naive flood), a `send()` that only checked the capacity gate would return the *retryable*
+//! `ErrSendBufferFull` forever, and an application retrying on it (the documented pattern)
+//! would livelock as a leaked task. `send()`/`send_text()` therefore check the `closing`
+//! flag first and fail *terminally* with `ErrDataChannelClosed`.
+//!
+//! This is the non-blocking analog of the old (deleted) close-wakes park-hang test.
+//!
+//! The test floods until the cap engages (`ErrSendBufferFull` observed ⇒ outstanding pinned
+//! at the limit), closes the connection, then asserts a subsequent `send()` and `send_text()`
+//! return `ErrDataChannelClosed` — NOT `ErrSendBufferFull` (which a retry loop would spin on)
+//! and NOT `Ok`. Deleting the `closing` guard makes this FAIL (it returns `ErrSendBufferFull`
+//! with outstanding pinned, or `Ok` if the buffer happened to drain).
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
@@ -20,15 +25,12 @@ use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
 use webrtc::error::Error;
 use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
 use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
-use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, timeout};
 
-const CHUNK: usize = 1024; // 1 KB messages
-// Small send high-water forced via `WEBRTC_SEND_HIGH_WATER_BYTES` in the test entry point
-// (must match). A low mark makes the gate engage — and a send genuinely PARK — deterministically
-// on every runtime: with the 4 MiB default the smol runtime self-limits the send pipeline to
-// ~3.4 MiB, so the sender never reaches the mark and never parks, and this test can't exercise
-// the wake-on-close path it exists to guard.
-const HIGH_WATER: usize = 256 * 1024;
+const CHUNK: usize = 1024;
+// Tiny send-buffer limit so a short naive flood deterministically fills it and the cap
+// engages (a send returns ErrSendBufferFull), pinning outstanding at the limit.
+const SEND_LIMIT: usize = 64 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -85,14 +87,7 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 }
 
 #[test]
-fn test_close_wakes_parked_backpressured_send() {
-    // Force a low send high-water so the gate engages and a send deterministically PARKS on every
-    // runtime (see the HIGH_WATER note). `send_limits()` reads this once, on the first send(), so
-    // setting it before `block_on` is in force. Safe: this is the only test in this binary, so no
-    // other thread is reading the environment concurrently.
-    unsafe {
-        std::env::set_var("WEBRTC_SEND_HIGH_WATER_BYTES", HIGH_WATER.to_string());
-    }
+fn test_data_channel_send_after_close_is_terminal() {
     block_on(run()).unwrap();
 }
 
@@ -111,7 +106,6 @@ async fn run() -> Result<()> {
     let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
     let received = Arc::new(AtomicUsize::new(0));
 
-    // ── Sender ────────────────────────────────────────────────────────────────
     let sender_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(GatherHandler {
             gather_tx: snd_gather_tx,
@@ -119,12 +113,13 @@ async fn run() -> Result<()> {
         }))
         .with_runtime(runtime.clone())
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_data_channel_send_buffer_limit(SEND_LIMIT)
         .build()
         .await?;
 
     let dc = sender_pc
         .create_data_channel(
-            "backpressure",
+            "after-close",
             Some(RTCDataChannelInit {
                 ordered: false,
                 max_retransmits: Some(0),
@@ -157,7 +152,6 @@ async fn run() -> Result<()> {
         .await
         .expect("sender local description");
 
-    // ── Receiver ──────────────────────────────────────────────────────────────
     let receiver_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(ReceiverHandler {
             gather_tx: rcv_gather_tx,
@@ -190,58 +184,48 @@ async fn run() -> Result<()> {
         .await
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
-    // ── Flood forever until send() errors ───────────────────────────────────────
-    // Signal is `true` when the terminating error was ErrDataChannelClosed (the expected
-    // wake-on-close), `false` for any other error. If close() fails to wake a parked send,
-    // this task never signals and the timeout below fires — the regression.
-    let (done_tx, mut done_rx) = channel::<bool>(1);
-    {
-        let dc = dc.clone();
-        runtime.spawn(Box::pin(async move {
-            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
-            loop {
-                if let Err(e) = dc.send(buf.clone()).await {
-                    let _ = done_tx.try_send(matches!(e, Error::ErrDataChannelClosed));
-                    break;
-                }
+    // Flood until the cap engages: a send returning ErrSendBufferFull proves outstanding is
+    // pinned at SEND_LIMIT — the exact state in which, post-close, a capacity-only send()
+    // would keep returning ErrSendBufferFull forever.
+    let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+    let mut hit_full = false;
+    for _ in 0..200_000 {
+        match dc.send(buf.clone()).await {
+            Ok(()) => {}
+            Err(Error::ErrSendBufferFull) => {
+                hit_full = true;
+                break;
             }
-        }));
-    }
-
-    // Wait until the send pipeline has climbed into the gated band (within a couple of chunks of
-    // the low high-water mark), so the gate is engaged and a send is parked (or one send away from
-    // it) when we close — the state whose wake-on-close this test guards.
-    let park_threshold = HIGH_WATER - 2 * CHUNK;
-    let mut parked = false;
-    for _ in 0..200 {
-        if dc.outstanding_bytes().await? >= park_threshold {
-            parked = true;
-            break;
+            Err(e) => return Err(anyhow::anyhow!("unexpected send error before close: {e:?}")),
         }
-        sleep(Duration::from_millis(50)).await;
     }
     assert!(
-        parked,
-        "sender never reached the high-water mark; the back-pressure path was not exercised"
+        hit_full,
+        "cap never engaged during the pre-close flood — cannot exercise the pinned-buffer \
+         terminal-close path"
     );
 
-    // Close the sender PC. A parked send() must wake and return within the timeout; without
-    // the fix it spins on its 50 ms liveness timer forever and this recv times out.
+    // Close the sender. The driver stops draining outstanding_bytes; the channel stays in
+    // the core map, so a capacity-only gate would still see outstanding pinned at the limit.
     sender_pc.close().await?;
 
-    let was_closed_err = timeout(Duration::from_secs(5), done_rx.recv())
-        .await
-        .map_err(|_| {
-            anyhow::anyhow!(
-                "BUG: a back-pressured send() did not return after close() — liveness hang"
-            )
-        })?
-        .ok_or_else(|| anyhow::anyhow!("flood task ended without reporting an error"))?;
-
-    assert!(
-        was_closed_err,
-        "parked send() returned an error other than ErrDataChannelClosed after close()"
-    );
+    // A send()/send_text() after close must fail TERMINALLY with ErrDataChannelClosed — not
+    // the retryable ErrSendBufferFull (which a retry loop would spin on forever) and not Ok.
+    match dc.send(buf.clone()).await {
+        Err(Error::ErrDataChannelClosed) => {}
+        Err(Error::ErrSendBufferFull) => panic!(
+            "send() after close returned the retryable ErrSendBufferFull (outstanding is \
+             pinned and never drains post-close ⇒ a retry loop livelocks); expected the \
+             terminal ErrDataChannelClosed"
+        ),
+        other => panic!("send() after close returned {other:?}; expected ErrDataChannelClosed"),
+    }
+    match dc.send_text("x").await {
+        Err(Error::ErrDataChannelClosed) => {}
+        other => {
+            panic!("send_text() after close returned {other:?}; expected ErrDataChannelClosed")
+        }
+    }
 
     receiver_pc.close().await?;
     Ok(())

--- a/tests/data_channel_send_backpressure.rs
+++ b/tests/data_channel_send_backpressure.rs
@@ -1,21 +1,34 @@
 //! Integration test for data-channel send back-pressure (the `outstanding_bytes`
-//! accounting + high-water/hard-ceiling gate in `DataChannel::send`).
+//! accounting + the **non-blocking** send-buffer cap in `DataChannel::send`).
 //!
 //! A "naive" sender floods a fixed amount over an **unordered / no-retransmit**
 //! (`max_retransmits: 0`) channel — no `bufferedAmount` flow control — while a
-//! normally-draining receiver reads. The test asserts three properties of the
-//! per-channel send counter that the back-pressure fix introduces:
+//! normally-draining receiver reads. The connection is built with a small explicit
+//! send-buffer limit (`with_data_channel_send_buffer_limit`) so the gate engages quickly
+//! and deterministically. The test asserts three properties:
 //!
-//!   1. **Bounded** — `outstanding_bytes()` stays near the high-water mark while the app
-//!      floods (the send gate keeps the pipeline from growing without limit). The flood
-//!      total exceeds the hard ceiling, so an unbounded path would visibly blow the bound;
-//!      the assertion is set below a disabled gate's peak, so it actually guards the gate.
-//!   2. **Conservation** — after the transfer, `outstanding_bytes()` drains back to
-//!      ~0. This is the key correctness property: the counter is decremented both on
-//!      SCTP acknowledgement *and* on `max_retransmits: 0` abandonment (forward-TSN),
-//!      so no path can leak and wedge a sender permanently.
-//!   3. **Delivery** — a substantial fraction of the bytes actually arrive (sanity
-//!      that the flood really flowed, not that `send()` silently no-op'd).
+//!   1. **Bounded** — `outstanding_bytes()` never exceeds the configured limit (plus a
+//!      small slack) while the app floods: the gate rejects with `ErrSendBufferFull`
+//!      rather than letting the send pipeline grow without limit. This is an *upper*
+//!      bound, so it can never fail spuriously when the gate works (the counter is
+//!      hard-capped by construction); it only fails if the gate is removed and the
+//!      pipeline grows past the bound — which is exactly the regression it guards.
+//!   2. **Reject engaged** — at least one `send()` returned `ErrSendBufferFull`. With a
+//!      tiny limit vs a large flood this is deterministic, and it is the strongest teeth:
+//!      deleting the cap makes `send()` never reject, so this fails regardless of how fast
+//!      the peer drains (whereas Property 1 only bites once outstanding actually climbs).
+//!   3. **Conservation** — after the transfer, `outstanding_bytes()` drains well below the
+//!      limit. The counter is decremented both on SCTP acknowledgement *and* on
+//!      `max_retransmits: 0` abandonment (forward-TSN), so no path can leak it.
+//!
+//! App-level receipt is logged but NOT asserted (the unordered/lossy receive path drops
+//! under a starved consumer — end-to-end delivery is proven by the reliable/ordered sibling
+//! `data_channel_send_unbounded.rs`).
+//!
+//! Unlike the old blocking design, `send()`/`send_text()` never park here: a full buffer
+//! is a synchronous `ErrSendBufferFull`, which the naive flood handles by yielding and
+//! retrying (the application's job now). See `examples/data-channels-flow-control` for
+//! the idiomatic `OnBufferedAmountLow`-paced sender that never trips the cap.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
@@ -23,23 +36,27 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::error::Error;
 use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
 use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
-use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+use webrtc::runtime::{
+    Runtime, Sender, block_on, channel, default_runtime, sleep, timeout, yield_now,
+};
 
 const CHUNK: usize = 1024; // 1 KB messages
-// 32 MB naive flood — deliberately larger than the 16 MiB hard ceiling so an *unbounded*
-// (gate-disabled) send path would blow well past any bound, giving Property 1 real teeth.
-const TOTAL_BYTES: usize = 32 * 1024 * 1024;
-// Must match the library defaults in `src/data_channel/mod.rs` (this test does not override
-// the `WEBRTC_SEND_*` env vars, so the defaults are in force).
-const HIGH_WATER: usize = 4 * 1024 * 1024;
-// The gate admits only while `outstanding + len <= HIGH_WATER`, so with a 1 KB chunk
-// `outstanding_bytes()` can never exceed HIGH_WATER once the gate is engaged; a small slack
-// covers sampling. Crucially this bound is BELOW the peak a disabled gate reaches (~5 MB+
-// measured), so a regression that removes the back-pressure gate makes this assertion FAIL
-// — unlike a bound at the 16 MiB hard ceiling, which a 32 MB flood never reaches gate-or-not.
-const OUTSTANDING_BOUND: usize = HIGH_WATER + 256 * 1024;
+// 16 MB naive flood — far larger than the limit below, so an *unbounded* (gate-disabled)
+// send path would grow the pipeline well past the bound, giving Property 1 real teeth.
+const TOTAL_BYTES: usize = 16 * 1024 * 1024;
+// Small explicit per-channel send-buffer limit, forced via the builder. Deliberately tiny
+// (64 KiB) so a 1 KB-chunk flood fills it within a single pre-yield send burst — the gate
+// engages, and therefore `send()` returns `ErrSendBufferFull` at least once, on every
+// runtime regardless of scheduling. That makes the reject assertion below deterministic.
+const SEND_LIMIT: usize = 64 * 1024;
+// The gate admits only while `outstanding + len <= SEND_LIMIT` (or onto an empty buffer),
+// so with 1 KB chunks `outstanding_bytes()` can never exceed SEND_LIMIT once engaged; the
+// 64 KiB slack only covers sampling. This bound is BELOW the peak a disabled gate reaches,
+// so a regression that removes the cap makes this assertion FAIL.
+const OUTSTANDING_BOUND: usize = SEND_LIMIT + 64 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -116,7 +133,7 @@ async fn run() -> Result<()> {
     let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
     let received = Arc::new(AtomicUsize::new(0));
 
-    // ── Sender ────────────────────────────────────────────────────────────────
+    // ── Sender (with an explicit small send-buffer limit) ───────────────────────
     let sender_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(GatherHandler {
             gather_tx: snd_gather_tx,
@@ -124,6 +141,7 @@ async fn run() -> Result<()> {
         }))
         .with_runtime(runtime.clone())
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_data_channel_send_buffer_limit(SEND_LIMIT)
         .build()
         .await?;
 
@@ -197,35 +215,54 @@ async fn run() -> Result<()> {
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
     // ── Naive flood: push TOTAL_BYTES with NO bufferedAmount flow control ───────
+    // A full buffer returns `ErrSendBufferFull` (non-blocking) instead of parking, so the
+    // naive sender yields and retries — never advancing `sent` on a rejection. Any other
+    // error is fatal.
     let flood_done = Arc::new(AtomicBool::new(false));
+    let flood_fatal = Arc::new(AtomicBool::new(false));
+    let rejections = Arc::new(AtomicUsize::new(0));
     {
         let dc = dc.clone();
         let flood_done = flood_done.clone();
+        let flood_fatal = flood_fatal.clone();
+        let rejections = rejections.clone();
         runtime.spawn(Box::pin(async move {
             let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
             let text = "x".repeat(CHUNK);
             let mut sent = 0usize;
             let mut use_text = false;
             while sent < TOTAL_BYTES {
-                // Alternate binary send() and send_text() so the back-pressure gate is
-                // exercised on both send paths (they share the same admit/park logic).
-                let ok = if use_text {
-                    dc.send_text(&text).await.is_ok()
+                // Alternate binary send() and send_text() so the cap is exercised on both
+                // send paths (they share the same admit/reject logic).
+                let res = if use_text {
+                    dc.send_text(&text).await
                 } else {
-                    dc.send(buf.clone()).await.is_ok()
+                    dc.send(buf.clone()).await
                 };
-                if ok {
-                    sent += CHUNK;
+                match res {
+                    Ok(()) => {
+                        sent += CHUNK;
+                        use_text = !use_text;
+                    }
+                    Err(Error::ErrSendBufferFull) => {
+                        rejections.fetch_add(1, Ordering::Relaxed);
+                        // Non-blocking gate: back off and let the driver drain acked bytes.
+                        yield_now().await;
+                    }
+                    Err(e) => {
+                        log::error!("flood: unexpected send error: {e:?}");
+                        flood_fatal.store(true, Ordering::Relaxed);
+                        break;
+                    }
                 }
-                use_text = !use_text;
             }
             flood_done.store(true, Ordering::Relaxed);
         }));
     }
 
-    // Sample outstanding_bytes() concurrently: the gate must hold it near the high-water
-    // mark for the whole flood (Property 1 — bounded). This is the assertion that guards
-    // the gate: it is below what a disabled gate reaches, so removing the gate fails here.
+    // Sample outstanding_bytes() concurrently: the cap must hold it at/under the limit for
+    // the whole flood (Property 1 — bounded). This upper bound cannot fail spuriously when
+    // the gate works (the counter is hard-capped), and fails if the gate is removed.
     let mut max_outstanding = 0usize;
     let deadline_ticks = 600; // 600 * 100ms = 60s cap
     let mut ticks = 0;
@@ -234,42 +271,56 @@ async fn run() -> Result<()> {
         max_outstanding = max_outstanding.max(o);
         assert!(
             o <= OUTSTANDING_BOUND,
-            "outstanding_bytes {o} exceeded the high-water bound {OUTSTANDING_BOUND} \
-             during flood — the send back-pressure gate is not enforcing the bound"
+            "outstanding_bytes {o} exceeded the send-buffer bound {OUTSTANDING_BOUND} \
+             during flood — the non-blocking send cap is not enforcing the bound"
         );
         ticks += 1;
         assert!(ticks < deadline_ticks, "flood did not complete within 60s");
         sleep(Duration::from_millis(100)).await;
     }
+    assert!(
+        !flood_fatal.load(Ordering::Relaxed),
+        "flood hit a non-ErrSendBufferFull send error (see log)"
+    );
 
-    // Property 2 — conservation: after the flood, the counter must drain toward 0
-    // as SCTP acks/abandons the last in-flight bytes. A decrement bug (e.g. abandoned
-    // no-retransmit bytes never released) would plateau here instead of draining.
+    // Property 2 — the reject path actually engaged. A tiny 64 KiB limit against a 16 MB
+    // flood guarantees at least one `ErrSendBufferFull`, so this is deterministic — and it
+    // is the strongest teeth: deleting the cap makes `send()` never reject, so `rejections`
+    // is 0 and this FAILS regardless of how fast the peer drains (unlike the upper bound
+    // above, which only bites once outstanding actually climbs). It also proves `send()`
+    // wasn't a silent no-op (a no-op never fills the buffer, so it never rejects either).
+    let n_rejections = rejections.load(Ordering::Relaxed);
+    assert!(
+        n_rejections > 0,
+        "send() never returned ErrSendBufferFull over a {TOTAL_BYTES}-byte flood at a \
+         {SEND_LIMIT}-byte limit — the non-blocking send cap did not engage"
+    );
+
+    // Property 3 — conservation: after the flood, the counter must drain well below the
+    // limit as SCTP acks/abandons the last in-flight bytes. A decrement bug (e.g. abandoned
+    // no-retransmit bytes never released) would plateau at the ~limit steady state instead.
     let mut final_outstanding = dc.outstanding_bytes().await?;
     for _ in 0..100 {
         final_outstanding = dc.outstanding_bytes().await?;
-        if final_outstanding < 512 * 1024 {
+        if final_outstanding < SEND_LIMIT / 4 {
             break;
         }
         sleep(Duration::from_millis(100)).await;
     }
     assert!(
-        final_outstanding < 512 * 1024,
+        final_outstanding < SEND_LIMIT / 4,
         "outstanding_bytes did not drain (leak?): {final_outstanding} bytes still outstanding"
     );
 
-    // Property 3 — delivery sanity: real bytes flowed (send() wasn't a silent no-op).
-    // This is only a floor: an *unordered / no-retransmit* naive flood legitimately
-    // abandons a large fraction (here ~5 MB of 8 MB was dropped, which is exactly what
-    // exercised the forward-TSN abandonment decrement checked by Property 2), so we do
-    // not assert near-complete delivery — only that a meaningful amount arrived.
+    // App-level receipt is informational only, NOT asserted: this is an unordered /
+    // no-retransmit channel whose built-in receive path hands messages to the app over a
+    // bounded, lossy channel, so a starved consumer (e.g. CI under coverage instrumentation)
+    // legitimately drops app-level messages. End-to-end delivery is proven by the reliable/
+    // ordered sibling test (data_channel_send_unbounded.rs) instead.
     let got = received.load(Ordering::Relaxed);
-    assert!(
-        got >= TOTAL_BYTES / 8,
-        "receiver only got {got} of {TOTAL_BYTES} bytes (send appears to have no-op'd)"
+    log::info!(
+        "send-backpressure: max_outstanding={max_outstanding} rejections={n_rejections} received={got}"
     );
-
-    log::info!("send-backpressure: max_outstanding={max_outstanding} received={got}");
 
     sender_pc.close().await?;
     receiver_pc.close().await?;

--- a/tests/data_channel_send_backpressure.rs
+++ b/tests/data_channel_send_backpressure.rs
@@ -1,0 +1,255 @@
+//! Integration test for data-channel send back-pressure (the `outstanding_bytes`
+//! accounting + high-water/hard-ceiling gate in `DataChannel::send`).
+//!
+//! A "naive" sender floods a fixed amount over an **unordered / no-retransmit**
+//! (`max_retransmits: 0`) channel — no `bufferedAmount` flow control — while a
+//! normally-draining receiver reads. The test asserts three properties of the
+//! per-channel send counter that the back-pressure fix introduces:
+//!
+//!   1. **Bounded** — `outstanding_bytes()` never exceeds the hard ceiling while the
+//!      app floods (the send gate keeps the pipeline from growing without limit).
+//!   2. **Conservation** — after the transfer, `outstanding_bytes()` drains back to
+//!      ~0. This is the key correctness property: the counter is decremented both on
+//!      SCTP acknowledgement *and* on `max_retransmits: 0` abandonment (forward-TSN),
+//!      so no path can leak and wedge a sender permanently.
+//!   3. **Delivery** — a substantial fraction of the bytes actually arrive (sanity
+//!      that the flood really flowed, not that `send()` silently no-op'd).
+use anyhow::Result;
+use bytes::BytesMut;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const CHUNK: usize = 1024; // 1 KB messages
+const TOTAL_BYTES: usize = 8 * 1024 * 1024; // 8 MB naive flood
+// Must match the library defaults in `src/data_channel/mod.rs` (this test does not
+// override the `WEBRTC_SEND_*` env vars, so the defaults are in force).
+const HARD_CEILING: usize = 16 * 1024 * 1024;
+
+struct GatherHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for GatherHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct ReceiverHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    received: Arc<AtomicUsize>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for ReceiverHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let received = self.received.clone();
+        // Must spawn: returning from on_data_channel unblocks the driver.
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        received.fetch_add(msg.data.len(), Ordering::Relaxed);
+                    }
+                    DataChannelEvent::OnClose | DataChannelEvent::OnError => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+#[test]
+fn test_data_channel_send_backpressure_bounded_and_conserved() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let (snd_gather_tx, mut snd_gather_rx) = channel::<()>(1);
+    let (snd_conn_tx, mut snd_conn_rx) = channel::<()>(1);
+    let (rcv_gather_tx, mut rcv_gather_rx) = channel::<()>(1);
+    let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
+    let received = Arc::new(AtomicUsize::new(0));
+
+    // ── Sender ────────────────────────────────────────────────────────────────
+    let sender_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(GatherHandler {
+            gather_tx: snd_gather_tx,
+            connected_tx: snd_conn_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let dc = sender_pc
+        .create_data_channel(
+            "backpressure",
+            Some(RTCDataChannelInit {
+                ordered: false,
+                max_retransmits: Some(0),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    // Drive the sender channel to OnOpen.
+    let (open_tx, mut open_rx) = channel::<()>(1);
+    {
+        let dc = dc.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        let _ = open_tx.try_send(());
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = sender_pc.create_offer(None).await?;
+    sender_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), snd_gather_rx.recv()).await;
+    let offer_sdp = sender_pc
+        .local_description()
+        .await
+        .expect("sender local description");
+
+    // ── Receiver ──────────────────────────────────────────────────────────────
+    let receiver_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(ReceiverHandler {
+            gather_tx: rcv_gather_tx,
+            connected_tx: rcv_conn_tx,
+            received: received.clone(),
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    receiver_pc.set_remote_description(offer_sdp).await?;
+    let answer = receiver_pc.create_answer(None).await?;
+    receiver_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), rcv_gather_rx.recv()).await;
+    let answer_sdp = receiver_pc
+        .local_description()
+        .await
+        .expect("receiver local description");
+    sender_pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), snd_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: sender connect"))?;
+    timeout(Duration::from_secs(5), rcv_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: receiver connect"))?;
+    timeout(Duration::from_secs(10), open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
+
+    // ── Naive flood: push TOTAL_BYTES with NO bufferedAmount flow control ───────
+    let flood_done = Arc::new(AtomicBool::new(false));
+    {
+        let dc = dc.clone();
+        let flood_done = flood_done.clone();
+        runtime.spawn(Box::pin(async move {
+            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let mut sent = 0usize;
+            while sent < TOTAL_BYTES {
+                if dc.send(buf.clone()).await.is_ok() {
+                    sent += CHUNK;
+                }
+            }
+            flood_done.store(true, Ordering::Relaxed);
+        }));
+    }
+
+    // Sample outstanding_bytes() concurrently: it must stay under the hard ceiling
+    // for the whole flood (Property 1 — bounded).
+    let mut max_outstanding = 0usize;
+    let deadline_ticks = 300; // 300 * 100ms = 30s cap
+    let mut ticks = 0;
+    while !flood_done.load(Ordering::Relaxed) {
+        let o = dc.outstanding_bytes().await?;
+        max_outstanding = max_outstanding.max(o);
+        assert!(
+            o <= HARD_CEILING,
+            "outstanding_bytes {o} exceeded hard ceiling {HARD_CEILING} during flood"
+        );
+        ticks += 1;
+        assert!(ticks < deadline_ticks, "flood did not complete within 30s");
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    // Property 2 — conservation: after the flood, the counter must drain toward 0
+    // as SCTP acks/abandons the last in-flight bytes. A decrement bug (e.g. abandoned
+    // no-retransmit bytes never released) would plateau here instead of draining.
+    let mut final_outstanding = dc.outstanding_bytes().await?;
+    for _ in 0..100 {
+        final_outstanding = dc.outstanding_bytes().await?;
+        if final_outstanding < 512 * 1024 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        final_outstanding < 512 * 1024,
+        "outstanding_bytes did not drain (leak?): {final_outstanding} bytes still outstanding"
+    );
+
+    // Property 3 — delivery sanity: real bytes flowed (send() wasn't a silent no-op).
+    // This is only a floor: an *unordered / no-retransmit* naive flood legitimately
+    // abandons a large fraction (here ~5 MB of 8 MB was dropped, which is exactly what
+    // exercised the forward-TSN abandonment decrement checked by Property 2), so we do
+    // not assert near-complete delivery — only that a meaningful amount arrived.
+    let got = received.load(Ordering::Relaxed);
+    assert!(
+        got >= TOTAL_BYTES / 8,
+        "receiver only got {got} of {TOTAL_BYTES} bytes (send appears to have no-op'd)"
+    );
+
+    log::info!("send-backpressure: max_outstanding={max_outstanding} received={got}");
+
+    sender_pc.close().await?;
+    receiver_pc.close().await?;
+    Ok(())
+}

--- a/tests/data_channel_send_backpressure.rs
+++ b/tests/data_channel_send_backpressure.rs
@@ -203,11 +203,21 @@ async fn run() -> Result<()> {
         let flood_done = flood_done.clone();
         runtime.spawn(Box::pin(async move {
             let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let text = "x".repeat(CHUNK);
             let mut sent = 0usize;
+            let mut use_text = false;
             while sent < TOTAL_BYTES {
-                if dc.send(buf.clone()).await.is_ok() {
+                // Alternate binary send() and send_text() so the back-pressure gate is
+                // exercised on both send paths (they share the same admit/park logic).
+                let ok = if use_text {
+                    dc.send_text(&text).await.is_ok()
+                } else {
+                    dc.send(buf.clone()).await.is_ok()
+                };
+                if ok {
                     sent += CHUNK;
                 }
+                use_text = !use_text;
             }
             flood_done.store(true, Ordering::Relaxed);
         }));

--- a/tests/data_channel_send_backpressure.rs
+++ b/tests/data_channel_send_backpressure.rs
@@ -1,11 +1,15 @@
-//! Integration test for data-channel send back-pressure (the `outstanding_bytes`
-//! accounting + the **non-blocking** send-buffer cap in `DataChannel::send`).
+//! Integration test for data-channel send back-pressure via the **non-blocking**
+//! `DataChannel::try_send` / `try_send_text` (the `outstanding_bytes` accounting + the
+//! fail-fast send-buffer cap).
 //!
 //! A "naive" sender floods a fixed amount over an **unordered / no-retransmit**
 //! (`max_retransmits: 0`) channel — no `bufferedAmount` flow control — while a
 //! normally-draining receiver reads. The connection is built with a small explicit
 //! send-buffer limit (`with_data_channel_send_buffer_limit`) so the gate engages quickly
-//! and deterministically. The test asserts three properties:
+//! and deterministically. `try_send`/`try_send_text` are the fail-fast APIs: over the
+//! limit they return `ErrSendBufferFull` immediately rather than blocking (that is
+//! `send`/`send_text`, covered by `data_channel_send_blocking.rs`). The test asserts three
+//! properties:
 //!
 //!   1. **Bounded** — `outstanding_bytes()` never exceeds the configured limit (plus a
 //!      small slack) while the app floods: the gate rejects with `ErrSendBufferFull`
@@ -13,10 +17,10 @@
 //!      bound, so it can never fail spuriously when the gate works (the counter is
 //!      hard-capped by construction); it only fails if the gate is removed and the
 //!      pipeline grows past the bound — which is exactly the regression it guards.
-//!   2. **Reject engaged** — at least one `send()` returned `ErrSendBufferFull`. With a
+//!   2. **Reject engaged** — at least one `try_send()` returned `ErrSendBufferFull`. With a
 //!      tiny limit vs a large flood this is deterministic, and it is the strongest teeth:
-//!      deleting the cap makes `send()` never reject, so this fails regardless of how fast
-//!      the peer drains (whereas Property 1 only bites once outstanding actually climbs).
+//!      deleting the cap makes `try_send()` never reject, so this fails regardless of how
+//!      fast the peer drains (whereas Property 1 only bites once outstanding actually climbs).
 //!   3. **Conservation** — after the transfer, `outstanding_bytes()` drains well below the
 //!      limit. The counter is decremented both on SCTP acknowledgement *and* on
 //!      `max_retransmits: 0` abandonment (forward-TSN), so no path can leak it.
@@ -25,10 +29,10 @@
 //! under a starved consumer — end-to-end delivery is proven by the reliable/ordered sibling
 //! `data_channel_send_unbounded.rs`).
 //!
-//! Unlike the old blocking design, `send()`/`send_text()` never park here: a full buffer
-//! is a synchronous `ErrSendBufferFull`, which the naive flood handles by yielding and
-//! retrying (the application's job now). See `examples/data-channels-flow-control` for
-//! the idiomatic `OnBufferedAmountLow`-paced sender that never trips the cap.
+//! `try_send()`/`try_send_text()` never park: a full buffer is a synchronous
+//! `ErrSendBufferFull`, which the naive flood handles by yielding and retrying. See
+//! `examples/data-channels-flow-control` for the idiomatic `OnBufferedAmountLow`-paced
+//! sender that never trips the cap.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
@@ -215,9 +219,9 @@ async fn run() -> Result<()> {
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
     // ── Naive flood: push TOTAL_BYTES with NO bufferedAmount flow control ───────
-    // A full buffer returns `ErrSendBufferFull` (non-blocking) instead of parking, so the
-    // naive sender yields and retries — never advancing `sent` on a rejection. Any other
-    // error is fatal.
+    // `try_send`/`try_send_text` return `ErrSendBufferFull` (non-blocking) instead of
+    // parking, so the naive sender yields and retries — never advancing `sent` on a
+    // rejection. Any other error is fatal.
     let flood_done = Arc::new(AtomicBool::new(false));
     let flood_fatal = Arc::new(AtomicBool::new(false));
     let rejections = Arc::new(AtomicUsize::new(0));
@@ -232,12 +236,12 @@ async fn run() -> Result<()> {
             let mut sent = 0usize;
             let mut use_text = false;
             while sent < TOTAL_BYTES {
-                // Alternate binary send() and send_text() so the cap is exercised on both
-                // send paths (they share the same admit/reject logic).
+                // Alternate binary try_send() and try_send_text() so the cap is exercised on
+                // both send paths (they share the same admit/reject logic).
                 let res = if use_text {
-                    dc.send_text(&text).await
+                    dc.try_send_text(&text).await
                 } else {
-                    dc.send(buf.clone()).await
+                    dc.try_send(buf.clone()).await
                 };
                 match res {
                     Ok(()) => {
@@ -272,7 +276,7 @@ async fn run() -> Result<()> {
         assert!(
             o <= OUTSTANDING_BOUND,
             "outstanding_bytes {o} exceeded the send-buffer bound {OUTSTANDING_BOUND} \
-             during flood — the non-blocking send cap is not enforcing the bound"
+             during flood — the non-blocking try_send cap is not enforcing the bound"
         );
         ticks += 1;
         assert!(ticks < deadline_ticks, "flood did not complete within 60s");
@@ -285,15 +289,15 @@ async fn run() -> Result<()> {
 
     // Property 2 — the reject path actually engaged. A tiny 64 KiB limit against a 16 MB
     // flood guarantees at least one `ErrSendBufferFull`, so this is deterministic — and it
-    // is the strongest teeth: deleting the cap makes `send()` never reject, so `rejections`
-    // is 0 and this FAILS regardless of how fast the peer drains (unlike the upper bound
-    // above, which only bites once outstanding actually climbs). It also proves `send()`
-    // wasn't a silent no-op (a no-op never fills the buffer, so it never rejects either).
+    // is the strongest teeth: deleting the cap makes `try_send()` never reject, so
+    // `rejections` is 0 and this FAILS regardless of how fast the peer drains (unlike the
+    // upper bound above, which only bites once outstanding actually climbs). It also proves
+    // `try_send()` wasn't a silent no-op (a no-op never fills the buffer, so it never rejects).
     let n_rejections = rejections.load(Ordering::Relaxed);
     assert!(
         n_rejections > 0,
-        "send() never returned ErrSendBufferFull over a {TOTAL_BYTES}-byte flood at a \
-         {SEND_LIMIT}-byte limit — the non-blocking send cap did not engage"
+        "try_send() never returned ErrSendBufferFull over a {TOTAL_BYTES}-byte flood at a \
+         {SEND_LIMIT}-byte limit — the non-blocking try_send cap did not engage"
     );
 
     // Property 3 — conservation: after the flood, the counter must drain well below the

--- a/tests/data_channel_send_blocking.rs
+++ b/tests/data_channel_send_blocking.rs
@@ -1,27 +1,29 @@
-//! Integration test for the send back-pressure **escape hatch**: building a connection with
-//! `with_data_channel_send_buffer_limit(0)` maps the limit to `usize::MAX`, disabling the gate
-//! so a caller that does its own flow control — or the send-backpressure A/B benchmark — runs
-//! with no library-imposed bound. (This is also the default when the limit is left unset, so
-//! the escape hatch and the out-of-the-box behaviour coincide: `send`/`send_text` never block
-//! and never reject.)
+//! Integration test for the **blocking** send back-pressure path: `DataChannel::send` with a
+//! configured `with_data_channel_send_buffer_limit`.
 //!
-//! Complement to `data_channel_send_backpressure.rs`: that test asserts the gate BOUNDS the
-//! pipeline; this one asserts the escape hatch DISABLES it. With the gate off, a naive 32 MB flood
-//! must have EVERY send admitted (return Ok) no matter how far `outstanding_bytes` climbs — the
-//! natural regression (mapping `0` to a literal `0` limit instead of `usize::MAX`) would make the
-//! second send return `ErrSendBufferFull`, which this flood catches on iteration 2. Conservation
-//! still holds — the counter drains back to ~0, and because a reliable/ordered channel has no
-//! abandonment path the counter decrements ONLY on SCTP acknowledgement, so draining to ~0 proves
-//! the peer actually SACKed every byte (real end-to-end delivery, independent of the built-in
-//! receive path's lossy app-delivery channel).
+//! Unlike `try_send` (which fails fast — see `data_channel_send_backpressure.rs`), a blocking
+//! `send()` over a **reliable / ordered** channel with a limit set must (a) never let the
+//! send pipeline grow past the limit, yet (b) still deliver every byte end-to-end, awaiting
+//! capacity as the peer acknowledges rather than dropping or erroring. This is the
+//! `tokio::mpsc::Sender::send`-shaped happy path.
 //!
-//! It deliberately does NOT assert a lower bound on the peak `outstanding_bytes`: messages are
-//! capped at the 256 KiB SCTP max and this stack restores SCTP rwnd at reassembly (not app-consume),
-//! so the sender drains at line rate and a contended CI runner never accumulates a large backlog.
+//! A naive sender floods `TOTAL_BYTES` with the blocking `send()` (no `bufferedAmount`
+//! pacing of its own — the library blocks it) while a normally-draining receiver reads. The
+//! test asserts:
+//!
+//!   1. **Bounded** — a concurrently sampled `outstanding_bytes()` never exceeds the limit
+//!      plus a small slack (one in-flight message) for the whole flood. A regression that
+//!      stopped blocking would let it climb toward the SCTP window and past this bound.
+//!   2. **Delivered + conserved** — after the flood, `outstanding_bytes()` drains to ~0.
+//!      On a reliable/ordered channel the counter decrements ONLY on SCTP acknowledgement
+//!      (no abandonment path), so draining to ~0 proves the blocking sender actually pushed
+//!      every byte through and the peer SACKed it — real end-to-end delivery, and no leak.
+//!
+//! `send()` never returns `ErrSendBufferFull` here (that is `try_send`); any error is fatal.
 use anyhow::Result;
 use bytes::BytesMut;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
@@ -29,9 +31,17 @@ use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnect
 use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
 use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
 
-const CHUNK: usize = 1024; // 1 KB messages
-// Reliable/ordered flood total; large enough to exercise the disabled-gate admit path many times.
-const TOTAL_BYTES: usize = 32 * 1024 * 1024;
+const CHUNK: usize = 4096; // 4 KB messages
+// Reliable/ordered flood total; large enough to keep the blocking gate engaged for a while.
+const TOTAL_BYTES: usize = 8 * 1024 * 1024;
+// Small per-channel send-buffer limit, below the ~1 MiB SCTP window so the blocking gate
+// engages regardless of scheduling.
+const SEND_LIMIT: usize = 256 * 1024;
+// A single sender admits at most one message beyond the limit before it must re-await
+// capacity, so `outstanding_bytes()` can never exceed SEND_LIMIT + CHUNK; the 64 KiB slack
+// only covers sampling. This bound is far below what a non-blocking pipeline would reach, so
+// a regression that stopped blocking makes the bounded assertion FAIL.
+const OUTSTANDING_BOUND: usize = SEND_LIMIT + 64 * 1024;
 
 struct GatherHandler {
     gather_tx: Sender<()>,
@@ -88,9 +98,7 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 }
 
 #[test]
-fn test_data_channel_send_unbounded_escape_hatch() {
-    // The gate is disabled via the builder's documented `0 = unbounded` escape hatch
-    // (`with_data_channel_send_buffer_limit(0)` inside `run`).
+fn test_data_channel_blocking_send_bounded_and_delivered() {
     block_on(run()).unwrap();
 }
 
@@ -109,7 +117,7 @@ async fn run() -> Result<()> {
     let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
     let received = Arc::new(AtomicUsize::new(0));
 
-    // ── Sender ────────────────────────────────────────────────────────────────
+    // ── Sender (with an explicit small send-buffer limit ⇒ blocking send) ───────
     let sender_pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(GatherHandler {
             gather_tx: snd_gather_tx,
@@ -117,16 +125,14 @@ async fn run() -> Result<()> {
         }))
         .with_runtime(runtime.clone())
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
-        // Disable the send-buffer gate: `0` = unbounded (maps the limit to usize::MAX).
-        .with_data_channel_send_buffer_limit(0)
+        .with_data_channel_send_buffer_limit(SEND_LIMIT)
         .build()
         .await?;
 
-    // Reliable + ordered so nothing is abandoned — conservation here is driven purely by SCTP
-    // acknowledgement (no forward-TSN path), a clean complement to the bounded test's unordered/
-    // no-retransmit channel, and the property that lets the drain double as a delivery proof.
+    // Reliable + ordered so nothing is abandoned — conservation is driven purely by SCTP
+    // acknowledgement, which lets the drain double as an end-to-end delivery proof.
     let dc = sender_pc
-        .create_data_channel("unbounded", Some(RTCDataChannelInit::default()))
+        .create_data_channel("blocking", Some(RTCDataChannelInit::default()))
         .await?;
 
     let (open_tx, mut open_rx) = channel::<()>(1);
@@ -186,53 +192,72 @@ async fn run() -> Result<()> {
         .await
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
-    // ── Naive flood with the gate DISABLED (limit=0 ⇒ usize::MAX) ───────────────
-    // The escape-hatch teeth: with the gate off EVERY send is admitted and returns Ok, no matter
-    // how far `outstanding_bytes` has climbed. The natural regression (mapping the `0` limit to a
-    // literal `0` instead of `usize::MAX`) makes the SECOND send (once outstanding > 0) return
-    // `ErrSendBufferFull`, failing here on the 2nd of 32768 iterations. Run in the main task so
-    // that failure fails the test synchronously.
-    //
-    // NB this cannot instead assert "outstanding exceeds the gated cap": messages are capped at the
-    // 256 KiB SCTP max, and this stack restores SCTP rwnd at reassembly (not app-consume), so the
-    // sender drains at line rate and never accumulates a backlog — on a contended CI runner the
-    // counter never climbs past the small in-flight window, so a lower-bound on it is unreliable.
-    let chunk = BytesMut::from(vec![0u8; CHUNK].as_slice());
-    let mut sent = 0usize;
-    while sent < TOTAL_BYTES {
-        dc.send(chunk.clone()).await.map_err(|e| {
-            anyhow::anyhow!(
-                "send #{} unexpectedly failed with the gate disabled ({e:?}) — the \
-                 limit=0 escape hatch did not map the send-buffer limit to usize::MAX",
-                sent / CHUNK + 1
-            )
-        })?;
-        sent += CHUNK;
+    // ── Naive flood with the BLOCKING send() (library paces it, not the app) ────
+    let flood_done = Arc::new(AtomicBool::new(false));
+    let flood_fatal = Arc::new(AtomicBool::new(false));
+    {
+        let dc = dc.clone();
+        let flood_done = flood_done.clone();
+        let flood_fatal = flood_fatal.clone();
+        runtime.spawn(Box::pin(async move {
+            let chunk = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let mut sent = 0usize;
+            while sent < TOTAL_BYTES {
+                if let Err(e) = dc.send(chunk.clone()).await {
+                    log::error!("blocking flood: unexpected send error: {e:?}");
+                    flood_fatal.store(true, Ordering::Relaxed);
+                    break;
+                }
+                sent += CHUNK;
+            }
+            flood_done.store(true, Ordering::Relaxed);
+        }));
     }
 
-    // Conservation AND real end-to-end delivery: reliable/ordered ⇒ the counter decrements ONLY on
-    // SCTP acknowledgement (no abandonment path), so draining to ~0 proves the peer SACKed every
-    // byte. This is the robust delivery proof — unlike the app-level `received` counter below, it
-    // does not depend on the built-in receive path's bounded, lossy app-delivery channel.
+    // Property 1 — bounded. The blocking gate must hold outstanding at/under the limit for
+    // the whole flood; this upper bound cannot fail spuriously when the gate works.
+    let mut max_outstanding = 0usize;
+    let deadline_ticks = 600; // 600 * 100ms = 60s cap
+    let mut ticks = 0;
+    while !flood_done.load(Ordering::Relaxed) {
+        let o = dc.outstanding_bytes().await?;
+        max_outstanding = max_outstanding.max(o);
+        assert!(
+            o <= OUTSTANDING_BOUND,
+            "outstanding_bytes {o} exceeded the send-buffer bound {OUTSTANDING_BOUND} during \
+             the blocking flood — send() is not blocking on the send-buffer limit"
+        );
+        ticks += 1;
+        assert!(
+            ticks < deadline_ticks,
+            "blocking flood did not complete within 60s"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        !flood_fatal.load(Ordering::Relaxed),
+        "blocking flood hit an unexpected send error (see log)"
+    );
+
+    // Property 2 — delivered + conserved. Reliable/ordered ⇒ the counter drains to ~0 only
+    // once the peer SACKs every byte, so this is both a leak check and an end-to-end delivery
+    // proof for the blocking path.
     let mut final_outstanding = dc.outstanding_bytes().await?;
     for _ in 0..300 {
         final_outstanding = dc.outstanding_bytes().await?;
-        if final_outstanding < 512 * 1024 {
+        if final_outstanding < 64 * 1024 {
             break;
         }
         sleep(Duration::from_millis(100)).await;
     }
     assert!(
-        final_outstanding < 512 * 1024,
-        "outstanding_bytes did not drain (leak?): {final_outstanding} bytes still outstanding"
+        final_outstanding < 64 * 1024,
+        "outstanding_bytes did not drain (leak / undelivered?): {final_outstanding} bytes \
+         still outstanding"
     );
 
-    // App-level receipt is informational only, NOT asserted: the built-in receive path hands
-    // messages to the app over a bounded, lossy channel, so a CPU-starved consumer (e.g. CI under
-    // coverage instrumentation) legitimately drops app-level messages even on a reliable/ordered
-    // channel. SCTP-level delivery is already proven by the drain above.
     let got = received.load(Ordering::Relaxed);
-    log::info!("send-unbounded: flooded {TOTAL_BYTES} bytes, gate disabled; app received={got}");
+    log::info!("blocking-send: max_outstanding={max_outstanding} app_received={got}");
 
     sender_pc.close().await?;
     receiver_pc.close().await?;

--- a/tests/data_channel_send_unbounded.rs
+++ b/tests/data_channel_send_unbounded.rs
@@ -1,0 +1,242 @@
+//! Integration test for the send back-pressure **escape hatch**: setting
+//! `WEBRTC_SEND_HIGH_WATER_BYTES=0` / `WEBRTC_SEND_HARD_CEILING_BYTES=0` maps the limits to
+//! `usize::MAX` (see `send_limits`, the `Some(0) => usize::MAX` arm), disabling the gate so a
+//! caller that does its own flow control — or the send-backpressure A/B benchmark — runs with
+//! no library-imposed bound.
+//!
+//! Complement to `data_channel_send_backpressure.rs`: that test asserts the gate BOUNDS the
+//! pipeline; this one asserts the escape hatch DISABLES it. With the gate off, a naive 32 MB flood
+//! must have EVERY send admitted (return Ok) no matter how far `outstanding_bytes` climbs — the
+//! natural regression of the `Some(0) => usize::MAX` arm (deleting it, so "0" parses as `0` and
+//! clamps `high_water = hard_ceiling = 0`) makes the second send return `ErrSendBufferFull`, which
+//! this flood catches. Conservation still holds — the counter drains back to ~0, and because a
+//! reliable/ordered channel has no abandonment path the counter decrements ONLY on SCTP
+//! acknowledgement, so draining to ~0 proves the peer actually SACKed every byte (real end-to-end
+//! delivery, independent of the built-in receive path's lossy app-delivery channel).
+//!
+//! It deliberately does NOT assert a lower bound on the peak `outstanding_bytes`: messages are
+//! capped at the 256 KiB SCTP max and this stack restores SCTP rwnd at reassembly (not app-consume),
+//! so the sender drains at line rate and a contended CI runner never accumulates a large backlog.
+use anyhow::Result;
+use bytes::BytesMut;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+const CHUNK: usize = 1024; // 1 KB messages
+// Reliable/ordered flood total; large enough to exercise the disabled-gate admit path many times.
+const TOTAL_BYTES: usize = 32 * 1024 * 1024;
+
+struct GatherHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for GatherHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct ReceiverHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    received: Arc<AtomicUsize>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for ReceiverHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let received = self.received.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        received.fetch_add(msg.data.len(), Ordering::Relaxed);
+                    }
+                    DataChannelEvent::OnClose | DataChannelEvent::OnError => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+#[test]
+fn test_data_channel_send_unbounded_escape_hatch() {
+    // Disable BOTH gates via the documented `0 = unbounded` escape hatch. `send_limits()` reads
+    // this once, on the first send(), so setting it before `block_on` is in force. Safe: this is
+    // the only test in this binary, so no other thread reads the environment concurrently.
+    unsafe {
+        std::env::set_var("WEBRTC_SEND_HIGH_WATER_BYTES", "0");
+        std::env::set_var("WEBRTC_SEND_HARD_CEILING_BYTES", "0");
+    }
+    block_on(run()).unwrap();
+}
+
+async fn run() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let (snd_gather_tx, mut snd_gather_rx) = channel::<()>(1);
+    let (snd_conn_tx, mut snd_conn_rx) = channel::<()>(1);
+    let (rcv_gather_tx, mut rcv_gather_rx) = channel::<()>(1);
+    let (rcv_conn_tx, mut rcv_conn_rx) = channel::<()>(1);
+    let received = Arc::new(AtomicUsize::new(0));
+
+    // ── Sender ────────────────────────────────────────────────────────────────
+    let sender_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(GatherHandler {
+            gather_tx: snd_gather_tx,
+            connected_tx: snd_conn_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    // Reliable + ordered so nothing is abandoned — conservation here is driven purely by SCTP
+    // acknowledgement (no forward-TSN path), a clean complement to the bounded test's unordered/
+    // no-retransmit channel, and the property that lets the drain double as a delivery proof.
+    let dc = sender_pc
+        .create_data_channel("unbounded", Some(RTCDataChannelInit::default()))
+        .await?;
+
+    let (open_tx, mut open_rx) = channel::<()>(1);
+    {
+        let dc = dc.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        let _ = open_tx.try_send(());
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = sender_pc.create_offer(None).await?;
+    sender_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), snd_gather_rx.recv()).await;
+    let offer_sdp = sender_pc
+        .local_description()
+        .await
+        .expect("sender local description");
+
+    // ── Receiver ──────────────────────────────────────────────────────────────
+    let receiver_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(ReceiverHandler {
+            gather_tx: rcv_gather_tx,
+            connected_tx: rcv_conn_tx,
+            received: received.clone(),
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    receiver_pc.set_remote_description(offer_sdp).await?;
+    let answer = receiver_pc.create_answer(None).await?;
+    receiver_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), rcv_gather_rx.recv()).await;
+    let answer_sdp = receiver_pc
+        .local_description()
+        .await
+        .expect("receiver local description");
+    sender_pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), snd_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: sender connect"))?;
+    timeout(Duration::from_secs(5), rcv_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: receiver connect"))?;
+    timeout(Duration::from_secs(10), open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
+
+    // ── Naive flood with the gate DISABLED (env=0 ⇒ limits are usize::MAX) ──────
+    // The escape-hatch teeth: with the gate off EVERY send is admitted and returns Ok, no matter
+    // how far `outstanding_bytes` has climbed. The natural regression of the `Some(0) => usize::MAX`
+    // arm — deleting it, so "0" parses as `Some(0) => 0` and clamps `high_water = hard_ceiling = 0`
+    // — makes the SECOND send (once outstanding > 0) return `ErrSendBufferFull`, failing here on the
+    // 2nd of 32768 iterations. Run in the main task so that failure fails the test synchronously.
+    //
+    // NB this cannot instead assert "outstanding exceeds the gated cap": messages are capped at the
+    // 256 KiB SCTP max, and this stack restores SCTP rwnd at reassembly (not app-consume), so the
+    // sender drains at line rate and never accumulates a backlog — on a contended CI runner the
+    // counter never climbs past the small in-flight window, so a lower-bound on it is unreliable.
+    let chunk = BytesMut::from(vec![0u8; CHUNK].as_slice());
+    let mut sent = 0usize;
+    while sent < TOTAL_BYTES {
+        dc.send(chunk.clone()).await.map_err(|e| {
+            anyhow::anyhow!(
+                "send #{} unexpectedly failed with the gate disabled ({e:?}) — the \
+                 WEBRTC_SEND_*=0 escape hatch did not map the limits to usize::MAX",
+                sent / CHUNK + 1
+            )
+        })?;
+        sent += CHUNK;
+    }
+
+    // Conservation AND real end-to-end delivery: reliable/ordered ⇒ the counter decrements ONLY on
+    // SCTP acknowledgement (no abandonment path), so draining to ~0 proves the peer SACKed every
+    // byte. This is the robust delivery proof — unlike the app-level `received` counter below, it
+    // does not depend on the built-in receive path's bounded, lossy app-delivery channel.
+    let mut final_outstanding = dc.outstanding_bytes().await?;
+    for _ in 0..300 {
+        final_outstanding = dc.outstanding_bytes().await?;
+        if final_outstanding < 512 * 1024 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        final_outstanding < 512 * 1024,
+        "outstanding_bytes did not drain (leak?): {final_outstanding} bytes still outstanding"
+    );
+
+    // App-level receipt is informational only, NOT asserted: the built-in receive path hands
+    // messages to the app over a bounded, lossy channel, so a CPU-starved consumer (e.g. CI under
+    // coverage instrumentation) legitimately drops app-level messages even on a reliable/ordered
+    // channel. SCTP-level delivery is already proven by the drain above.
+    let got = received.load(Ordering::Relaxed);
+    log::info!("send-unbounded: flooded {TOTAL_BYTES} bytes, gate disabled; app received={got}");
+
+    sender_pc.close().await?;
+    receiver_pc.close().await?;
+    Ok(())
+}

--- a/tests/data_channel_send_unbounded.rs
+++ b/tests/data_channel_send_unbounded.rs
@@ -1,18 +1,17 @@
-//! Integration test for the send back-pressure **escape hatch**: setting
-//! `WEBRTC_SEND_HIGH_WATER_BYTES=0` / `WEBRTC_SEND_HARD_CEILING_BYTES=0` maps the limits to
-//! `usize::MAX` (see `send_limits`, the `Some(0) => usize::MAX` arm), disabling the gate so a
-//! caller that does its own flow control — or the send-backpressure A/B benchmark — runs with
-//! no library-imposed bound.
+//! Integration test for the send back-pressure **escape hatch**: building a connection with
+//! `with_data_channel_send_buffer_limit(0)` maps the limit to `usize::MAX`, disabling the gate
+//! so a caller that does its own flow control — or the send-backpressure A/B benchmark — runs
+//! with no library-imposed bound.
 //!
 //! Complement to `data_channel_send_backpressure.rs`: that test asserts the gate BOUNDS the
 //! pipeline; this one asserts the escape hatch DISABLES it. With the gate off, a naive 32 MB flood
 //! must have EVERY send admitted (return Ok) no matter how far `outstanding_bytes` climbs — the
-//! natural regression of the `Some(0) => usize::MAX` arm (deleting it, so "0" parses as `0` and
-//! clamps `high_water = hard_ceiling = 0`) makes the second send return `ErrSendBufferFull`, which
-//! this flood catches. Conservation still holds — the counter drains back to ~0, and because a
-//! reliable/ordered channel has no abandonment path the counter decrements ONLY on SCTP
-//! acknowledgement, so draining to ~0 proves the peer actually SACKed every byte (real end-to-end
-//! delivery, independent of the built-in receive path's lossy app-delivery channel).
+//! natural regression (mapping `0` to a literal `0` limit instead of `usize::MAX`) would make the
+//! second send return `ErrSendBufferFull`, which this flood catches on iteration 2. Conservation
+//! still holds — the counter drains back to ~0, and because a reliable/ordered channel has no
+//! abandonment path the counter decrements ONLY on SCTP acknowledgement, so draining to ~0 proves
+//! the peer actually SACKed every byte (real end-to-end delivery, independent of the built-in
+//! receive path's lossy app-delivery channel).
 //!
 //! It deliberately does NOT assert a lower bound on the peak `outstanding_bytes`: messages are
 //! capped at the 256 KiB SCTP max and this stack restores SCTP rwnd at reassembly (not app-consume),
@@ -88,13 +87,8 @@ impl PeerConnectionEventHandler for ReceiverHandler {
 
 #[test]
 fn test_data_channel_send_unbounded_escape_hatch() {
-    // Disable BOTH gates via the documented `0 = unbounded` escape hatch. `send_limits()` reads
-    // this once, on the first send(), so setting it before `block_on` is in force. Safe: this is
-    // the only test in this binary, so no other thread reads the environment concurrently.
-    unsafe {
-        std::env::set_var("WEBRTC_SEND_HIGH_WATER_BYTES", "0");
-        std::env::set_var("WEBRTC_SEND_HARD_CEILING_BYTES", "0");
-    }
+    // The gate is disabled via the builder's documented `0 = unbounded` escape hatch
+    // (`with_data_channel_send_buffer_limit(0)` inside `run`).
     block_on(run()).unwrap();
 }
 
@@ -121,6 +115,8 @@ async fn run() -> Result<()> {
         }))
         .with_runtime(runtime.clone())
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        // Disable the send-buffer gate: `0` = unbounded (maps the limit to usize::MAX).
+        .with_data_channel_send_buffer_limit(0)
         .build()
         .await?;
 
@@ -188,12 +184,12 @@ async fn run() -> Result<()> {
         .await
         .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
 
-    // ── Naive flood with the gate DISABLED (env=0 ⇒ limits are usize::MAX) ──────
+    // ── Naive flood with the gate DISABLED (limit=0 ⇒ usize::MAX) ───────────────
     // The escape-hatch teeth: with the gate off EVERY send is admitted and returns Ok, no matter
-    // how far `outstanding_bytes` has climbed. The natural regression of the `Some(0) => usize::MAX`
-    // arm — deleting it, so "0" parses as `Some(0) => 0` and clamps `high_water = hard_ceiling = 0`
-    // — makes the SECOND send (once outstanding > 0) return `ErrSendBufferFull`, failing here on the
-    // 2nd of 32768 iterations. Run in the main task so that failure fails the test synchronously.
+    // how far `outstanding_bytes` has climbed. The natural regression (mapping the `0` limit to a
+    // literal `0` instead of `usize::MAX`) makes the SECOND send (once outstanding > 0) return
+    // `ErrSendBufferFull`, failing here on the 2nd of 32768 iterations. Run in the main task so
+    // that failure fails the test synchronously.
     //
     // NB this cannot instead assert "outstanding exceeds the gated cap": messages are capped at the
     // 256 KiB SCTP max, and this stack restores SCTP rwnd at reassembly (not app-consume), so the
@@ -205,7 +201,7 @@ async fn run() -> Result<()> {
         dc.send(chunk.clone()).await.map_err(|e| {
             anyhow::anyhow!(
                 "send #{} unexpectedly failed with the gate disabled ({e:?}) — the \
-                 WEBRTC_SEND_*=0 escape hatch did not map the limits to usize::MAX",
+                 limit=0 escape hatch did not map the send-buffer limit to usize::MAX",
                 sent / CHUNK + 1
             )
         })?;


### PR DESCRIPTION
# feat(datachannel): opt-in send back-pressure (writable / try_send) to bound peak RSS

> **v3 — redesigned again per @rainliu's review, now mirroring `tokio::mpsc`.** The send-buffer
> limit is **opt-in**: the default is `usize::MAX` (unbounded), so there is **zero behaviour change**
> unless an application configures a limit. When a limit *is* set, `send()`/`send_text()` **block**
> until there is room (like `mpsc::Sender::send`), new `try_send()`/`try_send_text()` **fail fast**
> with `ErrSendBufferFull` (like `mpsc::Sender::try_send`), and new `writable()` awaits capacity.
> (Evolution: v1 blocking-only → v2 non-blocking-only → v3 both, opt-in. See the thread.)

## Dependency: rtc#127 is merged ✅ — CI no longer blocked

The sans-io counter plumbing ([rtc#127](https://github.com/webrtc-rs/rtc/pull/127)) merged into
upstream `rtc` on 2026-07-14 as `4d902e9c`. This branch's `rtc` submodule pointer **already equals
upstream `master`'s**, so the PR builds standalone. This PR carries only the webrtc-side send
back-pressure API + tests + bench.

## Summary

Adds **opt-in send back-pressure** to data channels, so an application can bound peak RSS under a
fast producer and a slow reactor/peer. The unbounded send path (found while comparing webrtc-rs
against rustrtc, pinned down by an N-pair stress test) lets `dc.send()` grow send-side memory
without limit as the transfer grows — an OOM/DoS risk under a slow reactor **or** a slow/malicious
peer advertising a tiny receive window. Configuring a per-channel limit bounds it.

**The default is unbounded (`usize::MAX`)** — no behaviour change unless you opt in. Rationale
(per review): only Chromium hard-codes a 16 MiB send-queue cap; Safari and Firefox impose none, and
the W3C flow-control model is app-driven (`bufferedAmountLowThreshold` + `onbufferedamountlow`). So
the library keeps the historical non-blocking behaviour by default and lets the application choose a
cap and a blocking-vs-fail-fast policy.

## API

All new trait methods are `async fn` with **default bodies**, so an external `impl DataChannel`
keeps compiling (`writable` → `Ok(())`, `try_send`/`try_send_text` → delegate to `send`/`send_text`).

- **`PeerConnectionBuilder::with_data_channel_send_buffer_limit(bytes)`** — per-channel send-buffer
  limit, applied connection-wide. **Default `usize::MAX` (unbounded); `0` is also unbounded.** A
  finite limit opts into back-pressure. `16 * 1024 * 1024` (Chromium's `MaxSendQueueSize`) is a
  reasonable browser-like value, well above the ~1 MiB SCTP receive window.
- **`DataChannel::send` / `send_text`** — with a limit configured, **block** until the channel's
  `outstanding_bytes` is below it, then enqueue (mirrors `mpsc::Sender::send`). With no limit (the
  default) they never block, exactly as before.
- **`DataChannel::try_send` / `try_send_text`** *(new)* — **never block**: over the limit they return
  `Err(ErrSendBufferFull)` immediately (mirrors `mpsc::Sender::try_send`). `data` is **consumed** on
  rejection — retain a clone to retry.
- **`DataChannel::writable() -> Result<()>`** *(new)* — resolves once `outstanding_bytes` is below the
  limit (immediately when unbounded); `ErrDataChannelClosed` if the channel/connection is closing.
  This is the await-for-capacity primitive `send`/`send_text` use internally; call it directly to
  pace your own sends.
- **`DataChannel::outstanding_bytes() -> Result<usize>`** — query primitive (from rtc#127). Unlike
  `bufferedAmount` (post-packetization) it also counts bytes still queued in the app→core→SCTP
  pipeline — a slightly more complete back-pressure signal.
- **Errors:** `ErrSendBufferFull` (from `try_send`/`try_send_text` only; retryable once the buffer
  drains — pace on `OnBufferedAmountLow`, don't spin). `ErrDataChannelClosed` is checked first, so
  after `close()`/`Drop` every send method — and `writable()` — fails **terminally** rather than
  hanging or spinning on the retryable error; a send already **parked** in back-pressure is woken and
  returns `ErrDataChannelClosed` whenever the driver stops for any reason — `close()`/`Drop` **or** an
  abnormal error exit (so a stalled peer + a dropped network can't hang a parked sender).

## Semantics: level-triggered, not a reserved permit

`writable()` resolves on `outstanding_bytes < limit` — it is **not** a reserved permit like
`mpsc::Sender::reserve`. For the normal single-sender-per-channel case this is exact. With multiple
concurrent senders on one channel the limit is a **soft** bound (each admitted sender may add one
in-flight message over it) — the same property as `bufferedAmount`-based flow control. A lone message
larger than the limit still goes out (`writable()` returns as soon as `outstanding` hits 0), so a big
send never deadlocks.

## A/B: peak RSS under a naive flood

A naive sender that ignores `bufferedAmount` floods the blocking `send()` over **30 pairs × 32 MB**
(unordered / no-retransmit, dedicated reactor). Same binary, only the limit differs; `poop`, 3 runs
each. Opting into a limit bounds peak RSS (and, because the pipeline no longer balloons, runs
faster):

| measurement | unbounded (default) | 16 MiB limit | 4 MiB limit |
|---|---|---|---|
| wall_time | 5.07 s ± 113 ms | 4.31 s ± 121 ms — ⚡ **−14.9%** | 3.71 s ± 1.3 ms — ⚡ **−26.8%** |
| peak_rss | 2.36 GB ± 78 MB | 1.17 GB ± 34 MB — ⚡ **−50.5%** | 576 MB ± 17 MB — ⚡ **−75.6%** |
| cpu_cycles | 122 G ± 2.5 G | 109 G ± 1.8 G — ⚡ −10.1% | 96.2 G ± 0.1 G — ⚡ −21.0% |
| instructions | 109 G ± 2.0 G | 97.5 G ± 1.1 G — ⚡ −10.8% | 85.2 G ± 0.4 G — ⚡ −22.0% |
| cache_references | 8.47 G ± 235 M | 7.65 G ± 162 M — ⚡ −9.8% | 6.76 G ± 47 M — ⚡ −20.2% |
| cache_misses | 1.25 G ± 58 M | 1.12 G ± 26 M — ⚡ −10.1% | 1.02 G ± 28 M — ⚡ −18.1% |
| branch_misses | 312 M ± 12 M | 285 M ± 9 M — −8.8% | 256 M ± 3.9 M — ⚡ −18.1% |

The bounded arms' peak RSS stays **flat** as the transfer grows, whereas the unbounded arm scales
with total bytes in flight. Reproduce with `examples/data-channels-stress-bench` (see its header).

### Happy path is unaffected (flow-control A/B)

The complementary check: a well-behaved, `bufferedAmount`-paced sender (the
[#101](https://github.com/webrtc-rs/webrtc/issues/101#issuecomment-4950542200) throughput harness —
1 KB messages, 512 KB/1 MB watermarks, ordered/reliable, dedicated reactor) is **throughput- and
resource-neutral** vs `master`, because the opt-in machinery is dormant on the default (unbounded)
path — `writable()` short-circuits before locking, and the driver skips the per-iteration wake
entirely when no limit is set. `poop`, master vs this branch, 3 runs each:

| | master | this branch | Δ |
|---|---|---|---|
| throughput, N=1 | 722 Mbps | 726 Mbps | +0.5% (noise) |
| throughput, N=10 aggregate | 3261 Mbps | 3306 Mbps | +1.4% (noise) |

Every `poop` counter is within measurement noise (no significant markers): N=1 wall `−0.8%`, peak_rss
`+0.3%`, instructions `+0.9%`; N=10 wall `+1.0%`, peak_rss `−11.2%` (σ±19%), instructions `+0.7%`.

## Tests

All green on **tokio and smol**:

- `data_channel_send_blocking.rs` — blocking `send()` with a limit: `outstanding_bytes` stays bounded
  throughout **and** every byte is delivered (reliable/ordered ⇒ drain-to-0 proves SCTP acked all).
- `data_channel_send_backpressure.rs` — non-blocking `try_send`/`try_send_text` cap: bounded +
  reject-engaged + conservation (incl. `max_retransmits: 0` abandonment).
- `data_channel_close_wakes_send.rs` — a `send()` **parked** in back-pressure is woken by `close()`
  and returns `ErrDataChannelClosed` (liveness; without the `closing` check + `close`/`Drop` wake it
  hangs).
- `data_channel_send_after_close.rs` — `send`/`send_text`/`try_send`/`try_send_text`/`writable` all
  fail **terminally** after `close()`.
- `data_channel_send_unbounded.rs` — `0`/default = unbounded escape hatch; reliable end-to-end
  delivery with the gate disabled.
- unit tests — the trait default bodies (`outstanding_bytes`→0, `writable`→`Ok`, `try_send*`→delegate).

## Design evolution / addressing the review (@rainliu)

- **v1** parked `send()` in a loop → *"strongly against the parking loop."*
- **v2** made `send()` non-blocking (`ErrSendBufferFull`), 16 MiB default.
- **v3 (this)** mirrors `tokio::mpsc`, per the latest review:
  1. **Default `usize::MAX`** — zero behaviour change unless opted in (Safari/Firefox have no cap).
  2. **`async fn try_send`/`try_send_text`** (not sync) — the counter lives behind the async core
     mutex, so a sync `fn try_send` would need `try_lock()` and spuriously fail under contention;
     `async fn` is consistent with the rest of the object-safe trait and has no such failure mode.
  3. **Blocking `send`/`send_text` when a limit is set** — the complexity lives in `writable()`, and
     `send()` is just `self.writable().await?` then enqueue.
  4. **"Silent drop" clarified** — today's `send()` never drops *payload*; only the internal unit
     `WriteNotify` wake is droppable at channel capacity, and that is harmless (the driver runs
     `poll_writes()` unconditionally each loop). No data-loss bug; the new APIs are ergonomics.
