### PR TITLE
fix(data): raise PollDataChannel default read buffer to 16 KiB

### DIFF
--- a/data/src/data_channel/data_channel_test.rs
+++ b/data/src/data_channel/data_channel_test.rs
@@ -5,6 +5,11 @@ use util::conn::conn_bridge::*;
 use util::conn::*;
 
 use super::*;
+
+#[test]
+fn poll_data_channel_default_read_buffer_supports_16_kib_messages() {
+    assert_eq!(DEFAULT_READ_BUF_SIZE, 16 * 1024);
+}
 use crate::error::Result;
 
 async fn bridge_process_at_least_one(br: &Arc<Bridge>) {

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -470,7 +470,7 @@ impl PollDataChannel {
         self.data_channel.buffered_amount_low_threshold()
     }
 
-    /// Set the capacity of the temporary read buffer (default: 8192).
+    /// Set the capacity of the temporary read buffer (default: 16384).
     pub fn set_read_buf_capacity(&mut self, capacity: usize) {
         self.read_buf_cap = capacity
     }

--- a/data/src/data_channel/mod.rs
+++ b/data/src/data_channel/mod.rs
@@ -366,7 +366,11 @@ impl DataChannel {
 }
 
 /// Default capacity of the temporary read buffer used by [`PollStream`].
-const DEFAULT_READ_BUF_SIZE: usize = 8192;
+///
+/// A WebRTC data channel delivers complete SCTP messages. 16 KiB matches libp2p's maximum
+/// WebRTC message size, preventing a caller that relies on this default from failing with
+/// `ErrShortBuffer` for a valid message.
+const DEFAULT_READ_BUF_SIZE: usize = 16 * 1024;
 
 /// State of the read `Future` in [`PollStream`].
 enum ReadFut {


### PR DESCRIPTION
## Summary

- raise `PollDataChannel`'s default temporary read buffer from 8 KiB to 16 KiB;
- add a regression test that locks the default at 16 KiB; and
- correct the public setter documentation to match the new default.

Closes #823.

## Motivation

`PollDataChannel` adapts message-oriented SCTP DataChannels to `AsyncRead`. Each read starts by allocating its internal temporary buffer. SCTP delivers one complete user message, so a message larger than that fixed default produces `ErrShortBuffer` before `PollDataChannel` can split it across the caller's `ReadBuf`.

The prior 8 KiB default therefore rejected valid messages from callers that do not override `set_read_buf_capacity`. libp2p's WebRTC transport can use frames up to 16 KiB, which made this observable as a transport reset in browser-to-browser transfers.

16 KiB is a conservative default that accepts those frames while keeping the existing opt-in setter for applications needing a different bound. This does not change SCTP's negotiated maximum message size or the behaviour of explicitly configured channels.

## Validation

- `cargo check -p webrtc-data --tests`
- `cargo test -p webrtc-data data_channel::data_channel_test::poll_data_channel_default_read_buffer_supports_16_kib_messages -- --exact`

## Attribution

Prepared with assistance from Codex 5.6; the reproducer, design decision, and validation were reviewed by the contributor.