### PR TITLE
fix(driver): only announce peer-opened channels through on_data_channel

### DIFF
--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -566,17 +566,30 @@ where
 
                     if data_channel_exist {
                         let (evt_tx, evt_rx) = channel(DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
-                        let data_channel =
-                            Arc::new(DataChannelImpl::new(channel_id, self.inner.clone(), evt_rx));
 
-                        {
+                        // A vacant entry means the peer opened this channel: locally created
+                        // ones are registered by `create_data_channel` before their `OnOpen`
+                        // ever reaches us. Only those get announced through the handler --
+                        // `on_data_channel` is for remotely opened channels.
+                        let opened_by_peer = {
                             let mut data_channels = self.inner.data_channel_events_tx.lock().await;
-                            if let Entry::Vacant(e) = data_channels.entry(channel_id) {
-                                e.insert(evt_tx);
+                            match data_channels.entry(channel_id) {
+                                Entry::Vacant(e) => {
+                                    e.insert(evt_tx);
+                                    true
+                                }
+                                Entry::Occupied(_) => false,
                             }
-                        }
+                        };
 
-                        self.inner.handler.on_data_channel(data_channel).await;
+                        if opened_by_peer {
+                            let data_channel = Arc::new(DataChannelImpl::new(
+                                channel_id,
+                                self.inner.clone(),
+                                evt_rx,
+                            ));
+                            self.inner.handler.on_data_channel(data_channel).await;
+                        }
                     }
                 }
 

--- a/tests/on_data_channel_only_for_remote.rs
+++ b/tests/on_data_channel_only_for_remote.rs
@@ -1,0 +1,260 @@
+//! `on_data_channel` must fire only for channels the **peer** opened.
+//!
+//! The driver announced every `OnOpen` through the handler, including channels this side
+//! created itself. Two things went wrong with that:
+//!
+//!   1. An application that opens a channel and also implements `on_data_channel` sees its
+//!      own channel come back as if the peer had opened it. Anything that treats the
+//!      callback as "here is an incoming stream" (a muxer, a router) acts on a stream the
+//!      peer knows nothing about.
+//!   2. The announced handle is unusable anyway. `create_data_channel` already registered
+//!      the event sender for that id, so the driver's `Entry::Vacant` check declined to
+//!      replace it — the `DataChannelImpl` handed to the callback carried a fresh receiver
+//!      whose sender was dropped on the spot. It never yields a single event.
+//!
+//! Only the offerer opens a channel here. The answerer must see exactly it; the offerer must
+//! see nothing at all. Before the fix the offerer was handed its own channel back.
+//!
+//! (Deliberately one-sided: having both peers open an in-band channel *before* the DTLS role
+//! is settled makes `generate_data_channel_id` hand out the same id on both sides, which is a
+//! separate problem and would muddy this assertion.)
+
+use anyhow::Result;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Sender, block_on, channel, default_runtime, timeout};
+
+/// Records the label of every channel announced through `on_data_channel`.
+struct Handler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+    announced: Arc<Mutex<Vec<String>>>,
+    announced_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for Handler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+
+    async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
+        let label = dc.label().await.unwrap_or_default();
+        self.announced.lock().unwrap().push(label);
+        let _ = self.announced_tx.try_send(());
+    }
+}
+
+struct Peer {
+    pc: Box<dyn PeerConnection>,
+    announced: Arc<Mutex<Vec<String>>>,
+    gather_rx: webrtc::runtime::Receiver<()>,
+    connected_rx: webrtc::runtime::Receiver<()>,
+    announced_rx: webrtc::runtime::Receiver<()>,
+}
+
+async fn build_peer(runtime: Arc<dyn webrtc::runtime::Runtime>) -> Result<Peer> {
+    let (gather_tx, gather_rx) = channel::<()>(1);
+    let (connected_tx, connected_rx) = channel::<()>(1);
+    // Sized above the expected count so a regression queues its extra announcement rather
+    // than dropping it — the assertion should fail loudly, not hang.
+    let (announced_tx, announced_rx) = channel::<()>(8);
+    let announced = Arc::new(Mutex::new(Vec::new()));
+
+    let pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(Handler {
+            gather_tx,
+            connected_tx,
+            announced: announced.clone(),
+            announced_tx,
+        }))
+        .with_runtime(runtime)
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    Ok(Peer {
+        pc: Box::new(pc),
+        announced,
+        gather_rx,
+        connected_rx,
+        announced_rx,
+    })
+}
+
+#[test]
+fn test_on_data_channel_fires_only_for_peer_opened_channels() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let mut offerer = build_peer(runtime.clone()).await?;
+    let mut answerer = build_peer(runtime.clone()).await?;
+
+    // Only the offerer opens a channel.
+    let offerer_dc = offerer
+        .pc
+        .create_data_channel("from-offerer", Some(RTCDataChannelInit::default()))
+        .await?;
+
+    // Offer / answer over loopback.
+    let offer = offerer.pc.create_offer(None).await?;
+    offerer.pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer.gather_rx.recv()).await;
+    let offer_sdp = offerer
+        .pc
+        .local_description()
+        .await
+        .expect("offerer local description");
+
+    answerer.pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer.pc.create_answer(None).await?;
+    answerer.pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer.gather_rx.recv()).await;
+    let answer_sdp = answerer
+        .pc
+        .local_description()
+        .await
+        .expect("answerer local description");
+    offerer.pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), offerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: offerer connect"))?;
+    timeout(Duration::from_secs(5), answerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: answerer connect"))?;
+
+    // The answerer must be told about it.
+    timeout(Duration::from_secs(10), answerer.announced_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: answerer never saw the peer's channel"))?;
+
+    // Give the regression a chance to deliver the surplus announcement before asserting —
+    // the offerer's own channel is open well before this point.
+    webrtc::runtime::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        *answerer.announced.lock().unwrap(),
+        vec!["from-offerer".to_string()],
+        "answerer must be told about the channel the offerer opened"
+    );
+    assert!(
+        offerer.announced.lock().unwrap().is_empty(),
+        "the offerer opened that channel itself; on_data_channel must not report it back \
+         (saw {:?})",
+        offerer.announced.lock().unwrap()
+    );
+
+    // The locally created handle keeps working — the fix must not disturb its event stream,
+    // which is exactly what the surplus announcement used to steal a receiver for.
+    assert_eq!(
+        offerer_dc.ready_state().await?,
+        webrtc::data_channel::RTCDataChannelState::Open,
+        "the offerer's own channel should be open"
+    );
+
+    Ok(())
+}
+
+/// A `negotiated` channel is opened out of band on both sides, so neither peer should ever
+/// hear about it through `on_data_channel` (W3C `RTCDataChannelInit.negotiated`).
+///
+/// This is the shape libp2p's WebRTC transports use for their Noise handshake stream: the
+/// surplus announcement handed that channel to the muxer as if it were an incoming stream.
+#[test]
+fn test_negotiated_channel_is_never_announced() {
+    block_on(run_negotiated()).unwrap();
+}
+
+async fn run_negotiated() -> Result<()> {
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let mut offerer = build_peer(runtime.clone()).await?;
+    let mut answerer = build_peer(runtime.clone()).await?;
+
+    let negotiated = || {
+        Some(RTCDataChannelInit {
+            negotiated: Some(0),
+            ordered: true,
+            ..Default::default()
+        })
+    };
+    let offerer_dc = offerer.pc.create_data_channel("", negotiated()).await?;
+    let _answerer_dc = answerer.pc.create_data_channel("", negotiated()).await?;
+
+    let offer = offerer.pc.create_offer(None).await?;
+    offerer.pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer.gather_rx.recv()).await;
+    let offer_sdp = offerer.pc.local_description().await.expect("offer");
+
+    answerer.pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer.pc.create_answer(None).await?;
+    answerer.pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer.gather_rx.recv()).await;
+    let answer_sdp = answerer.pc.local_description().await.expect("answer");
+    offerer.pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), offerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: offerer connect"))?;
+    timeout(Duration::from_secs(5), answerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: answerer connect"))?;
+
+    // Wait for the channel to actually open, otherwise "nothing was announced" would pass
+    // trivially.
+    let (open_tx, mut open_rx) = channel::<()>(1);
+    {
+        let dc = offerer_dc.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        let _ = open_tx.try_send(());
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+    timeout(Duration::from_secs(10), open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: negotiated channel never opened"))?;
+    webrtc::runtime::sleep(Duration::from_millis(500)).await;
+
+    assert!(
+        offerer.announced.lock().unwrap().is_empty(),
+        "a negotiated channel must never reach on_data_channel (offerer saw {:?})",
+        offerer.announced.lock().unwrap()
+    );
+    assert!(
+        answerer.announced.lock().unwrap().is_empty(),
+        "a negotiated channel must never reach on_data_channel (answerer saw {:?})",
+        answerer.announced.lock().unwrap()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`PeerConnectionDriver` forwards every `OnOpen` event to
`PeerConnectionEventHandler::on_data_channel`, including channels this side
created itself.

Two things go wrong with that.

**1. The callback no longer means "the peer opened a channel".**

An application that calls `create_data_channel` and also implements
`on_data_channel` is handed its own channel back. Anything that treats the
callback as "here is an incoming stream" — a muxer, a router, a dispatcher —
acts on a stream the remote peer knows nothing about.

`negotiated` channels are hit hardest. They are opened out of band on *both*
sides, so per [W3C `RTCDataChannelInit.negotiated`][w3c] neither peer should ever
hear about them through the callback:

> If set to true, it is up to the application to negotiate the channel and
> create an `RTCDataChannel` object with the same `id` at the other peer.

Today both peers do. This is how I ran into it: libp2p's WebRTC transports run
their Noise handshake over a `negotiated: 0` channel, and the muxer received
that handshake channel as if it were the first incoming substream.

**2. The announced handle is unusable anyway.**

`create_data_channel` has already registered the event sender for that id, so
the `Entry::Vacant` check declines to replace it. The `DataChannelImpl` handed
to the callback carries a fresh `evt_rx` whose sender was dropped on the spot —
it never yields a single event. So the surplus announcement isn't just
semantically wrong, it hands out a dead handle.

[w3c]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-negotiated

## Fix

The vacancy check already distinguishes the two cases; it just wasn't being used
for the announcement. A vacant entry means the peer opened this channel, because
locally created ones are registered by `create_data_channel` before their
`OnOpen` can reach the driver. Announce only those.

```rust
let opened_by_peer = {
    let mut data_channels = self.inner.data_channel_events_tx.lock().await;
    match data_channels.entry(channel_id) {
        Entry::Vacant(e) => { e.insert(evt_tx); true }
        Entry::Occupied(_) => false,
    }
};

if opened_by_peer {
    let data_channel = Arc::new(DataChannelImpl::new(channel_id, self.inner.clone(), evt_rx));
    self.inner.handler.on_data_channel(data_channel).await;
}
```

Locally created channels keep working exactly as before — they are driven
through the handle `create_data_channel` returned, whose sender is the one left
in the map.

## Test

`tests/on_data_channel_only_for_remote.rs` covers both shapes over a loopback
connection:

- `test_on_data_channel_fires_only_for_peer_opened_channels` — the offerer opens
  one in-band channel. The answerer must see exactly it; the offerer must see
  nothing.
- `test_negotiated_channel_is_never_announced` — both peers open a
  `negotiated: Some(0)` channel out of band. Neither may be announced. The test
  waits for the channel to actually open first, so "nothing was announced"
  can't pass trivially.

Both fail on master:

```
test_on_data_channel_fires_only_for_peer_opened_channels ... FAILED
  the offerer opened that channel itself; on_data_channel must not report it back
  (saw ["from-offerer"])

test_negotiated_channel_is_never_announced ... FAILED
  a negotiated channel must never reach on_data_channel (offerer saw [""])
```

and pass with the fix.

One note on the first test being deliberately one-sided: if both peers open an
in-band channel *before* the DTLS role is settled, `generate_data_channel_id`
hands out the same id on both sides. That's a separate issue and would muddy
this assertion, so only the offerer opens one here. Happy to file that
separately if it's news to you.

## Checks

`cargo fmt --check`, `cargo test` and `cargo clippy` are clean locally.
(`cargo clippy --all-targets` reports one pre-existing error in `tests/ice_test.rs`,
present on master and untouched here; CI's `cargo clippy` doesn't build test
targets.)

## Disclosure

This change was developed with AI assistance (Claude Code). I hit the behaviour
while building a WebRTC-Direct libp2p transport on top of 0.20, traced it to
this code path by reading the driver, and confirmed the fix end-to-end against
that transport before opening this PR. Happy to adjust the approach or the test
style if you'd prefer something different.