### PR TITLE
feat(runtime): bounded shared reactor pool + configurable SCTP receive window

### DIFF
--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -176,6 +176,7 @@ where
     udp_addrs: Vec<A>,
     tcp_addrs: Vec<A>,
     dedicated_reactor: bool,
+    reactor_pool_size: Option<usize>,
     data_channel_send_buffer_limit: usize,
 }
 
@@ -189,6 +190,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             udp_addrs: vec![],
             tcp_addrs: vec![],
             dedicated_reactor: false,
+            reactor_pool_size: None,
             // `usize::MAX` = unbounded: no send back-pressure unless the application
             // opts in via `with_data_channel_send_buffer_limit`. This keeps `send`/
             // `send_text` non-blocking by default (zero behaviour change).
@@ -227,6 +229,31 @@ where
         self
     }
 
+    /// Sets the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes.
+    ///
+    /// This bounds how much unacknowledged data a remote peer may have in flight toward
+    /// this connection — a bandwidth-delay-product ceiling. The buffer fills only under
+    /// load, so lowering it trims per-connection resident memory (useful for servers
+    /// holding many connections — it stacks with the shared reactor pool, see
+    /// [`with_dedicated_reactor_thread`](Self::with_dedicated_reactor_thread)); but a
+    /// smaller window can throttle throughput on high-latency, high-bandwidth paths,
+    /// where more data must be in flight to keep the pipe full.
+    ///
+    /// **Default: 1 MiB** (left unset), which suits typical internet paths. Lower it
+    /// (e.g. 256 KiB) for memory-bound, many-connection or low-RTT (LAN/loopback)
+    /// deployments. Applies to whichever [`SettingEngine`] is set, so call it *after*
+    /// [`with_setting_engine`](Self::with_setting_engine) when supplying a custom engine.
+    ///
+    /// **Bounds:** values below the RFC 4960 §6 floor of 1500 bytes (including `0`) are
+    /// raised to it — a smaller window would break the SCTP handshake. Keep it **≥ the
+    /// largest data-channel message you expect to receive** (default max is 64 KiB) or a
+    /// full-size inbound message stalls. `0` is *not* "unbounded" here — leave this unset
+    /// to keep the 1 MiB default.
+    pub fn with_sctp_receive_buffer_size(mut self, size: u32) -> Self {
+        self.builder = self.builder.with_sctp_receive_buffer_size(size);
+        self
+    }
+
     /// Configures the builder with the specified interceptor [`Registry`].
     pub fn with_interceptor_registry<P>(
         self,
@@ -243,6 +270,7 @@ where
             udp_addrs: self.udp_addrs,
             tcp_addrs: self.tcp_addrs,
             dedicated_reactor: self.dedicated_reactor,
+            reactor_pool_size: self.reactor_pool_size,
             data_channel_send_buffer_limit: self.data_channel_send_buffer_limit,
         }
     }
@@ -271,27 +299,62 @@ where
         self
     }
 
-    /// Run this peer connection's driver on its own dedicated OS thread with a
-    /// single-threaded reactor, instead of on the shared async runtime.
+    /// Run this peer connection's driver on the shared **bounded reactor pool**
+    /// instead of on the general-purpose async runtime.
     ///
     /// This *confines* the driver (and thus its SCTP/DTLS/SRTP state and I/O
-    /// reactor) to a single dedicated thread, so the async runtime never migrates
-    /// it across its worker pool — the dominant cost for in-process data-channel
-    /// throughput on multi-threaded runtimes (issue #101). It costs one OS thread
-    /// per peer connection, so it is **off by default**: enable it for
-    /// latency/throughput-sensitive deployments with a modest number of
-    /// connections, and leave it off for large-scale servers (e.g. SFUs) with
-    /// thousands of connections.
+    /// reactor) to a single reactor thread for its lifetime, so the async runtime
+    /// never migrates it across its worker pool — the dominant cost for in-process
+    /// data-channel throughput on multi-threaded runtimes (issue #101).
+    ///
+    /// The reactor thread comes from a process-global pool of at most `N` threads
+    /// (see [`with_reactor_pool_size`](Self::with_reactor_pool_size) /
+    /// [`set_reactor_pool_size`](crate::runtime::set_reactor_pool_size);
+    /// default: host parallelism). Drivers are assigned round-robin, so up to a
+    /// few I/O-bound drivers share a thread cooperatively and the reactor-thread
+    /// count stays **bounded by the pool size regardless of connection count** —
+    /// unlike the earlier model, which spent one OS thread per connection. This
+    /// makes it viable even for large-scale servers (e.g. SFUs); it is still
+    /// **off by default** because the general runtime is the right choice when the
+    /// application already schedules its own work across all cores.
     ///
     /// Note: this is *thread confinement*, not CPU-core affinity — the OS
-    /// scheduler may still move the dedicated thread between cores.
-    /// TODO(#101): pin the reactor thread to a specific core (via `core_affinity`)
+    /// scheduler may still move a pool thread between cores.
+    /// TODO(#101): pin pool threads to specific cores (via `core_affinity`)
     /// for cache/NUMA locality as a follow-up.
     ///
