### PR TITLE
perf(driver): UDP GSO send + GRO receive batching via quinn-udp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ description = "Async-friendly WebRTC implementation in Rust"
 
 [features]
 default = ["runtime-tokio"]
-runtime-tokio = ["dep:tokio"]
-runtime-smol = ["dep:smol", "dep:async-broadcast"]
+runtime-tokio = ["dep:tokio", "dep:quinn-udp"]
+runtime-smol = ["dep:smol", "dep:async-broadcast", "dep:quinn-udp"]
 
 [dependencies]
 rtc = { version = "0.20.0-rc.3", path = "rtc/rtc" }
@@ -28,6 +28,12 @@ futures = "0.3.32"
 tokio = { version = "1.52.3", features = ["net", "time", "sync", "rt", "rt-multi-thread"], optional = true }
 smol = { version = "2.0.2", optional = true }
 async-broadcast = { version = "0.7.2", optional = true }
+
+# UDP GSO (UDP_SEGMENT) send batching + GRO receive coalescing. Runtime-agnostic
+# (sync, non-blocking); driven through each runtime's readiness loop. Pulled in by
+# whichever runtime feature is enabled. `default-features = false` drops its optional
+# tracing/log integration (we use `log` directly in the wrappers).
+quinn-udp = { version = "0.6", default-features = false, optional = true }
 
 [dev-dependencies]
 signal = { version = "0.20.0-rc.3", path = "rtc/examples/examples/signal", package = "rtc-signal" }

--- a/examples/data-channels-flow-control-multi/data-channels-flow-control-multi.rs
+++ b/examples/data-channels-flow-control-multi/data-channels-flow-control-multi.rs
@@ -28,7 +28,7 @@ use webrtc::runtime::{Runtime, Sender, block_on, channel, default_runtime};
 
 const BUFFERED_LOW: u32 = 512 * 1024; // 512 KB
 const BUFFERED_HIGH: u32 = 1024 * 1024; // 1 MB