-    /// Note: with this enabled, event-handler callbacks run on the dedicated
-    /// reactor thread, so they must not block.
+    /// Note: with this enabled, event-handler callbacks run on a shared reactor
+    /// pool thread, so they must not block (blocking one stalls its co-tenant
+    /// drivers as well as itself).
+    ///
+    /// Note: the first time each pool thread is used, [`build`](Self::build) briefly
+    /// blocks the calling task's runtime thread while that thread's runtime starts
+    /// (a one-time, sub-millisecond rendezvous per pool slot, at most pool-size times
+    /// per process). Prefer building connections off a latency-critical runtime thread
+    /// if that matters.
     pub fn with_dedicated_reactor_thread(mut self, enabled: bool) -> Self {
         self.dedicated_reactor = enabled;
+        self
+    }
+
+    /// Set the size of the shared reactor pool used when
+    /// [`with_dedicated_reactor_thread(true)`](Self::with_dedicated_reactor_thread)
+    /// is enabled — the maximum number of reactor threads across the whole process,
+    /// regardless of how many connections use the pool.
+    ///
+    /// The pool is process-global and sized **once**, lazily, when the first
+    /// dedicated-reactor connection is built. This method forwards to
+    /// [`set_reactor_pool_size`](crate::runtime::set_reactor_pool_size) at
+    /// [`build`](Self::build) time, so only the first such connection's value
+    /// takes effect; prefer setting it once at startup (here or via that function,
+    /// or the `WEBRTC_REACTOR_POOL_SIZE` environment variable). Passing `0`
+    /// restores the default resolution (env var, then host parallelism).
+    ///
+    /// Smaller pools use fewer threads and less memory (fewer per-thread allocator
+    /// arenas) at the cost of more drivers sharing each thread; size it to trade
+    /// resident memory against per-connection isolation for your workload.
+    pub fn with_reactor_pool_size(mut self, size: usize) -> Self {
+        self.reactor_pool_size = Some(size);
         self
     }
 
@@ -332,6 +395,15 @@ where
         };
 
         let core = self.builder.build()?;
+
+        // Apply the reactor-pool size before the first `spawn_reactor` builds the
+        // process-global pool. Only meaningful when this connection uses the pool
+        // (dedicated reactor enabled), so don't touch the global otherwise; and the
+        // pool is sized once, lazily, so the value in effect when the first
+        // dedicated-reactor connection is built wins — see `with_reactor_pool_size`.
+        if let Some(size) = self.reactor_pool_size.filter(|_| self.dedicated_reactor) {
+            crate::runtime::set_reactor_pool_size(size);
+        }
 
         // `0` = unbounded (same as the `usize::MAX` default); normalise it to `usize::MAX`
         // so the send-buffer gate (and `writable()`) short-circuits to a no-op.
@@ -462,10 +534,12 @@ where
 {
     inner: Arc<PeerConnectionRef<I>>,
     driver_handle: Mutex<Option<JoinHandle>>,
-    /// Whether the driver runs on a dedicated reactor thread. When true, `close()`
-    /// waits for that thread to finish, and `Drop` signals it to stop (via
-    /// [`PeerConnectionRef::closing`]) so it does not leak if the connection is
-    /// dropped without an explicit `close()`.
+    /// Whether the driver runs on the shared bounded reactor pool (a task pinned to
+    /// one pool thread) rather than the general async runtime. When true, `close()`
+    /// waits for that task to finish and then aborts it, and `Drop` signals it to
+    /// stop (via [`PeerConnectionRef::closing`]) so a driver task is not left
+    /// running on a pool thread if the connection is dropped without an explicit
+    /// `close()`.
     dedicated_reactor: bool,
 }
 