-const CHUNK: usize = 1024; // 1 KB messages
+// Application message size is set at runtime via FLOW_MSG_KB (default 1 KB).
 
 fn env_usize(key: &str, default: usize) -> usize {
     std::env::var(key)
@@ -135,6 +135,8 @@ async fn run_pair(
     dedicated: bool,
     warmup_bytes: usize,
     stop_bytes: usize,
+    chunk_bytes: usize,
+    ordered: bool,
     mbps_tx: Sender<f64>,
 ) -> anyhow::Result<[Arc<dyn PeerConnection>; 2]> {
     let stop = Arc::new(AtomicBool::new(false));
@@ -150,18 +152,22 @@ async fn run_pair(
     )
     .await?;
 
-    // Unordered / no-retransmit — matches the stock data-channels-flow-control example
-    // (and pion's), so each stack's N-pair bench uses that stack's own example config.
-    let dc = requester
-        .create_data_channel(
-            "data",
-            Some(RTCDataChannelInit {
-                ordered: false,
-                max_retransmits: Some(0),
-                ..Default::default()
-            }),
-        )
-        .await?;
+    // Default: unordered / no-retransmit (matches the stock data-channels-flow-control
+    // example and pion's). FLOW_ORDERED=1 switches to ordered + reliable (no
+    // max_retransmits), matching the batch-drain issue-101 comment's harness.
+    let dc_init = if ordered {
+        RTCDataChannelInit {
+            ordered: true,
+            ..Default::default()
+        }
+    } else {
+        RTCDataChannelInit {
+            ordered: false,
+            max_retransmits: Some(0),
+            ..Default::default()
+        }
+    };
+    let dc = requester.create_data_channel("data", Some(dc_init)).await?;
     dc.set_buffered_amount_low_threshold(BUFFERED_LOW).await?;
     dc.set_buffered_amount_high_threshold(BUFFERED_HIGH).await?;
 
@@ -169,7 +175,7 @@ async fn run_pair(
     {
         let stop = stop.clone();
         runtime.spawn(Box::pin(async move {
-            let buf = BytesMut::from(vec![0u8; CHUNK].as_slice());
+            let buf = BytesMut::from(vec![0u8; chunk_bytes].as_slice());
             let mut dc_open = false;
             let mut paused = false;
             loop {
@@ -244,6 +250,15 @@ async fn async_main() -> anyhow::Result<()> {
     let pairs = env_usize("FLOW_PAIRS", 10);
     let warmup_bytes = env_usize("FLOW_WARMUP_MB", 64) * 1024 * 1024;
     let stop_bytes = env_usize("FLOW_STOP_MB", 128) * 1024 * 1024;
+    // Application message size. Large messages (e.g. 64) fragment into many MTU-sized
+    // SCTP DATA chunks -> many same-size datagrams to one peer, which the driver
+    // coalesces into single UDP GSO syscalls; 1 (the default) is one datagram/message.
+    let chunk_bytes = env_usize("FLOW_MSG_KB", 1) * 1024;
+    // FLOW_ORDERED=1 -> ordered + reliable data channel (issue-101 batch-drain harness);
+    // default is unordered / no-retransmit.
+    let ordered = std::env::var("FLOW_ORDERED")
+        .map(|v| v != "0")
+        .unwrap_or(false);
     let dedicated = std::env::var("FLOW_DEDICATED_REACTOR")
         .map(|v| v != "0")
         .unwrap_or(true);
@@ -262,6 +277,8 @@ async fn async_main() -> anyhow::Result<()> {
             dedicated,
             warmup_bytes,
             stop_bytes,
+            chunk_bytes,
+            ordered,
             mbps_tx.clone(),
         )
         .await?;

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -59,6 +59,28 @@ const UDP_RECV_BUF_LEN: usize = 2000;
 /// receive (`UDP_SEGMENT`/GRO cap is 64 per buffer).
 const MAX_GRO_SEGMENTS: usize = 64;
 
+/// Upper bound on datagrams coalesced into one UDP GSO send. The kernel caps
+/// `UDP_SEGMENT` at 64 segments per `sendmsg`; a socket may report fewer.
+const MAX_GSO_SEGMENTS: usize = 64;
+
+/// Upper bound on the total bytes of one UDP GSO batch. Kept at the single-datagram
+/// UDP payload limit (65535) so a batch never trips the kernel's aggregate-size
+/// checks and disables GSO — at ~1.25 KB datagrams this still coalesces ~50 per call.
+const MAX_GSO_BATCH_BYTES: usize = 65535;
+
+/// Minimum datagrams in a run before it is worth a single GSO `sendmsg` instead of
+/// individual `send_to`s. GSO trades N cheap `sendto` syscalls for one heavier
+/// `sendmsg` (control-message construction + kernel GSO setup) plus one buffer
+/// concatenation, so it only pays off once the run is large. Below this the batching
+/// machinery is pure overhead — exactly the paced single-connection case, where the
+/// watermark dribbles a few datagrams per flush. A too-low threshold there GSOs the
+/// occasional large drain and thrashes the tiny working set (measured on loopback:
+/// threshold 2 → wall +58%, threshold 8 → +21%, threshold 16 → −15% i.e. back to a
+/// win). Throughput-bound bursts (bulk/flood/many-connection) run far larger (50+),
+/// so 16 keeps their full win (N=10 wall −34%, flood +77%) while erasing the
+/// single-connection regression.
+const MIN_GSO_RUN: usize = 16;
+
 /// Per-datagram size assumed when sizing a GRO receive buffer, at the standard
 /// Ethernet MTU. GRO coalesces up to `max_gro_segments()` datagrams into one buffer,
 /// each at most one wire MTU, so the buffer must be `max_gro_segments() *
@@ -112,6 +134,9 @@ where
     tcp_transport: RTCTcpTransport,
     mdns_socket: Option<Arc<dyn AsyncUdpSocket>>,
     udp_sockets: HashMap<SocketAddr, Arc<dyn AsyncUdpSocket>>,
+    /// Reused scratch buffer for concatenating a run of same-destination datagrams
+    /// into one UDP GSO send (see [`flush_writes`](Self::flush_writes)).
+    gso_scratch: Vec<u8>,
     ice_gathering_active: bool,
     stun_gathering_complete: bool,
     turn_gathering_complete: bool,
@@ -140,6 +165,7 @@ where
             turn_relayer,
             mdns_socket,
             udp_sockets,
+            gso_scratch: Vec::new(),
             tcp_transport: RTCTcpTransport::new(tcp_listeners),
             ice_gathering_active: false,
             stun_gathering_complete: false,
@@ -1049,18 +1075,140 @@ where
             }
         }
 
-        // 1.c peer_connection poll_write() - Send all outgoing packets
-        for msg in Self::drain_core_writes(self.inner.clone()).await {
-            let four_tuple: FourTuple = FourTuple::from(&msg.transport);
-            if let Err(err) = self.handle_write(msg).await {
-                error!(
-                    "Failed to write packet to {:?} from {:?}: {}",
-                    four_tuple.peer_addr, four_tuple.local_addr, err
-                );
-            }
-        }
+        // 1.c peer_connection poll_write() - Send all outgoing packets, coalescing
+        // consecutive same-destination datagrams into single UDP GSO syscalls.
+        let writes = Self::drain_core_writes(self.inner.clone()).await;
+        self.flush_writes(writes).await;
 
         Ok(())
+    }
+
+    /// Send a drained batch of outgoing packets, coalescing maximal runs of
+    /// consecutive datagrams sharing the same UDP `(local_addr, peer_addr, ecn)`
+    /// into a single `UDP_SEGMENT` (GSO) syscall.
+    ///
+    /// During a bulk transfer the ICE handler stamps every non-STUN packet with the
+    /// one selected candidate pair, so these runs are long and homogeneous (each an
+    /// MTU-sized DTLS record → equal-size datagram) — the ideal GSO case. A run is
+    /// extended while the next datagram has the same 4-tuple and is exactly
+    /// `segment_size` bytes (a shorter datagram can only be the run's final segment,
+    /// a larger one starts a fresh run), capped by the socket's GSO segment limit and
+    /// [`MAX_GSO_BATCH_BYTES`]. Everything the GSO path can't own — TCP, mDNS,
+    /// TURN-relayed, or datagrams for an unknown socket — falls back to the
+    /// per-packet [`handle_write`](Self::handle_write) path unchanged.
+    async fn flush_writes(&mut self, mut writes: Vec<TaggedBytesMut>) {
+        // Borrow the reusable concat buffer out of `self` so the sends below don't
+        // hold a `&self` borrow across `.await`.
+        let mut scratch = std::mem::take(&mut self.gso_scratch);
+        let n = writes.len();
+        let mut i = 0;
+        while i < n {
+            let tp = writes[i].transport;
+            let seg = writes[i].message.len();
+
+            // Only plain UDP datagrams routed to one of our sockets are GSO-eligible.
+            let plain_udp = tp.transport_protocol == TransportProtocol::UDP
+                && tp.peer_addr.port() != MDNS_PORT
+                && !self.turn_relayer.contains_local_addr(tp.local_addr)
+                && self.udp_sockets.contains_key(&tp.local_addr);
+            if !plain_udp {
+                // TCP / mDNS / TURN-relayed / unknown-socket: owned per-packet path.
+                // Move the message out (writes[i] is never read again) rather than
+                // cloning it — this runs for every packet on a TURN-relayed connection,
+                // so a per-packet deep copy here would be a real cost.
+                let msg = TaggedBytesMut {
+                    now: writes[i].now,
+                    transport: writes[i].transport,
+                    message: std::mem::take(&mut writes[i].message),
+                };
+                let four_tuple: FourTuple = FourTuple::from(&msg.transport);
+                if let Err(err) = self.handle_write(msg).await {
+                    error!(
+                        "Failed to write packet to {:?} from {:?}: {}",
+                        four_tuple.peer_addr, four_tuple.local_addr, err
+                    );
+                }
+                i += 1;
+                continue;
+            }
+
+            let socket = self.udp_sockets.get(&tp.local_addr).unwrap().clone();
+            let ecn = tp.ecn.map(|e| e as u8);
+
+            // Max datagrams the kernel accepts in one GSO `sendmsg` for this socket
+            // (1 = GSO unavailable / empty first datagram → no batching).
+            let max_seg = if seg > 0 {
+                socket.max_gso_segments().min(MAX_GSO_SEGMENTS)
+            } else {
+                1
+            };
+
+            // Grow the GSO run [i, end) while the 4-tuple matches and the size rule holds.
+            let mut end = i + 1;
+            if max_seg > 1 {
+                let mut total = seg;
+                while (end - i) < max_seg && end < n {
+                    let w_tp = writes[end].transport;
+                    // Same 4-tuple (local, peer) already implies non-mDNS and
+                    // non-TURN-relayed here (tp passed the plain_udp gate), so those two
+                    // checks are not repeated; protocol/ecn still must match.
+                    if w_tp.transport_protocol != TransportProtocol::UDP
+                        || w_tp.peer_addr != tp.peer_addr
+                        || w_tp.local_addr != tp.local_addr
+                        || w_tp.ecn.map(|e| e as u8) != ecn
+                    {
+                        break;
+                    }
+                    let wl = writes[end].message.len();
+                    // A larger datagram cannot be a GSO segment — it starts the next run.
+                    if wl == 0 || wl > seg || total + wl > MAX_GSO_BATCH_BYTES {
+                        break;
+                    }
+                    total += wl;
+                    end += 1;
+                    // A shorter datagram is only valid as the run's final segment.
+                    if wl < seg {
+                        break;
+                    }
+                }
+            }
+
+            // GSO only when the run is both worth it and physically batchable. Clamp the
+            // threshold to `max_seg` so a socket with a small GSO limit (< MIN_GSO_RUN)
+            // still batches rather than degrading to all-singleton sends.
+            if max_seg > 1 && end - i >= MIN_GSO_RUN.min(max_seg) {
+                // Large run: one GSO sendmsg beats end-i individual send_to syscalls.
+                scratch.clear();
+                for w in &writes[i..end] {
+                    scratch.extend_from_slice(&w.message);
+                }
+                if let Err(err) = socket.send_segments(&scratch, seg, tp.peer_addr, ecn).await {
+                    error!(
+                        "Failed to GSO-send {} datagrams to {:?} from {:?}: {}",
+                        end - i,
+                        tp.peer_addr,
+                        tp.local_addr,
+                        err
+                    );
+                }
+            } else {
+                // Small run (or singleton): individual send_to is cheaper than the GSO
+                // setup. (ECN is carried only on the GSO run path; inert today since the
+                // rtc core always emits ecn: None.)
+                for w in &writes[i..end] {
+                    if let Err(err) = socket.send_to(&w.message, tp.peer_addr).await {
+                        error!(
+                            "Failed to write packet to {:?} from {:?}: {}",
+                            tp.peer_addr, tp.local_addr, err
+                        );
+                    }
+                }
+            }
+            i = end;
+        }
+
+        scratch.clear();
+        self.gso_scratch = scratch;
     }
 
     async fn poll_events(&mut self) {

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -55,6 +55,37 @@ pub(crate) const TRACK_LOCAL_EVENT_CHANNEL_CAPACITY: usize = 256;
 const DEFAULT_TIMEOUT_DURATION: Duration = Duration::from_secs(86400); // 1 day duration
 const UDP_RECV_BUF_LEN: usize = 2000;
 
+/// Upper bound on the number of datagrams the kernel may coalesce into one UDP GRO
+/// receive (`UDP_SEGMENT`/GRO cap is 64 per buffer).
+const MAX_GRO_SEGMENTS: usize = 64;
+
+/// Per-datagram size assumed when sizing a GRO receive buffer, at the standard
+/// Ethernet MTU. GRO coalesces up to `max_gro_segments()` datagrams into one buffer,
+/// each at most one wire MTU, so the buffer must be `max_gro_segments() *
+/// GRO_RECV_SEGMENT_LEN` — the kernel truncates (silently drops the tail datagrams)
+/// if the coalesced super-datagram overflows the buffer. WebRTC keeps its own
+/// datagrams well under this (DTLS/SCTP MTU ~1200); the 1500 headroom covers a peer
+/// sending up to standard-MTU-sized datagrams. Jumbo-frame paths (MTU > 1500) are not
+/// supported for GRO and would truncate.
+const GRO_RECV_SEGMENT_LEN: usize = 1500;
+
+/// Size a UDP receive buffer for a socket that may coalesce `max_gro` datagrams via
+/// GRO. Falls back to the plain single-datagram size when GRO is unavailable.
+///
+/// NOTE: with GRO enabled this returns ~96 KB (64 * 1500) per socket vs the ~2 KB
+/// non-GRO size — a real per-connection RSS cost that scales with socket count
+/// (relevant at SFU scale). It cannot be shrunk without risking truncation (see
+/// [`GRO_RECV_SEGMENT_LEN`]); the buffers are zero-initialized so pages stay unmapped
+/// until actually written. Measured net effect is still an RSS *reduction* under load
+/// because batching cuts per-packet allocator churn far more than the buffers cost.
+fn gro_recv_buf_len(max_gro: usize) -> usize {
+    if max_gro > 1 {
+        max_gro.min(MAX_GRO_SEGMENTS) * GRO_RECV_SEGMENT_LEN
+    } else {
+        UDP_RECV_BUF_LEN
+    }
+}
+
 /// Unified inner message type for the peer connection driver
 #[derive(Debug)]
 pub(crate) enum PeerConnectionDriverEvent {
@@ -151,22 +182,27 @@ where
             }))
             .collect();
 
-        // Pre-allocate buffers once - one per socket, these will be reused forever
+        // Pre-allocate buffers once - one per socket, these will be reused forever.
+        // Sized for the socket's GRO coalescing capacity so a single `recv_gro` can
+        // hold up to `max_gro_segments()` datagrams without truncation.
         let mut udp_socket_buffers: Vec<Vec<u8>> = udp_socket_list
             .iter()
-            .map(|_| vec![0u8; UDP_RECV_BUF_LEN])
+            .map(|(_, socket)| vec![0u8; gro_recv_buf_len(socket.max_gro_segments())])
             .collect();
 
-        // Helper function to create a recv future for a specific socket
+        // Helper function to create a recv future for a specific socket. Uses GRO
+        // (`recv_gro`) so one syscall may return several coalesced datagrams; `stride`
+        // carries the per-datagram size for de-segmentation by the caller.
         let create_udp_recv_future = |idx: usize,
                                       local_addr: SocketAddr,
                                       socket: Arc<dyn AsyncUdpSocket>,
                                       mut buf: Vec<u8>| async move {
-            match socket.recv_from(&mut buf).await {
-                Ok((n, peer_addr)) => SocketRecvResult::Packet {
-                    n,
+            match socket.recv_gro(&mut buf).await {
+                Ok(gro) => SocketRecvResult::Packet {
+                    n: gro.len,
+                    stride: gro.stride,
                     local_addr,
-                    peer_addr,
+                    peer_addr: gro.peer_addr,
                     idx,
                     buf,
                 },
@@ -197,7 +233,14 @@ where
         // amortizes the per-iteration cost (poll_writes/events/reads core locks,
         // timeout recompute, select setup).
         const MAX_UDP_RECV_BURST: usize = 64;
-        let mut burst_buf = vec![0u8; UDP_RECV_BUF_LEN];
+        // The burst buffer is shared across sockets, so size it for the largest GRO
+        // capacity among them (falls back to the plain size when none support GRO).
+        let burst_buf_len = udp_socket_list
+            .iter()
+            .map(|(_, socket)| gro_recv_buf_len(socket.max_gro_segments()))
+            .max()
+            .unwrap_or(UDP_RECV_BUF_LEN);
+        let mut burst_buf = vec![0u8; burst_buf_len];
 
         loop {
             // Shutdown safety-net. `close()`/`Drop` set this flag and best-effort
@@ -291,21 +334,13 @@ where
                 udp_recv_result = udp_recv_future => {
                     if let Some(res) = udp_recv_result {
                         match res {
-                            Some(SocketRecvResult::Packet { n, local_addr, peer_addr, idx, buf }) => {
+                            Some(SocketRecvResult::Packet { n, stride, local_addr, peer_addr, idx, buf }) => {
                                 trace!("Received {} bytes from {} to {}", n, peer_addr, local_addr);
 
-                                if let Err(err) = self.handle_read(TaggedBytesMut {
-                                    now: Instant::now(),
-                                    transport: TransportContext {
-                                        local_addr,
-                                        peer_addr,
-                                        ecn: None,
-                                        transport_protocol: TransportProtocol::UDP,
-                                    },
-                                    message: BytesMut::from(&buf[..n]),
-                                }).await {
-                                     error!("handle_read error: {}", err);
-                                }
+                                // A single recv may return several GRO-coalesced
+                                // datagrams; split `buf[..n]` back into individual
+                                // datagrams by `stride` and deliver each.
+                                self.deliver_udp_batch(&buf, n, stride, local_addr, peer_addr).await;
 
                                 // Immediately create a new future for this socket and reuse the buffer
                                 let (socket_local_addr, socket) = &udp_socket_list[idx];
@@ -319,21 +354,9 @@ where
                                 // ready datagrams from this socket without blocking.
                                 let mut burst = 0;
                                 while burst < MAX_UDP_RECV_BURST {
-                                    match socket.recv_from(&mut burst_buf).now_or_never() {
-                                        Some(Ok((bn, bpeer))) => {
-                                            let bmsg = BytesMut::from(&burst_buf[..bn]);
-                                            if let Err(err) = self.handle_read(TaggedBytesMut {
-                                                now: Instant::now(),
-                                                transport: TransportContext {
-                                                    local_addr: socket_local_addr,
-                                                    peer_addr: bpeer,
-                                                    ecn: None,
-                                                    transport_protocol: TransportProtocol::UDP,
-                                                },
-                                                message: bmsg,
-                                            }).await {
-                                                error!("handle_read error (burst): {}", err);
-                                            }
+                                    match socket.recv_gro(&mut burst_buf).now_or_never() {
+                                        Some(Ok(gro)) => {
+                                            self.deliver_udp_batch(&burst_buf, gro.len, gro.stride, socket_local_addr, gro.peer_addr).await;
                                             burst += 1;
                                         }
                                         _ => break, // would-block (pending) or error
@@ -422,6 +445,45 @@ where
                 msg.transport.peer_addr, msg.transport.local_addr, msg.transport.transport_protocol
             );
             Ok(0)
+        }
+    }
+
+    /// Split a (possibly GRO-coalesced) UDP receive buffer into individual datagrams
+    /// and feed each to [`handle_read`](Self::handle_read).
+    ///
+    /// `buf[..n]` holds one or more datagrams of `stride` bytes each (the last may be
+    /// shorter). When `stride == n` (no GRO, or a lone datagram) this delivers exactly
+    /// one datagram — identical to the pre-GRO behavior. A zero-length datagram
+    /// (`n == 0`) is dropped (the loop never runs); empty UDP datagrams carry no
+    /// STUN/DTLS/SCTP payload, so this is harmless.
+    async fn deliver_udp_batch(
+        &mut self,
+        buf: &[u8],
+        n: usize,
+        stride: usize,
+        local_addr: SocketAddr,
+        peer_addr: SocketAddr,
+    ) {
+        let step = stride.max(1);
+        let mut off = 0;
+        while off < n {
+            let end = (off + step).min(n);
+            if let Err(err) = self
+                .handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&buf[off..end]),
+                })
+                .await
+            {
+                error!("handle_read error: {}", err);
+            }
+            off = end;
         }
     }
 
@@ -1061,5 +1123,24 @@ where
         let mut core = self.inner.core.lock().await;
         core.handle_timeout(now)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod gro_buf_tests {
+    use super::{GRO_RECV_SEGMENT_LEN, MAX_GRO_SEGMENTS, UDP_RECV_BUF_LEN, gro_recv_buf_len};
+
+    #[test]
+    fn gro_recv_buf_len_sizes_for_capacity_and_falls_back_without_gro() {
+        // GRO available: sized to hold up to `max_gro` coalesced datagrams.
+        assert_eq!(gro_recv_buf_len(64), 64 * GRO_RECV_SEGMENT_LEN);
+        assert_eq!(gro_recv_buf_len(8), 8 * GRO_RECV_SEGMENT_LEN);
+        // Capped at the kernel's max coalescing (MAX_GRO_SEGMENTS).
+        assert_eq!(
+            gro_recv_buf_len(1000),
+            MAX_GRO_SEGMENTS * GRO_RECV_SEGMENT_LEN
+        );
+        // GRO unavailable (max_gro <= 1): plain single-datagram buffer.
+        assert_eq!(gro_recv_buf_len(1), UDP_RECV_BUF_LEN);
     }
 }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -12,7 +12,10 @@ use crate::media_stream::track_remote::static_rtp::TrackRemoteStaticRTP;
 use crate::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
 use crate::peer_connection::PeerConnectionRef;
 use crate::peer_connection::transports::tcp_transport::RTCTcpTransport;
-use crate::peer_connection::transports::{SocketRecvResult, is_retryable_socket_recv_error};
+use crate::peer_connection::transports::{
+    MAX_GSO_BATCH_BYTES, MAX_GSO_SEGMENTS, MIN_GSO_RUN, SocketRecvResult, UDP_RECV_BUF_LEN,
+    gro_recv_buf_len, is_retryable_socket_recv_error,
+};
 use crate::rtp_transceiver::rtp_receiver::RtpReceiverImpl;
 use crate::rtp_transceiver::{RtpReceiver, RtpTransceiverImpl};
 use crate::runtime::{AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, Receiver, channel};
@@ -53,60 +56,6 @@ pub(crate) const TRACK_REMOTE_EVENT_CHANNEL_CAPACITY: usize = 256;
 pub(crate) const TRACK_LOCAL_EVENT_CHANNEL_CAPACITY: usize = 256;
 
 const DEFAULT_TIMEOUT_DURATION: Duration = Duration::from_secs(86400); // 1 day duration
-const UDP_RECV_BUF_LEN: usize = 2000;
-
-/// Upper bound on the number of datagrams the kernel may coalesce into one UDP GRO
-/// receive (`UDP_SEGMENT`/GRO cap is 64 per buffer).
-const MAX_GRO_SEGMENTS: usize = 64;
-
-/// Upper bound on datagrams coalesced into one UDP GSO send. The kernel caps
-/// `UDP_SEGMENT` at 64 segments per `sendmsg`; a socket may report fewer.
-const MAX_GSO_SEGMENTS: usize = 64;
-
-/// Upper bound on the total bytes of one UDP GSO batch. Kept at the single-datagram
-/// UDP payload limit (65535) so a batch never trips the kernel's aggregate-size
-/// checks and disables GSO — at ~1.25 KB datagrams this still coalesces ~50 per call.
-const MAX_GSO_BATCH_BYTES: usize = 65535;
-
-/// Minimum datagrams in a run before it is worth a single GSO `sendmsg` instead of
-/// individual `send_to`s. GSO trades N cheap `sendto` syscalls for one heavier
-/// `sendmsg` (control-message construction + kernel GSO setup) plus one buffer
-/// concatenation, so it only pays off once the run is large. Below this the batching
-/// machinery is pure overhead — exactly the paced single-connection case, where the
-/// watermark dribbles a few datagrams per flush. A too-low threshold there GSOs the
-/// occasional large drain and thrashes the tiny working set (measured on loopback:
-/// threshold 2 → wall +58%, threshold 8 → +21%, threshold 16 → −15% i.e. back to a
-/// win). Throughput-bound bursts (bulk/flood/many-connection) run far larger (50+),
-/// so 16 keeps their full win (N=10 wall −34%, flood +77%) while erasing the
-/// single-connection regression.
-const MIN_GSO_RUN: usize = 16;
-
-/// Per-datagram size assumed when sizing a GRO receive buffer, at the standard
-/// Ethernet MTU. GRO coalesces up to `max_gro_segments()` datagrams into one buffer,
-/// each at most one wire MTU, so the buffer must be `max_gro_segments() *
-/// GRO_RECV_SEGMENT_LEN` — the kernel truncates (silently drops the tail datagrams)
-/// if the coalesced super-datagram overflows the buffer. WebRTC keeps its own
-/// datagrams well under this (DTLS/SCTP MTU ~1200); the 1500 headroom covers a peer
-/// sending up to standard-MTU-sized datagrams. Jumbo-frame paths (MTU > 1500) are not
-/// supported for GRO and would truncate.
-const GRO_RECV_SEGMENT_LEN: usize = 1500;
-
-/// Size a UDP receive buffer for a socket that may coalesce `max_gro` datagrams via
-/// GRO. Falls back to the plain single-datagram size when GRO is unavailable.
-///
-/// NOTE: with GRO enabled this returns ~96 KB (64 * 1500) per socket vs the ~2 KB
-/// non-GRO size — a real per-connection RSS cost that scales with socket count
-/// (relevant at SFU scale). It cannot be shrunk without risking truncation (see
-/// [`GRO_RECV_SEGMENT_LEN`]); the buffers are zero-initialized so pages stay unmapped
-/// until actually written. Measured net effect is still an RSS *reduction* under load
-/// because batching cuts per-packet allocator churn far more than the buffers cost.
-fn gro_recv_buf_len(max_gro: usize) -> usize {
-    if max_gro > 1 {
-        max_gro.min(MAX_GRO_SEGMENTS) * GRO_RECV_SEGMENT_LEN
-    } else {
-        UDP_RECV_BUF_LEN
-    }
-}
 
 /// Unified inner message type for the peer connection driver
 #[derive(Debug)]
@@ -1271,24 +1220,5 @@ where
         let mut core = self.inner.core.lock().await;
         core.handle_timeout(now)?;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod gro_buf_tests {
-    use super::{GRO_RECV_SEGMENT_LEN, MAX_GRO_SEGMENTS, UDP_RECV_BUF_LEN, gro_recv_buf_len};
-
-    #[test]
-    fn gro_recv_buf_len_sizes_for_capacity_and_falls_back_without_gro() {
-        // GRO available: sized to hold up to `max_gro` coalesced datagrams.
-        assert_eq!(gro_recv_buf_len(64), 64 * GRO_RECV_SEGMENT_LEN);
-        assert_eq!(gro_recv_buf_len(8), 8 * GRO_RECV_SEGMENT_LEN);
-        // Capped at the kernel's max coalescing (MAX_GRO_SEGMENTS).
-        assert_eq!(
-            gro_recv_buf_len(1000),
-            MAX_GRO_SEGMENTS * GRO_RECV_SEGMENT_LEN
-        );
-        // GRO unavailable (max_gro <= 1): plain single-datagram buffer.
-        assert_eq!(gro_recv_buf_len(1), UDP_RECV_BUF_LEN);
     }
 }

--- a/src/peer_connection/transports/mod.rs
+++ b/src/peer_connection/transports/mod.rs
@@ -8,7 +8,12 @@ pub(crate) mod turn_relayer;
 
 pub(crate) enum SocketRecvResult {
     Packet {
+        /// Total bytes received into `buf` across all GRO-coalesced datagrams.
         n: usize,
+        /// Per-datagram size for GRO de-segmentation; `buf[..n]` is walked in
+        /// `stride`-sized steps (the last datagram may be shorter). Equals `n`
+        /// when a single datagram was received.
+        stride: usize,
         local_addr: SocketAddr,
         peer_addr: SocketAddr,
         idx: usize,

--- a/src/peer_connection/transports/mod.rs
+++ b/src/peer_connection/transports/mod.rs
@@ -6,6 +6,62 @@ pub(crate) mod stun_gatherer;
 pub(crate) mod tcp_transport;
 pub(crate) mod turn_relayer;
 
+/// Plain single-datagram UDP receive buffer size (no GRO coalescing).
+pub(crate) const UDP_RECV_BUF_LEN: usize = 2000;
+
+/// Upper bound on the number of datagrams the kernel may coalesce into one UDP GRO
+/// receive (`UDP_SEGMENT`/GRO cap is 64 per buffer).
+pub(crate) const MAX_GRO_SEGMENTS: usize = 64;
+
+/// Upper bound on datagrams coalesced into one UDP GSO send. The kernel caps
+/// `UDP_SEGMENT` at 64 segments per `sendmsg`; a socket may report fewer.
+pub(crate) const MAX_GSO_SEGMENTS: usize = 64;
+
+/// Upper bound on the total bytes of one UDP GSO batch. Kept at the single-datagram
+/// UDP payload limit (65535) so a batch never trips the kernel's aggregate-size
+/// checks and disables GSO — at ~1.25 KB datagrams this still coalesces ~50 per call.
+pub(crate) const MAX_GSO_BATCH_BYTES: usize = 65535;
+
+/// Minimum datagrams in a run before it is worth a single GSO `sendmsg` instead of
+/// individual `send_to`s. GSO trades N cheap `sendto` syscalls for one heavier
+/// `sendmsg` (control-message construction + kernel GSO setup) plus one buffer
+/// concatenation, so it only pays off once the run is large. Below this the batching
+/// machinery is pure overhead — exactly the paced single-connection case, where the
+/// watermark dribbles a few datagrams per flush. A too-low threshold there GSOs the
+/// occasional large drain and thrashes the tiny working set (measured on loopback:
+/// threshold 2 → wall +58%, threshold 8 → +21%, threshold 16 → −15% i.e. back to a
+/// win). Throughput-bound bursts (bulk/flood/many-connection) run far larger (50+),
+/// so 16 keeps their full win (N=10 wall −34%, flood +77%) while erasing the
+/// single-connection regression.
+pub(crate) const MIN_GSO_RUN: usize = 16;
+
+/// Per-datagram size assumed when sizing a GRO receive buffer, at the standard
+/// Ethernet MTU. GRO coalesces up to `max_gro_segments()` datagrams into one buffer,
+/// each at most one wire MTU, so the buffer must be `max_gro_segments() *
+/// GRO_RECV_SEGMENT_LEN` — the kernel truncates (silently drops the tail datagrams)
+/// if the coalesced super-datagram overflows the buffer. WebRTC keeps its own
+/// datagrams well under this (DTLS/SCTP MTU ~1200); the 1500 headroom covers a peer
+/// sending up to standard-MTU-sized datagrams. Jumbo-frame paths (MTU > 1500) are not
+/// supported for GRO and would truncate.
+pub(crate) const GRO_RECV_SEGMENT_LEN: usize = 1500;
+
+/// Size a UDP receive buffer for a socket that may coalesce `max_gro` datagrams via
+/// GRO. Falls back to the plain single-datagram size when GRO is unavailable.
+///
+/// NOTE: with GRO enabled this returns ~96 KB (64 * 1500) per socket vs the ~2 KB
+/// non-GRO size — a real per-connection RSS cost that scales with socket count
+/// (relevant at SFU scale). It cannot be shrunk without risking truncation (see
+/// [`GRO_RECV_SEGMENT_LEN`]); the buffers are zero-initialized so pages stay unmapped
+/// until actually written. Measured net effect is still an RSS *reduction* under load
+/// because batching cuts per-packet allocator churn far more than the buffers cost.
+pub(crate) fn gro_recv_buf_len(max_gro: usize) -> usize {
+    if max_gro > 1 {
+        max_gro.min(MAX_GRO_SEGMENTS) * GRO_RECV_SEGMENT_LEN
+    } else {
+        UDP_RECV_BUF_LEN
+    }
+}
+
 pub(crate) enum SocketRecvResult {
     Packet {
         /// Total bytes received into `buf` across all GRO-coalesced datagrams.
@@ -49,4 +105,23 @@ pub(crate) fn is_retryable_socket_recv_error(err: &io::Error) -> bool {
             | io::ErrorKind::ConnectionReset
             | io::ErrorKind::TimedOut
     )
+}
+
+#[cfg(test)]
+mod gro_buf_tests {
+    use super::{GRO_RECV_SEGMENT_LEN, MAX_GRO_SEGMENTS, UDP_RECV_BUF_LEN, gro_recv_buf_len};
+
+    #[test]
+    fn gro_recv_buf_len_sizes_for_capacity_and_falls_back_without_gro() {
+        // GRO available: sized to hold up to `max_gro` coalesced datagrams.
+        assert_eq!(gro_recv_buf_len(64), 64 * GRO_RECV_SEGMENT_LEN);
+        assert_eq!(gro_recv_buf_len(8), 8 * GRO_RECV_SEGMENT_LEN);
+        // Capped at the kernel's max coalescing (MAX_GRO_SEGMENTS).
+        assert_eq!(
+            gro_recv_buf_len(1000),
+            MAX_GRO_SEGMENTS * GRO_RECV_SEGMENT_LEN
+        );
+        // GRO unavailable (max_gro <= 1): plain single-datagram buffer.
+        assert_eq!(gro_recv_buf_len(1), UDP_RECV_BUF_LEN);
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -136,6 +136,25 @@ pub trait Runtime: Send + Sync + Debug + 'static {
     ) -> Pin<Box<dyn Future<Output = io::Result<Arc<dyn AsyncTcpStream>>> + Send + 'a>>;
 }
 
+/// Outcome of a batched UDP receive ([`AsyncUdpSocket::recv_gro`]).
+///
+/// `buf[..len]` holds one or more datagrams received in a single syscall. When the
+/// kernel coalesced consecutive same-flow datagrams via UDP GRO, each is `stride`
+/// bytes except possibly the last — walk `buf[..len]` in `stride`-sized steps to
+/// recover the individual datagrams. Without GRO (or for a lone datagram)
+/// `stride == len` and there is exactly one datagram. Every datagram in the batch
+/// shares `peer_addr` (GRO only coalesces a single source flow).
+#[derive(Debug, Clone, Copy)]
+pub struct GroRecv {
+    /// Total bytes written to the buffer across all coalesced datagrams.
+    pub len: usize,
+    /// Size of each datagram in the batch; the final one may be shorter. Always
+    /// `>= 1` when `len > 0`.
+    pub stride: usize,
+    /// Source address shared by every datagram in the batch.
+    pub peer_addr: SocketAddr,
+}
+
 /// Abstract implementation of a UDP socket for runtime independence
 ///
 /// Simple async wrapper around UDP sockets
@@ -155,6 +174,73 @@ pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
 
     /// Get the local address this socket is bound to
     fn local_addr(&self) -> io::Result<SocketAddr>;
+
+    /// Maximum number of segments a single [`send_segments`](Self::send_segments)
+    /// call can emit in one syscall via UDP GSO. Returns `1` when GSO is
+    /// unavailable (each segment then costs one syscall).
+    fn max_gso_segments(&self) -> usize {
+        1
+    }
+
+    /// Maximum number of datagrams the kernel may coalesce into one
+    /// [`recv_gro`](Self::recv_gro) via UDP GRO. Returns `1` when GRO is
+    /// unavailable. Used to size receive buffers.
+    fn max_gro_segments(&self) -> usize {
+        1
+    }
+
+    /// Send `buf` as consecutive datagrams of `segment_size` bytes to `target`
+    /// using a single UDP GSO (`UDP_SEGMENT`) syscall — the final datagram may be
+    /// shorter than `segment_size`. `ecn`, when `Some`, stamps the ECN codepoint
+    /// bits on every segment. Returns the number of payload bytes accepted.
+    ///
+    /// The default implementation falls back to a loop of [`send_to`](Self::send_to),
+    /// so implementors without GSO support (and external impls) need not override it.
+    /// Callers should only batch (`buf` spanning more than one segment) when
+    /// [`max_gso_segments`](Self::max_gso_segments) reports `> 1`.
+    fn send_segments<'a>(
+        &'a self,
+        buf: &'a [u8],
+        segment_size: usize,
+        target: SocketAddr,
+        ecn: Option<u8>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+        Box::pin(async move {
+            let _ = ecn;
+            // `segment_size == 0` means "no segmentation" — send the whole buffer as a
+            // single datagram rather than shredding it into 1-byte sends.
+            let step = if segment_size == 0 {
+                buf.len().max(1)
+            } else {
+                segment_size
+            };
+            let mut sent = 0;
+            for chunk in buf.chunks(step) {
+                sent += self.send_to(chunk, target).await?;
+            }
+            Ok(sent)
+        })
+    }
+
+    /// Receive one or more datagrams into `buf` in a single syscall, using UDP GRO
+    /// to coalesce consecutive same-flow datagrams when available. See [`GroRecv`]
+    /// for how to split the buffer back into individual datagrams.
+    ///
+    /// The default implementation receives a single datagram (`stride == len`), so
+    /// implementors without GRO support (and external impls) need not override it.
+    fn recv_gro<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<GroRecv>> + Send + 'a>> {
+        Box::pin(async move {
+            let (len, peer_addr) = self.recv_from(buf).await?;
+            Ok(GroRecv {
+                len,
+                stride: if len == 0 { 1 } else { len },
+                peer_addr,
+            })
+        })
+    }
 }
 
 /// Abstract implementation of a TCP listener for runtime independence.
@@ -395,3 +481,98 @@ pub type BroadcastSender<T> = smol::SmolBroadcastSender<T>;
 /// The concrete broadcast channel Receiver type for the active runtime.
 #[cfg(all(not(feature = "runtime-tokio"), feature = "runtime-smol"))]
 pub type BroadcastReceiver<T> = smol::SmolBroadcastReceiver<T>;
+
+#[cfg(test)]
+mod default_impl_tests {
+    //! Cover the `AsyncUdpSocket` DEFAULT method bodies (send_segments / recv_gro /
+    //! max_gso_segments / max_gro_segments). The concrete tokio/smol impls override
+    //! them, so nothing else exercises the defaults — a minimal fake that implements
+    //! only the required methods does.
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    struct FakeUdp {
+        sent: Mutex<Vec<Vec<u8>>>,
+        to_recv: Mutex<Vec<u8>>,
+    }
+
+    impl AsyncUdpSocket for FakeUdp {
+        fn send_to<'a>(
+            &'a self,
+            buf: &'a [u8],
+            _target: SocketAddr,
+        ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+            Box::pin(async move {
+                self.sent.lock().unwrap().push(buf.to_vec());
+                Ok(buf.len())
+            })
+        }
+        fn recv_from<'a>(
+            &'a self,
+            buf: &'a mut [u8],
+        ) -> Pin<Box<dyn Future<Output = io::Result<(usize, SocketAddr)>> + Send + 'a>> {
+            Box::pin(async move {
+                let data = self.to_recv.lock().unwrap();
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                Ok((n, "127.0.0.1:9".parse::<SocketAddr>().unwrap()))
+            })
+        }
+        fn local_addr(&self) -> io::Result<SocketAddr> {
+            Ok("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        }
+    }
+
+    fn addr() -> SocketAddr {
+        "127.0.0.1:5".parse::<SocketAddr>().unwrap()
+    }
+
+    #[test]
+    fn default_caps_are_one() {
+        let s = FakeUdp::default();
+        assert_eq!(s.max_gso_segments(), 1);
+        assert_eq!(s.max_gro_segments(), 1);
+    }
+
+    #[test]
+    fn default_send_segments_loops_send_to() {
+        let s = FakeUdp::default();
+        // 11 bytes, segment_size 3 -> datagrams of 3,3,3,2.
+        let buf = [1u8, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4];
+        let sent = futures::executor::block_on(s.send_segments(&buf, 3, addr(), None)).unwrap();
+        assert_eq!(sent, 11);
+        let calls = s.sent.lock().unwrap();
+        assert_eq!(calls.len(), 4);
+        assert_eq!(calls[0], vec![1, 1, 1]);
+        assert_eq!(calls[3], vec![4, 4]);
+    }
+
+    #[test]
+    fn default_send_segments_zero_size_is_one_datagram() {
+        let s = FakeUdp::default();
+        let buf = [7u8; 10];
+        futures::executor::block_on(s.send_segments(&buf, 0, addr(), Some(2))).unwrap();
+        let calls = s.sent.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "segment_size 0 must send one datagram, not shred"
+        );
+        assert_eq!(calls[0].len(), 10);
+    }
+
+    #[test]
+    fn default_recv_gro_is_single_datagram() {
+        let s = FakeUdp::default();
+        *s.to_recv.lock().unwrap() = vec![9, 9, 9, 9, 9];
+        let mut buf = [0u8; 32];
+        let gro = futures::executor::block_on(s.recv_gro(&mut buf)).unwrap();
+        assert_eq!(gro.len, 5);
+        assert_eq!(
+            gro.stride, 5,
+            "stride == len for a single (non-GRO) datagram"
+        );
+        assert_eq!(gro.peer_addr, "127.0.0.1:9".parse::<SocketAddr>().unwrap());
+    }
+}

--- a/src/runtime/smol.rs
+++ b/src/runtime/smol.rs
@@ -1,7 +1,6 @@
 //! smol runtime implementation
 
 use super::*;
-use ::smol::net::UdpSocket as SmolUdpSocket;
 use ::smol::spawn;
 use std::io::{Read, Write};
 use std::sync::Arc;
@@ -57,7 +56,7 @@ impl Runtime for SmolRuntime {
     }
 
     fn wrap_udp_socket(&self, sock: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>> {
-        Ok(Arc::new(UdpSocket::new(sock)?))
+        Ok(Arc::new(UdpSocket::new(sock)?) as Arc<dyn AsyncUdpSocket>)
     }
 
     fn wrap_tcp_listener(
@@ -92,15 +91,23 @@ impl Runtime for SmolRuntime {
 
 #[derive(Debug)]
 struct UdpSocket {
-    io: Arc<SmolUdpSocket>,
+    io: Arc<::smol::Async<std::net::UdpSocket>>,
+    /// GSO/GRO capability + syscall helper for this socket (see `quinn-udp`).
+    state: Arc<::quinn_udp::UdpSocketState>,
 }
 
 impl UdpSocket {
     fn new(sock: std::net::UdpSocket) -> io::Result<Self> {
-        // Wrap std socket in smol's Async
+        // Wrap std socket in smol's Async (sets non-blocking).
         let async_sock = ::smol::Async::new(sock)?;
+        // Probe + enable UDP GSO/GRO (and ECN/MTU options) on the socket. This is a
+        // one-time reconfiguration; `send_to`/`recv_from` keep working, but the recv
+        // path must now use `recv_gro` to decode GRO-coalesced buffers.
+        let state =
+            ::quinn_udp::UdpSocketState::new(::quinn_udp::UdpSockRef::from(async_sock.get_ref()))?;
         Ok(Self {
-            io: Arc::new(SmolUdpSocket::from(async_sock)),
+            io: Arc::new(async_sock),
+            state: Arc::new(state),
         })
     }
 }
@@ -111,18 +118,74 @@ impl AsyncUdpSocket for UdpSocket {
         buf: &'a [u8],
         target: SocketAddr,
     ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
-        Box::pin(async move { self.io.send_to(buf, target).await })
+        Box::pin(async move { self.io.write_with(|s| s.send_to(buf, target)).await })
     }
 
     fn recv_from<'a>(
         &'a self,
         buf: &'a mut [u8],
     ) -> Pin<Box<dyn Future<Output = io::Result<(usize, SocketAddr)>> + Send + 'a>> {
-        Box::pin(async move { self.io.recv_from(buf).await })
+        Box::pin(async move { self.io.read_with(|s| s.recv_from(buf)).await })
     }
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.io.local_addr()
+        self.io.get_ref().local_addr()
+    }
+
+    fn max_gso_segments(&self) -> usize {
+        self.state.max_gso_segments()
+    }
+
+    fn max_gro_segments(&self) -> usize {
+        self.state.gro_segments()
+    }
+
+    fn send_segments<'a>(
+        &'a self,
+        buf: &'a [u8],
+        segment_size: usize,
+        target: SocketAddr,
+        ecn: Option<u8>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+        Box::pin(async move {
+            let transmit = ::quinn_udp::Transmit {
+                destination: target,
+                ecn: ecn.and_then(::quinn_udp::EcnCodepoint::from_bits),
+                contents: buf,
+                segment_size: Some(segment_size),
+                src_ip: None,
+            };
+            self.io
+                .write_with(|s| self.state.send(::quinn_udp::UdpSockRef::from(s), &transmit))
+                .await?;
+            Ok(buf.len())
+        })
+    }
+
+    fn recv_gro<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<GroRecv>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut meta = [::quinn_udp::RecvMeta::default()];
+            self.io
+                .read_with(|s| {
+                    let mut bufs = [std::io::IoSliceMut::new(buf)];
+                    self.state
+                        .recv(::quinn_udp::UdpSockRef::from(s), &mut bufs, &mut meta)
+                })
+                .await?;
+            let m = &meta[0];
+            Ok(GroRecv {
+                len: m.len,
+                stride: if m.stride == 0 {
+                    m.len.max(1)
+                } else {
+                    m.stride
+                },
+                peer_addr: m.addr,
+            })
+        })
     }
 }
 

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -56,8 +56,14 @@ impl Runtime for TokioRuntime {
 
     fn wrap_udp_socket(&self, sock: std::net::UdpSocket) -> io::Result<Arc<dyn AsyncUdpSocket>> {
         sock.set_nonblocking(true)?;
+        let io = ::tokio::net::UdpSocket::from_std(sock)?;
+        // Probe + enable UDP GSO/GRO (and ECN/MTU options) on the socket. This is a
+        // one-time reconfiguration; `send_to`/`recv_from` keep working, but the recv
+        // path must now use `recv_gro` to decode GRO-coalesced buffers.
+        let state = ::quinn_udp::UdpSocketState::new(::quinn_udp::UdpSockRef::from(&io))?;
         Ok(Arc::new(UdpSocket {
-            io: Arc::new(::tokio::net::UdpSocket::from_std(sock)?),
+            io: Arc::new(io),
+            state: Arc::new(state),
         }))
     }
 
@@ -93,6 +99,8 @@ impl Runtime for TokioRuntime {
 #[derive(Debug, Clone)]
 struct UdpSocket {
     io: Arc<::tokio::net::UdpSocket>,
+    /// GSO/GRO capability + syscall helper for this socket (see `quinn-udp`).
+    state: Arc<::quinn_udp::UdpSocketState>,
 }
 
 impl AsyncUdpSocket for UdpSocket {
@@ -113,6 +121,83 @@ impl AsyncUdpSocket for UdpSocket {
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.local_addr()
+    }
+
+    fn max_gso_segments(&self) -> usize {
+        self.state.max_gso_segments()
+    }
+
+    fn max_gro_segments(&self) -> usize {
+        self.state.gro_segments()
+    }
+
+    fn send_segments<'a>(
+        &'a self,
+        buf: &'a [u8],
+        segment_size: usize,
+        target: SocketAddr,
+        ecn: Option<u8>,
+    ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'a>> {
+        Box::pin(async move {
+            let transmit = ::quinn_udp::Transmit {
+                destination: target,
+                ecn: ecn.and_then(::quinn_udp::EcnCodepoint::from_bits),
+                contents: buf,
+                segment_size: Some(segment_size),
+                src_ip: None,
+            };
+            loop {
+                match self.io.try_io(::tokio::io::Interest::WRITABLE, || {
+                    self.state
+                        .send(::quinn_udp::UdpSockRef::from(&self.io), &transmit)
+                }) {
+                    Ok(()) => return Ok(buf.len()),
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        self.io.writable().await?;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+    }
+
+    fn recv_gro<'a>(
+        &'a self,
+        buf: &'a mut [u8],
+    ) -> Pin<Box<dyn Future<Output = io::Result<GroRecv>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut meta = [::quinn_udp::RecvMeta::default()];
+            loop {
+                let mut bufs = [std::io::IoSliceMut::new(buf)];
+                let res = self.io.try_io(::tokio::io::Interest::READABLE, || {
+                    self.state.recv(
+                        ::quinn_udp::UdpSockRef::from(&self.io),
+                        &mut bufs,
+                        &mut meta,
+                    )
+                });
+                // `bufs` (which borrows `buf`) is no longer used past this point, so the
+                // borrow ends here and the `.await` below can re-borrow on the next loop.
+                match res {
+                    Ok(_) => {
+                        let m = &meta[0];
+                        return Ok(GroRecv {
+                            len: m.len,
+                            stride: if m.stride == 0 {
+                                m.len.max(1)
+                            } else {
+                                m.stride
+                            },
+                            peer_addr: m.addr,
+                        });
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        self.io.readable().await?;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Batches the driver's UDP I/O to cut per-byte CPU and syscalls on the data-channel path:

- **GRO receive coalescing** — wrap each UDP socket with `quinn-udp`'s `UdpSocketState` (enables `UDP_GRO`), so one `recv` returns several kernel-coalesced datagrams; the driver de-segments by `stride`.
- **GSO send batching** — coalesce consecutive same-`(local, peer, ecn)` equal-size datagrams into a single `UDP_SEGMENT` (`sendmsg`) syscall.
- **Adaptive threshold** — GSO only pays off for large runs (one heavier `sendmsg` + cmsg + concat vs N cheap `sendto`). A paced single connection dribbles ~2 datagrams/flush, where the machinery is pure overhead. So the GSO path is gated on `MIN_GSO_RUN = 16` datagrams; below it, each datagram is sent individually. Throughput-bound bursts (bulk/flood/many-connection) run far larger and keep the full win.

Runtime-agnostic: implemented for both tokio (`try_io` + `writable`/`readable`) and smol (`Async::write_with`/`read_with`). Falls back to per-packet `send_to`/`recv_from` on platforms without GSO/GRO.

## ⚠️ New dependency — `quinn-udp`

This adds **`quinn-udp` 0.6** (`default-features = false`, pulled in only by the `runtime-tokio`/`runtime-smol` features). It's small (`libc` + `socket2`, both already transitive), MIT/Apache-2.0, and handles the GSO/GRO capability probing + syscalls + fallback across platforms. Flagging for review since it's a new dep on the crate. A hand-rolled `UDP_SEGMENT`/`recvmmsg` path is possible but re-implements the platform matrix quinn-udp already covers.

## Benchmarks (`poop`, Ryzen 1700, loopback, fixed byte volume; base = current master)

Loopback is latency/scheduling-bound, so the win is CPU-efficiency in paced regimes and throughput in send-bound regimes. Full counter tables below (⚡ = significant win, 💩 = significant regression, no marker = within noise). All numbers are the shipped binary (`MIN_GSO_RUN=16`, GSO+GRO) unless noted.

**Harnesses** (each an A/B of the same example built from `master` vs this branch):
- Ordered/reliable N=1, N=10 and the 64 KB and sweep runs: `examples/data-channels-flow-control-multi` — env `FLOW_PAIRS={1,10} FLOW_MSG_KB={1,64} FLOW_ORDERED={0,1} FLOW_DEDICATED_REACTOR=1 FLOW_WARMUP_MB={16,32} FLOW_STOP_MB={64,128}` (`FLOW_ORDERED`/`FLOW_MSG_KB` are added by this PR); the sweep sets `WEBRTC_MIN_GSO_RUN`.
- Flood: [`restsend/rustrtc`](https://github.com/restsend/rustrtc)'s own `examples/benchmark.rs` (`benchmark webrtc 10` / `rustrtc 10`) — 10 pairs, 1 KB, `WEBRTC_DEDICATED_REACTOR=1 WEBRTC_SEND_LIMIT_KB=256`, run in a fixed-work mode (`RUSTRTC_STOP_MB=128`, stop after N MB/pair and exit) so each run is `poop`-able.

### Ordered/reliable, N=1 single connection — and why the threshold (issue #101 batch-drain-comment harness, 160 MB fixed)

N=1 is latency-bound, so batching only helps once runs are large — exactly where `MIN_GSO_RUN` earns its keep. Threshold sweep on this branch (`WEBRTC_MIN_GSO_RUN` varied, one poop session; `@16` is the shipped default), delta + ⚡/💩 vs base:

| measurement | base (38 runs) | @2 un-thr. (21) | @8 (30) | @16 shipped (45) | @32 (51) |
|---|---|---|---|---|---|
| wall_time | 3.71s ± 933ms | 💩 +85.2% ± 11.8% | 💩 +27.8% ± 11.1% | ⚡ −15.3% ± 8.7% | ⚡ −24.9% ± 9.6% |
| peak_rss | 23.9MB ± 10.4MB | ⚡ −55.8% ± 19.6% | ⚡ −45.2% ± 20.0% | ⚡ −49.4% ± 14.7% | −1.5% ± 22.3% |
| cpu_cycles | 5.29G ± 175M | 💩 +107.4% ± 2.8% | 💩 +66.1% ± 4.3% | 💩 +30.8% ± 2.9% | 💩 +14.0% ± 2.2% |
| instructions | 8.81G ± 95.8M | 💩 +21.5% ± 0.6% | 💩 +12.6% ± 1.0% | 💩 +4.2% ± 0.7% | +1.0% ± 0.6% |
| cache_references | 749M ± 30.1M | 💩 +133.4% ± 2.4% | 💩 +83.5% ± 5.2% | 💩 +35.8% ± 3.9% | 💩 +12.4% ± 2.8% |
| cache_misses | 76.5M ± 6.66M | 💩 +622.3% ± 7.8% | 💩 +398.1% ± 20.7% | 💩 +195.0% ± 14.7% | 💩 +83.7% ± 10.4% |
| branch_misses | 21.1M ± 1.53M | 💩 +355.7% ± 5.6% | 💩 +226.7% ± 11.9% | 💩 +113.2% ± 8.1% | 💩 +47.7% ± 6.0% |

Un-thresholded (`@2` = GSO for any 2+ run) regresses hard — GSO's `sendmsg`/cmsg/concat overhead with nothing to batch (loopback already passes the GSO super-packet through un-segmented: verified via `ethtool -k lo` `tx-udp-segmentation: on` + `perf`, so it isn't segmentation cost). Raising the threshold shrinks the regression to a win; `@16` is the knee. N=1 wall_time is high-variance/latency-bound — across sessions `@16` measures roughly −15%…−25%, all wins — while the more stable instruction/cache counters barely move with the threshold above `@16`, so 16 is a safe default. The throughput-bound regimes below (N=10, flood; bursts of 50+ datagrams) are past every threshold, so their win is independent of it.

### Ordered/reliable, N=10 connections (800 MB fixed)

| measurement | base (12 runs) | this PR (18 runs) | delta |
|---|---|---|---|
| wall_time | 5.09s ± 739ms | 3.43s ± 748ms | ⚡ −32.6% ± 11.2% |
| peak_rss | 212MB ± 43.7MB | 244MB ± 67.4MB | +15.2% ± 21.3% |
| cpu_cycles | 38.4G ± 1.77G | 40.3G ± 1.39G | 💩 +4.8% ± 3.1% |
| instructions | 46.4G ± 780M | 44.7G ± 644M | ⚡ −3.6% ± 1.2% |
| cache_references | 4.25G ± 137M | 3.97G ± 152M | ⚡ −6.7% ± 2.6% |
| cache_misses | 543M ± 32.1M | 613M ± 40.4M | 💩 +12.9% ± 5.2% |
| branch_misses | 152M ± 9.44M | 148M ± 8.85M | −3.0% ± 4.5% |

### 64 KB messages, N=10 — GSO's raw per-byte effect (un-thresholded: base / GRO-only / GSO+GRO)

| measurement | base (17 runs) | GRO-only Δ | GSO+GRO Δ (26 runs) |
|---|---|---|---|
| wall_time | 5.53s ± 1.23s | −2.0% ± 13.1% | ⚡ −35.3% ± 9.5% |
| peak_rss | 1.24GB ± 655MB | −8.4% ± 33.4% | +0.3% ± 22.3% |
| cpu_cycles | 67.2G ± 12.3G | +0.0% ± 12.1% | −3.8% ± 8.1% |
| instructions | 56.4G ± 9.34G | −3.7% ± 9.8% | ⚡ −24.3% ± 6.7% |
| cache_references | 5.04G ± 846M | −2.5% ± 10.0% | ⚡ −26.7% ± 6.7% |
| cache_misses | 1.07G ± 196M | −0.5% ± 11.7% | ⚡ −37.6% ± 7.5% |
| branch_misses | 125M ± 17.9M | −2.1% ± 9.0% | ⚡ −40.4% ± 5.8% |

GRO alone is ≈ neutral; the GSO **send** batching is the CPU win.

### Flood (rustrtc bench: 1 KB ×10, unordered/reliable, 256 KB send limit)

Fixed **1.28 GB** of work per run (10 pairs × 128 MB, `RUSTRTC_STOP_MB=128`), so wall-time is inverse end-to-end throughput; delta + ⚡/💩 vs base-webrtc:

| measurement | base-webrtc (32 runs) | this PR (52 runs) | rustrtc (92 runs) |
|---|---|---|---|
| wall_time | 8.27s ± 1.24s | ⚡ −37.6% ± 11.0% | ⚡ −65.7% ± 3.0% |
| peak_rss | 768MB ± 134MB | ⚡ −79.9% ± 5.8% | ⚡ −97.0% ± 3.5% |
| cpu_cycles | 133G ± 19.7G | ⚡ −45.2% ± 4.5% | ⚡ −46.0% ± 3.0% |
| instructions | 97.2G ± 6.91G | ⚡ −24.8% ± 2.9% | ⚡ −42.5% ± 1.4% |
| cache_references | 8.65G ± 434M | ⚡ −19.8% ± 2.5% | ⚡ −33.5% ± 1.0% |
| cache_misses | 2.02G ± 237M | ⚡ −35.6% ± 5.5% | ⚡ −35.6% ± 2.4% |
| branch_misses | 278M ± 8.46M | +0.9% ± 2.1% | 💩 +8.8% ± 2.5% |

vs base-webrtc this PR is a significant win on every axis (wall −37.6% ≈ +60% throughput, cpu_cycles −45%, instructions −25%, cache_misses −36%, peak_rss −80%). The **rustrtc** column's wall gap is inflated by webrtc's much heavier per-connection setup/teardown (10× DTLS handshakes + dedicated reactor threads), which the fixed-work wall includes — so it isn't a steady-state throughput comparison. The fairer per-byte metric is the counters: this PR narrows webrtc's instructions/byte gap to rustrtc from **1.74× → 1.31×** (97.2G→73.0G vs 55.9G) and peak_rss from **34× → 6.7×** (768→154 MB vs 23 MB).

## Notes / trade-offs

- **GRO recv buffers** are ~96 KB/socket (must cover the kernel's max coalescing to avoid truncation). Documented; the net measured RSS is still a reduction under load because batching cuts allocator churn far more than the buffers cost, but it's a per-connection cost worth knowing at SFU scale.
- `quinn-udp`'s socket setup also sets the DF bit (`IP_PMTUDISC_PROBE`) — fine for WebRTC (packets ≤ MTU); it does **not** enable `IP_RECVERR`.

## Testing

Both runtimes green (tokio lib+integration, smol integration), rtc-sctp unchanged; clippy/fmt clean. Added a fake-socket unit test covering the `AsyncUdpSocket` default bodies (`send_segments`/`recv_gro`/caps). Local patch coverage ~95%.

## Relationship to the rtc SACK/FORWARD-TSN PR

Independent of the companion rtc marshal-trim PR (webrtc-rs/rtc#130) — this branch pins rtc at the current upstream commit and needs no rtc change. They can merge in any order.