@@ -735,15 +809,18 @@ where
     I: Interceptor,
 {
     fn drop(&mut self) {
-        // A dedicated reactor thread only exits when its event loop returns, so
-        // a connection dropped without an explicit `close()` would leak the
-        // thread. Set the shutdown flag (infallible) so the driver stops at the
-        // top of its next loop iteration, then best-effort wake it so it stops
-        // promptly rather than after its next timer/socket event. Crucially the
-        // flag — not the wake — is the guarantee: a full channel drops the wake
-        // but cannot leak the thread. (Task-based drivers detach harmlessly, so
-        // this is limited to the dedicated-reactor case to avoid changing the
-        // default lifecycle.)
+        // A reactor-pool driver task only exits when its event loop returns, so a
+        // connection dropped without an explicit `close()` would leave that task
+        // running on a shared pool thread — pinning a scarce reactor thread and
+        // holding the connection's buffers alive (the RSS this pool exists to
+        // bound). Dropping the join handle merely detaches the task. So set the
+        // shutdown flag (infallible) so the driver stops at the top of its next
+        // loop iteration, then best-effort wake it so it stops promptly rather
+        // than after its next timer/socket event. Crucially the flag — not the
+        // wake — is the guarantee: a full channel drops the wake but cannot leak
+        // the task. (Drivers on the general runtime detach harmlessly onto the
+        // application's own worker pool, so this is limited to the pooled-reactor
+        // case to avoid changing the default lifecycle.)
         if self.dedicated_reactor {
             self.inner.closing.store(true, Ordering::Release);
             // Wake a sender blocked in `DataChannel::writable()` so it returns promptly
@@ -788,18 +865,19 @@ where
         let driver_handle = self.driver_handle.lock().await.take();
         if let Some(driver_handle) = driver_handle {
             if self.dedicated_reactor {
-                // The reactor runs on its own OS thread that cannot be aborted;
-                // wait (bounded) for its event loop to actually return, so the
-                // socket and thread are released by the time `close()` resolves.
-                // It exits promptly once it observes the shutdown above; the bound
-                // only prevents `close()` from hanging on a wedged reactor, after
-                // which the handle is dropped (detached) as a last resort.
+                // The reactor driver is a task pinned to a shared pool thread.
+                // First wait (bounded) for its event loop to return on its own, so
+                // it flushes the SCTP shutdown and releases its socket by the time
+                // `close()` resolves — it exits promptly once it observes the
+                // shutdown signalled above. Then abort the task unconditionally to
+                // free the pool thread of it (a no-op once it has finished; the
+                // fallback that reclaims a driver still wedged at the bound).
                 //
                 // Note: if `close()` is called *from within an event-handler
                 // callback* (which, for a dedicated reactor, runs on this very
-                // thread), the loop cannot make progress until the handler
-                // returns, so this wait runs out its full bound before detaching.
-                // Handlers must not block (see `with_dedicated_reactor_thread`).
+                // task), the loop cannot make progress until the handler returns,
+                // so this wait runs out its full bound before aborting. Handlers
+                // must not block (see `with_dedicated_reactor_thread`).
                 let step = std::time::Duration::from_millis(1);
                 let max = std::time::Duration::from_secs(2);
                 let mut waited = std::time::Duration::ZERO;
@@ -807,6 +885,7 @@ where
                     crate::runtime::sleep(step).await;
                     waited += step;
                 }
+                driver_handle.abort();
             } else {
                 driver_handle.abort();
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,7 +16,56 @@
 
 #![allow(clippy::type_complexity)]
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt::Debug, future::Future, io, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
+
+/// Process-global override for the shared reactor pool's thread count, set via
+/// [`set_reactor_pool_size`]. `0` means "unset": fall back to the
+/// `WEBRTC_REACTOR_POOL_SIZE` environment variable, then to host parallelism.
+static REACTOR_POOL_SIZE: AtomicUsize = AtomicUsize::new(0);
+
+/// Upper clamp on the reactor-pool thread count, guarding against a fat-fingered
+/// `WEBRTC_REACTOR_POOL_SIZE` / [`set_reactor_pool_size`] value eagerly allocating a
+/// slot table large enough to OOM (or overflow). Far above any sane reactor count.
+pub(crate) const MAX_REACTOR_POOL_SIZE: usize = 1024;
+
+/// Set the size of the shared reactor-thread pool used by
+/// [`Runtime::spawn_reactor`] (i.e. by connections built with
+/// [`with_dedicated_reactor_thread(true)`](crate::peer_connection::PeerConnectionBuilder::with_dedicated_reactor_thread)).
+///
+/// The pool is process-global and sized **once**, lazily, on first use. Call this
+/// before building the first dedicated-reactor `PeerConnection`; later calls (or
+/// calls after the pool has been created) have no effect. `0` restores the
+/// default resolution (env var, then host parallelism).
+///
+/// Prefer this or the `WEBRTC_REACTOR_POOL_SIZE` env var for a global default;
+/// [`PeerConnectionBuilder::with_reactor_pool_size`](crate::peer_connection::PeerConnectionBuilder::with_reactor_pool_size)
+/// is a convenience that forwards here at build time.
+pub fn set_reactor_pool_size(size: usize) {
+    REACTOR_POOL_SIZE.store(size, Ordering::Relaxed);
+}
+
+/// Resolve the reactor-pool size, in precedence order: an explicit override (via
+/// [`set_reactor_pool_size`]), then the `WEBRTC_REACTOR_POOL_SIZE` env var, then
+/// host parallelism (`available_parallelism`, falling back to 4). Read once by
+/// each runtime when it lazily builds its pool.
+pub(crate) fn reactor_pool_size() -> usize {
+    let override_size = REACTOR_POOL_SIZE.load(Ordering::Relaxed);
+    let resolved = if override_size != 0 {
+        override_size
+    } else {
+        std::env::var("WEBRTC_REACTOR_POOL_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n != 0)
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(4)
+            })
+    };
+    resolved.clamp(1, MAX_REACTOR_POOL_SIZE)
+}
 
 /// Handle to a spawned task that can be used to manage its lifecycle
 pub struct JoinHandle {
@@ -49,40 +98,6 @@ trait JoinHandleInner: Send + Sync {
     fn is_finished(&self) -> bool;
 }
 
-/// [`JoinHandleInner`] backed by a dedicated OS thread running a single-threaded
-/// reactor (see [`Runtime::spawn_reactor`]). A thread cannot be force-cancelled,
-/// so shutdown is driven by the peer connection's `Close` event; `abort` is a
-/// best-effort no-op and `detach` simply drops the join handle.
-struct ThreadReactorHandle(std::sync::Mutex<Option<std::thread::JoinHandle<()>>>);
-
-impl JoinHandleInner for ThreadReactorHandle {
-    fn detach(&self) {
-        if let Ok(mut guard) = self.0.lock() {
-            let _ = guard.take();
-        }
-    }
-
-    fn abort(&self) {
-        // Threads cannot be cancelled; the reactor exits when its event loop
-        // returns (the peer connection sends a Close driver event on shutdown).
-    }
-
-    fn is_finished(&self) -> bool {
-        self.0
-            .lock()
-            .map(|guard| guard.as_ref().is_none_or(|handle| handle.is_finished()))
-            .unwrap_or(true)
-    }
-}
-
-/// Wrap a dedicated reactor thread's join handle in a runtime-agnostic [`JoinHandle`].
-/// Used by the tokio and smol [`Runtime::spawn_reactor`] implementations.
-fn reactor_join_handle(join: std::thread::JoinHandle<()>) -> JoinHandle {
-    JoinHandle {
-        inner: Box::new(ThreadReactorHandle(std::sync::Mutex::new(Some(join)))),
-    }
-}
-
 /// Abstracts I/O and timer operations for runtime independence
 ///
 /// This trait allows the WebRTC implementation to work with different async runtimes
@@ -97,17 +112,27 @@ pub trait Runtime: Send + Sync + Debug + 'static {
     #[track_caller]
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> JoinHandle;
 
-    /// Drive `future` to completion on a dedicated single-threaded reactor.
+    /// Drive `future` to completion on a **shared, bounded pool** of
+    /// single-threaded reactors, pinned to one pool thread for its lifetime.
     ///
-    /// The tokio and smol implementations spawn a dedicated OS thread with its
-    /// own single-threaded runtime, confining a peer-connection driver to that
-    /// one thread so the async runtime never migrates it across the shared worker
+    /// The tokio and smol implementations keep a process-global pool of at most
+    /// `N` dedicated OS threads (each hosting its own single-threaded runtime),
+    /// created lazily and sized by [`reactor_pool_size`]. Each `future` is
+    /// assigned to one pool thread round-robin and never migrates off it, so the
+    /// async runtime never moves a peer-connection driver across a shared worker
     /// pool — the dominant cost for in-process data-channel throughput (issue
-    /// #101). The socket wrapping and the whole event loop run inside `future`,
-    /// on this reactor, so I/O resources bind to the dedicated runtime's reactor.
+    /// #101) — while the thread (and per-thread allocator arena) count stays
+    /// bounded by `N` regardless of connection count, instead of one OS thread
+    /// per connection. The socket wrapping and the whole event loop run inside
+    /// `future`, on the pool thread's runtime, so I/O resources bind to it.
+    ///
+    /// `future` runs as an abortable *task* on its pool thread; the returned
+    /// [`JoinHandle`] aborts that task (not a whole thread). Up to a few drivers
+    /// cooperatively share a pool thread; they are I/O-bound and yield at await
+    /// points, so they interleave without blocking one another.
     ///
     /// This is thread confinement, not CPU-core affinity: the OS scheduler may
-    /// still move the thread between cores. Pinning it to a specific core (via
+    /// still move a pool thread between cores. Pinning pool threads to cores (via
     /// `core_affinity`) is a planned follow-up (issue #101).
     ///
     /// The default implementation falls back to [`Runtime::spawn`] on the ambient

--- a/src/runtime/smol.rs
+++ b/src/runtime/smol.rs
@@ -4,7 +4,8 @@ use super::*;
 use ::smol::net::UdpSocket as SmolUdpSocket;
 use ::smol::spawn;
 use std::io::{Read, Write};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 
 /// A WebRTC runtime for smol
 #[derive(Debug)]
@@ -27,9 +28,86 @@ impl super::JoinHandleInner for SmolJoinHandle {
     }
 
     fn is_finished(&self) -> bool {
-        false
+        // Once detached the task is untracked here (treated as finished); otherwise
+        // report the underlying task's completion. The reactor-pool teardown relies
+        // on this to wait for a driver task to actually stop.
+        self.0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_none_or(|task| task.is_finished())
     }
 }
+
+/// Shared, bounded pool of single-threaded reactor executors, replacing the old
+/// one-OS-thread-per-`PeerConnection` model. Each slot is a dedicated thread that
+/// runs exactly one `smol::Executor` via `block_on(ex.run(pending()))`, created
+/// lazily on first use and kept alive for the process lifetime. Because a given
+/// executor is run by only that one thread, its tasks never migrate off it, so
+/// the thread (and per-thread allocator arena) count stays bounded by the pool
+/// size regardless of connection count (issue #101 RSS). See
+/// [`Runtime::spawn_reactor`].
+struct ReactorPool {
+    /// One lazily-initialised pool slot. `Some(executor)` is a live pool thread's
+    /// executor; `None` records that this slot's thread could not be spawned (a rare
+    /// resource-exhaustion failure), so its work falls back to the global executor
+    /// rather than panicking.
+    slots: Box<[OnceLock<Option<Arc<::smol::Executor<'static>>>>]>,
+    next: AtomicUsize,
+}
+
+impl ReactorPool {
+    fn new(size: usize) -> Self {
+        let size = size.clamp(1, super::MAX_REACTOR_POOL_SIZE);
+        let slots = (0..size)
+            .map(|_| OnceLock::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            slots,
+            next: AtomicUsize::new(0),
+        }
+    }
+
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> ::smol::Task<()> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.slots.len();
+        match self.slots[idx].get_or_init(|| spawn_reactor_thread(idx)) {
+            Some(executor) => executor.spawn(future),
+            // Slot thread failed to start; degrade to the global executor rather
+            // than losing the driver (it lacks thread-pinning, but keeps the
+            // connection alive).
+            None => spawn(future),
+        }
+    }
+}
+
+/// Spawn one pool thread — a dedicated OS thread that runs a single `Executor`
+/// forever — and return an `Arc` to that executor, or `None` if the thread could
+/// not be spawned (a rare resource-exhaustion failure; the caller degrades to the
+/// global executor). Because only this thread ever calls `run` on the executor,
+/// tasks spawned onto it stay pinned to this thread (no work-stealing / migration).
+/// smol's I/O reactor is process-global, so sockets wrapped inside those tasks are
+/// pollable here.
+fn spawn_reactor_thread(idx: usize) -> Option<Arc<::smol::Executor<'static>>> {
+    let executor = Arc::new(::smol::Executor::new());
+    let thread_executor = executor.clone();
+    let spawned = std::thread::Builder::new()
+        // Keep <= 15 bytes so the name survives Linux's `comm` truncation.
+        .name(format!("webrtc-rx{idx}"))
+        .spawn(move || {
+            ::smol::block_on(thread_executor.run(std::future::pending::<()>()));
+        });
+    match spawned {
+        Ok(_) => Some(executor),
+        Err(err) => {
+            log::error!("failed to spawn reactor pool thread: {err}");
+            None
+        }
+    }
+}
+
+/// Process-global reactor pool, sized once on first use from [`reactor_pool_size`].
+static REACTOR_POOL: OnceLock<ReactorPool> = OnceLock::new();
 
 impl Runtime for SmolRuntime {
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> super::JoinHandle {
@@ -40,20 +118,15 @@ impl Runtime for SmolRuntime {
     }
 
     fn spawn_reactor(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> super::JoinHandle {
-        let join = std::thread::Builder::new()
-            // Keep <= 15 bytes so the name survives Linux's `comm` truncation.
-            .name("webrtc-reactor".into())
-            .spawn(move || {
-                // Dedicated thread driving this connection's event loop to keep it
-                // off the shared global executor. smol's reactor is process-global,
-                // so sockets wrapped inside `future` are safe to poll here.
-                // TODO(#101): this confines the driver to one thread but does not
-                // pin that thread to a CPU core; a follow-up can set core affinity
-                // via the `core_affinity` crate for cache/NUMA locality.
-                ::smol::block_on(future);
-            })
-            .expect("failed to spawn dedicated reactor thread");
-        super::reactor_join_handle(join)
+        // Route to the process-global bounded reactor pool (built lazily, sized
+        // once from `reactor_pool_size`). The driver runs as a task pinned to one
+        // pool thread; the returned handle aborts that task, not a whole thread.
+        let task = REACTOR_POOL
+            .get_or_init(|| ReactorPool::new(super::reactor_pool_size()))
+            .spawn(future);
+        super::JoinHandle {
+            inner: Box::new(SmolJoinHandle(std::sync::Mutex::new(Some(task)))),
+        }
     }
 
     fn wrap_udp_socket(&self, sock: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>> {

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -1,11 +1,103 @@
 //! Tokio runtime implementation
 
 use super::*;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 
 /// A WebRTC runtime for Tokio
 #[derive(Debug)]
 pub struct TokioRuntime;
+
+/// Shared, bounded pool of single-threaded reactor runtimes, replacing the old
+/// one-OS-thread-per-`PeerConnection` model. Each slot is a dedicated thread
+/// hosting a `new_current_thread` runtime, created lazily on first use and kept
+/// alive for the process lifetime; driver futures are assigned to slots
+/// round-robin and pinned there, so the thread (and per-thread allocator arena)
+/// count is bounded by the pool size regardless of connection count (issue #101
+/// RSS). See [`Runtime::spawn_reactor`].
+struct ReactorPool {
+    /// One lazily-initialised pool slot. A slot's thread is created only when that
+    /// slot is first assigned work, so `M` connections use `min(M, N)` threads (an
+    /// unshared thread each below the bound, then sharing). `Some(handle)` is a live
+    /// pool runtime; `None` records that this slot's thread could not be created
+    /// (a rare resource-exhaustion failure), so its work falls back to the ambient
+    /// runtime instead — never a panic out of `build()`.
+    slots: Box<[OnceLock<Option<::tokio::runtime::Handle>>]>,
+    /// Round-robin cursor over `slots`.
+    next: AtomicUsize,
+}
+
+impl ReactorPool {
+    fn new(size: usize) -> Self {
+        let size = size.clamp(1, MAX_REACTOR_POOL_SIZE);
+        let slots = (0..size)
+            .map(|_| OnceLock::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            slots,
+            next: AtomicUsize::new(0),
+        }
+    }
+
+    fn spawn(
+        &self,
+        future: Pin<Box<dyn Future<Output = ()> + Send>>,
+    ) -> ::tokio::task::JoinHandle<()> {
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % self.slots.len();
+        match self.slots[idx].get_or_init(|| spawn_reactor_thread(idx)) {
+            Some(handle) => handle.spawn(future),
+            // Slot thread failed to start; degrade to the ambient runtime rather
+            // than losing the driver (spawn_reactor is always called from within a
+            // tokio runtime context — the application's — so this is valid).
+            None => ::tokio::spawn(future),
+        }
+    }
+}
+
+/// Spawn one pool thread — a dedicated OS thread hosting a current-thread tokio
+/// runtime — and return a `Handle` onto it, or `None` if the thread or its runtime
+/// could not be built (a rare resource-exhaustion failure; the caller degrades to
+/// the ambient runtime). The thread parks on `block_on(pending())` forever, which
+/// keeps the runtime's I/O and timer drivers running so it can drive every future
+/// later `Handle::spawn`ed onto it while the block_on future itself never completes.
+fn spawn_reactor_thread(idx: usize) -> Option<::tokio::runtime::Handle> {
+    // Rendezvous: hand the freshly-built runtime's Handle back to this caller.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<::tokio::runtime::Handle>(0);
+    let spawned = std::thread::Builder::new()
+        // Keep <= 15 bytes so the name survives Linux's `comm` truncation.
+        .name(format!("webrtc-rx{idx}"))
+        .spawn(move || {
+            match ::tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => {
+                    // Hand back a Handle, then keep the runtime (and its I/O + timer
+                    // drivers) alive so `Handle::spawn`ed driver tasks make progress
+                    // while we park here forever.
+                    let _ = tx.send(rt.handle().clone());
+                    rt.block_on(std::future::pending::<()>());
+                }
+                Err(err) => {
+                    // Dropping `tx` unblocks the rendezvous `recv` with an error.
+                    log::error!("failed to build reactor pool runtime: {err}");
+                }
+            }
+        });
+    match spawned {
+        // `recv` errs only if the thread dropped `tx` without sending, i.e. the
+        // runtime build failed above — surface that as `None`, not a panic.
+        Ok(_) => rx.recv().ok(),
+        Err(err) => {
+            log::error!("failed to spawn reactor pool thread: {err}");
+            None
+        }
+    }
+}
+
+/// Process-global reactor pool, sized once on first use from [`reactor_pool_size`].
+static REACTOR_POOL: OnceLock<ReactorPool> = OnceLock::new();
 
 struct TokioJoinHandle(::tokio::task::JoinHandle<()>);
 
@@ -32,26 +124,15 @@ impl Runtime for TokioRuntime {
     }
 
     fn spawn_reactor(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> super::JoinHandle {
-        let join = std::thread::Builder::new()
-            // Keep <= 15 bytes so the name survives Linux's `comm` truncation.
-            .name("webrtc-reactor".into())
-            .spawn(move || {
-                // A single-threaded runtime: its I/O + timer drivers live on this
-                // one thread, so tokio never migrates the driver task across its
-                // worker pool. enable_all() is required for sleep()/recv_from().
-                // TODO(#101): this confines the driver to one thread but does not
-                // pin that thread to a CPU core; a follow-up can set core affinity
-                // via the `core_affinity` crate for cache/NUMA locality.
-                match ::tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                {
-                    Ok(rt) => rt.block_on(future),
-                    Err(err) => log::error!("failed to build dedicated reactor runtime: {err}"),
-                }
-            })
-            .expect("failed to spawn dedicated reactor thread");
-        super::reactor_join_handle(join)
+        // Route to the process-global bounded reactor pool (built lazily, sized
+        // once from `reactor_pool_size`). The driver runs as a task pinned to one
+        // pool thread; the returned handle aborts that task, not a whole thread.
+        let handle = REACTOR_POOL
+            .get_or_init(|| ReactorPool::new(super::reactor_pool_size()))
+            .spawn(future);
+        super::JoinHandle {
+            inner: Box::new(TokioJoinHandle(handle)),
+        }
     }
 
     fn wrap_udp_socket(&self, sock: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>> {

--- a/tests/dedicated_reactor_drop.rs
+++ b/tests/dedicated_reactor_drop.rs
@@ -1,21 +1,32 @@
-//! Regression test: dropping a dedicated-reactor peer connection *without*
-//! calling `close()` must still terminate its reactor OS thread (issue #101).
+//! Regression tests for the bounded shared reactor pool (issue #101).
 //!
-//! This covers the shutdown-leak window raised in review: `Drop` sets the
-//! `closing` flag and best-effort wakes the driver, so the reactor thread exits
-//! even if the wake could not be enqueued — it does not leak. On Linux we prove
-//! it directly by watching the OS thread named `webrtc-reactor` disappear from
-//! `/proc/self/task`. Each file under `tests/` is its own test binary (own
-//! process), so this thread count is not polluted by other tests.
+//! `with_dedicated_reactor_thread(true)` no longer spawns one OS thread per
+//! `PeerConnection`; it pins each driver to a thread drawn from a process-global
+//! pool of at most `N` threads (`set_reactor_pool_size`). This test asserts the
+//! two properties that replace the old one-thread-per-connection model:
+//!
+//! 1. **Bounded threads (the RSS win):** building `M > N` dedicated-reactor
+//!    connections creates at most `N` reactor threads, not `M`. On Linux we prove
+//!    it directly by counting OS threads named `webrtc-rx*` in `/proc/self/task`.
+//!    Each file under `tests/` is its own test binary (own process), so this
+//!    thread count — and the process-global pool size — is not polluted by other
+//!    tests.
+//!
+//! 2. **Drop terminates the driver task (no leak):** dropping a connection
+//!    *without* `close()` must stop its driver task so the connection's state and
+//!    buffers are freed (the pool thread itself is shared and persists). We prove
+//!    the driver task released the connection by watching a `Weak` to the event
+//!    handler — which only the driver task transitively holds once the app drops
+//!    the connection — become dead.
 use std::sync::Arc;
-
-use webrtc::peer_connection::{PeerConnectionBuilder, PeerConnectionEventHandler};
-use webrtc::runtime::block_on;
-
-#[cfg(target_os = "linux")]
 use std::time::Duration;
-#[cfg(target_os = "linux")]
-use webrtc::runtime::sleep;
+
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::runtime::{block_on, set_reactor_pool_size, sleep};
+
+/// Small pool so `N_CONNECTIONS > POOL_SIZE` and the bound actually bites.
+const POOL_SIZE: usize = 2;
+const N_CONNECTIONS: usize = 5;
 
 struct NoopHandler;
 
@@ -23,7 +34,9 @@ struct NoopHandler;
 impl PeerConnectionEventHandler for NoopHandler {}
 
 #[test]
-fn test_dedicated_reactor_thread_stops_on_drop() {
+fn test_reactor_pool_is_bounded_and_drop_stops_driver_task() {
+    // Size the process-global pool before the first dedicated-reactor build.
+    set_reactor_pool_size(POOL_SIZE);
     block_on(run());
 }
 
@@ -31,40 +44,94 @@ async fn run() {
     #[cfg(target_os = "linux")]
     let before = reactor_thread_count();
 
+    // Build M > N dedicated-reactor connections. Keep only a `Weak` to each
+    // handler: after the connection is dropped, the sole remaining strong ref is
+    // the one the driver task holds (via its `Arc<PeerConnectionRef>`), so the
+    // Weak dies exactly when that task terminates and releases the connection.
+    let mut pcs = Vec::new();
+    let mut handler_weaks = Vec::new();
+    for _ in 0..N_CONNECTIONS {
+        let handler = Arc::new(NoopHandler);
+        handler_weaks.push(Arc::downgrade(&handler));
+        let pc = PeerConnectionBuilder::new()
+            .with_handler(handler) // moves the only app-side strong ref into the builder
+            .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+            .with_dedicated_reactor_thread(true)
+            .build()
+            .await
+            .expect("build dedicated-reactor peer connection");
+        pcs.push(pc);
+    }
+
+    // Property 1: at most POOL_SIZE reactor threads exist, regardless of the
+    // N_CONNECTIONS drivers sharing them.
+    #[cfg(target_os = "linux")]
+    {
+        let bounded = wait_until(Duration::from_secs(5), || {
+            reactor_thread_count() == before + POOL_SIZE
+        })
+        .await;
+        assert!(
+            bounded,
+            "expected exactly {POOL_SIZE} reactor threads for {N_CONNECTIONS} connections, \
+             found {} (pool not bounded / not shared)",
+            reactor_thread_count() - before
+        );
+    }
+
+    // Drop every connection WITHOUT close() — the leak scenario under test.
+    drop(pcs);
+
+    // Property 2: each driver task terminates on drop and releases its connection
+    // state (its handler Weak dies). Without the `Drop` shutdown signal the task
+    // would keep running on its pool thread and this would spin out the timeout.
+    let stopped = wait_until(Duration::from_secs(5), || {
+        handler_weaks.iter().all(|w| w.strong_count() == 0)
+    })
+    .await;
+    assert!(
+        stopped,
+        "a dropped connection's driver task did not terminate (leaked task/state)"
+    );
+
+    // Property 1 (still): the pool threads are shared and persist after the
+    // connections are gone — they are NOT torn down per connection.
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(
+            reactor_thread_count(),
+            before + POOL_SIZE,
+            "reactor pool threads should persist after connections are dropped"
+        );
+    }
+
+    // Liveness: the pool is still usable after those drops — a fresh
+    // dedicated-reactor connection builds on it and reuses the same bounded pool.
+    // Uses the `with_reactor_pool_size` builder knob (equivalent to the free
+    // `set_reactor_pool_size` used above; the pool is already sized, so this is a
+    // no-op here) to exercise that path.
     let pc = PeerConnectionBuilder::new()
         .with_handler(Arc::new(NoopHandler))
         .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
         .with_dedicated_reactor_thread(true)
+        .with_reactor_pool_size(POOL_SIZE)
         .build()
         .await
-        .expect("build dedicated-reactor peer connection");
-
-    // The reactor thread should be running now (build() awaits driver init).
+        .expect("reactor pool unusable after drops");
     #[cfg(target_os = "linux")]
-    {
-        let started = wait_until(Duration::from_secs(5), || {
-            reactor_thread_count() == before + 1
-        })
-        .await;
-        assert!(started, "dedicated reactor thread did not start");
-    }
-
-    // Drop WITHOUT close() — the leak scenario under test.
-    drop(pc);
-
-    // The reactor thread must terminate on drop; otherwise it (and its runtime
-    // and sockets) would leak for the lifetime of the process.
-    #[cfg(target_os = "linux")]
-    {
-        let stopped = wait_until(Duration::from_secs(5), || reactor_thread_count() == before).await;
-        assert!(stopped, "dedicated reactor thread leaked after drop");
-    }
+    assert_eq!(
+        reactor_thread_count(),
+        before + POOL_SIZE,
+        "a new connection must reuse the existing pool, not grow it"
+    );
+    pc.close().await.expect("close");
 }
 
-/// Number of live OS threads named `webrtc-reactor` in this process.
+/// Number of live OS threads whose name starts with `webrtc-rx` in this process.
 ///
 /// The name is set via `std::thread::Builder::name`; Linux truncates thread
-/// names (`comm`) to 15 bytes, so `webrtc-reactor` (14 bytes) survives intact.
+/// names (`comm`) to 15 bytes, so `webrtc-rx{i}` survives intact for realistic
+/// pool sizes.
 #[cfg(target_os = "linux")]
 fn reactor_thread_count() -> usize {
     std::fs::read_dir("/proc/self/task")
@@ -73,14 +140,13 @@ fn reactor_thread_count() -> usize {
         .flatten()
         .filter(|entry| {
             std::fs::read_to_string(entry.path().join("comm"))
-                .map(|comm| comm.trim() == "webrtc-reactor")
+                .map(|comm| comm.trim().starts_with("webrtc-rx"))
                 .unwrap_or(false)
         })
         .count()
 }
 
 /// Poll `cond` until it is true or `timeout` elapses, yielding between checks.
-#[cfg(target_os = "linux")]
 async fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
     let step = Duration::from_millis(10);
     let mut waited = Duration::ZERO;

--- a/tests/sctp_receive_buffer.rs
+++ b/tests/sctp_receive_buffer.rs
@@ -1,0 +1,171 @@
+//! The `with_sctp_receive_buffer_size` builder knob plumbs the SCTP receive
+//! window (a_rwnd) end-to-end, and a sub-RFC-4960-floor value is clamped up so it
+//! doesn't silently break the handshake.
+//!
+//! Both tests establish a real data channel and deliver a message, which only
+//! succeeds if the SCTP association actually formed with the configured window —
+//! exercising the setter, the builder forwarders, and the `start()` branch that
+//! chains `TransportConfig::with_max_receive_buffer_size`.
+use anyhow::Result;
+use bytes::BytesMut;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime, sleep, timeout};
+
+struct SenderHandler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for SenderHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct ReceiverHandler {
+    gather_tx: Sender<()>,
+    received: Arc<AtomicUsize>,
+    runtime: Arc<dyn Runtime>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for ReceiverHandler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let received = self.received.clone();
+        self.runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        received.fetch_add(msg.data.len(), Ordering::Relaxed);
+                    }
+                    DataChannelEvent::OnClose | DataChannelEvent::OnError => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+}
+
+/// Build a sender+receiver pair, both with the given SCTP receive window, open a
+/// data channel and deliver `msg`; assert it arrives (i.e. the association formed).
+async fn exchange_one_message(recv_buf: u32, msg: &[u8]) -> Result<()> {
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let (snd_gather_tx, mut snd_gather_rx) = channel::<()>(1);
+    let (snd_conn_tx, mut snd_conn_rx) = channel::<()>(1);
+    let (rcv_gather_tx, mut rcv_gather_rx) = channel::<()>(1);
+    let received = Arc::new(AtomicUsize::new(0));
+
+    let sender_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(SenderHandler {
+            gather_tx: snd_gather_tx,
+            connected_tx: snd_conn_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_sctp_receive_buffer_size(recv_buf)
+        .build()
+        .await?;
+
+    let dc = sender_pc
+        .create_data_channel("rwnd", Some(RTCDataChannelInit::default()))
+        .await?;
+    let (open_tx, mut open_rx) = channel::<()>(1);
+    {
+        let dc = dc.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        let _ = open_tx.try_send(());
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = sender_pc.create_offer(None).await?;
+    sender_pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), snd_gather_rx.recv()).await;
+    let offer_sdp = sender_pc.local_description().await.expect("offer");
+
+    let receiver_pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(ReceiverHandler {
+            gather_tx: rcv_gather_tx,
+            received: received.clone(),
+            runtime: runtime.clone(),
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .with_sctp_receive_buffer_size(recv_buf)
+        .build()
+        .await?;
+
+    receiver_pc.set_remote_description(offer_sdp).await?;
+    let answer = receiver_pc.create_answer(None).await?;
+    receiver_pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), rcv_gather_rx.recv()).await;
+    let answer_sdp = receiver_pc.local_description().await.expect("answer");
+    sender_pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), snd_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: connect (recv_buf={recv_buf})"))?;
+    timeout(Duration::from_secs(10), open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
+
+    dc.send(BytesMut::from(msg)).await?;
+
+    let mut delivered = false;
+    for _ in 0..100 {
+        if received.load(Ordering::Relaxed) >= msg.len() {
+            delivered = true;
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        delivered,
+        "message not delivered with sctp_receive_buffer_size={recv_buf} — association did not form/flow"
+    );
+
+    sender_pc.close().await?;
+    receiver_pc.close().await?;
+    Ok(())
+}
+
+#[test]
+fn test_sctp_receive_buffer_size_lowered() {
+    // A realistic lowered window (256 KiB): the whole plumbing path + start() Some-branch.
+    block_on(exchange_one_message(256 * 1024, b"hello rwnd")).unwrap();
+}
+
+#[test]
+fn test_sctp_receive_buffer_size_below_rfc_floor_is_clamped() {
+    // 1000 < RFC 4960's 1500-byte floor: the setter clamps it up, so the handshake
+    // still succeeds and data flows. Without the clamp the peer would reject our INIT
+    // (ErrInitAdvertisedReceiver1500) and this would time out.
+    block_on(exchange_one_message(1000, b"clamped")).unwrap();
+}


### PR DESCRIPTION
Two related memory/scalability features. They share `peer_connection/mod.rs`
(both add builder methods), so they are on one branch/commit; happy to split
into stacked PRs if you'd prefer.

## 1. Bounded shared reactor pool (issue #101)

Replace the **one-OS-thread-per-`PeerConnection`** dedicated reactor
(`with_dedicated_reactor_thread`) with a **process-global bounded pool** of `N`
lazily-created single-threaded reactor threads — tokio current-thread runtimes
kept alive via `block_on(pending())`; smol `Executor`s — with each driver
pinned to a pool thread round-robin. The driver is now an abortable **task**,
not a whole OS thread.

**Why:** above ~`num_cpus` connections, thread-per-PC oversubscribes the CPU
and RSS grows with connection count. The pool bounds both. Measured (ported
data-channel bench, Ryzen 1700/16T, `thr / peak_rss / threads`):

| conns | thread-per-PC | pool N=16 | pool N=8 |
|---|---|---|---|
| 20  | **242 / 715 MB / 37** | 205 / 863 / 33 | 147 / 732 / 25 |
| 60  | 212 / 1280 / 77 | **271 / 1006 / 33** | 239 / 784 / 25 |
| 100 | 279 / 1623 / 117 | **337 / 1169 / 33** | 267 / 810 / 25 |

Above the crossover (conns > cores — the SFU target) the pool wins on **both**
throughput and RSS, and RSS stops scaling with connection count (pool +35% over
a 5× connection increase vs +127% for thread-per-PC). Below the crossover it is
a mild throughput trade with no RSS win, so it stays **off by default**.

Config: `with_reactor_pool_size(n)` / `runtime::set_reactor_pool_size(n)` /
`WEBRTC_REACTOR_POOL_SIZE` (default = host parallelism, clamped ≤ 1024). A
pool-thread build/spawn failure degrades to the ambient runtime rather than
panicking.

## 2. Configurable SCTP receive window (a_rwnd)

`PeerConnectionBuilder::with_sctp_receive_buffer_size(u32)` forwards the new
`rtc` `SettingEngine` setting, letting many-connection / low-RTT deployments
shrink the 1 MiB SCTP receive window (stacks with the pool: ≈ −70% peak_rss
combined at 100 conns). Sub-1500-byte values are clamped (RFC 4960 §6). Default
unchanged.

## Depends on

**webrtc-rs/rtc#129** (the SCTP receive-buffer setting). The submodule here is
bumped to that branch commit. ⚠️ **CI will be red until #129 merges** and the
submodule is re-pinned to the merged `rtc` commit — the branch commit is only on
my `rtc` fork, so upstream's recursive submodule checkout can't resolve it yet
(same flow as #817 / rtc#127). Marked **draft** for that reason.

## Tests

Both runtime suites green (tokio + smol). Rewrote the dedicated-reactor drop
test for the bounded-pool invariants (thread count bounded by pool size; drop
terminates the driver *task*), and added an SCTP receive-window data-channel
round-trip test (incl. a sub-1500 value proving the clamp keeps the handshake
working). Reviewed via two adversarial multi-agent passes; the one confirmed
issue (rwnd sub-1500 footgun) is the clamp above.