### PR TITLE
fix(peer_connection): export the stats types `get_stats` names

### DIFF
--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -81,8 +81,8 @@ use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
 use rtc::rtp_transceiver::{RTCRtpTransceiverId, RTCRtpTransceiverInit};
 use rtc::sansio::Protocol;
 use rtc::shared::error::{Error, Result};
-use rtc::statistics::StatsSelector;
-use rtc::statistics::report::RTCStatsReport;
+pub use rtc::statistics::StatsSelector;
+pub use rtc::statistics::report::{RTCStatsReport, RTCStatsReportEntry};
 
 use crate::media_stream::track_local::TrackLocalEvent;
 use crate::media_stream::track_local::static_rtp::TrackLocalStaticRTP;

--- a/tests/remote_certificate_fingerprint.rs
+++ b/tests/remote_certificate_fingerprint.rs
@@ -1,0 +1,210 @@
+//! Worked example: reading the peers' DTLS certificate fingerprints out of `get_stats`.
+//!
+//! 0.17 had `RTCDtlsTransport::get_remote_certificate`; on 0.20 the statistics report is the
+//! route. Certificate-pinning protocols need the *remote* fingerprint — libp2p's WebRTC-Direct,
+//! for one, binds both peers' fingerprints into its Noise handshake prologue, and a listener
+//! can only learn the dialer's from the certificate the peer actually presented.
+//!
+//! The lookup is a two-step because the report identifies certificates indirectly: it carries a
+//! `Certificate` entry per side and neither says which side it belongs to — only the `Transport`
+//! entry's `local_certificate_id` / `remote_certificate_id` tell them apart. A cross-check pins
+//! that down: what one peer sees as *remote* must equal what the other reports as its *local*
+//! certificate, in both directions.
+//!
+//! Getting this backwards is not a loud failure. A pinning protocol would compare a fingerprint
+//! against itself and happily accept every peer.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use webrtc::peer_connection::{
+    PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCStatsReportEntry,
+    StatsSelector,
+};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Sender, block_on, channel, default_runtime, timeout};
+
+/// Which end of the connection a certificate belongs to.
+#[derive(Clone, Copy)]
+enum Side {
+    Local,
+    Remote,
+}
+
+/// The SHA-256 fingerprint of one side's DTLS certificate, colon-separated hex — the same shape
+/// as an SDP `a=fingerprint:` value ([RFC 4572 §5]). `None` before the handshake has completed.
+///
+/// [RFC 4572 §5]: https://www.rfc-editor.org/rfc/rfc4572#section-5
+async fn certificate_fingerprint(
+    pc: &dyn PeerConnection,
+    now: Instant,
+    side: Side,
+) -> Option<String> {
+    let report = pc.get_stats(now, StatsSelector::None).await;
+
+    let id = report.iter().find_map(|entry| match entry {
+        RTCStatsReportEntry::Transport(transport) => {
+            let id = match side {
+                Side::Local => &transport.local_certificate_id,
+                Side::Remote => &transport.remote_certificate_id,
+            };
+            (!id.is_empty()).then(|| id.clone())
+        }
+        _ => None,
+    })?;
+
+    report.iter().find_map(|entry| match entry {
+        RTCStatsReportEntry::Certificate(cert) if cert.stats.id == id => {
+            Some(cert.fingerprint.clone())
+        }
+        _ => None,
+    })
+}
+
+struct Handler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for Handler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+struct Peer {
+    pc: Box<dyn PeerConnection>,
+    gather_rx: webrtc::runtime::Receiver<()>,
+    connected_rx: webrtc::runtime::Receiver<()>,
+}
+
+impl Peer {
+    async fn fingerprint(&self, now: Instant, side: Side) -> Option<String> {
+        certificate_fingerprint(&*self.pc, now, side).await
+    }
+}
+
+async fn build_peer(runtime: Arc<dyn webrtc::runtime::Runtime>) -> Result<Peer> {
+    let (gather_tx, gather_rx) = channel::<()>(1);
+    let (connected_tx, connected_rx) = channel::<()>(1);
+
+    let pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(Handler {
+            gather_tx,
+            connected_tx,
+        }))
+        .with_runtime(runtime)
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    Ok(Peer {
+        pc: Box::new(pc),
+        gather_rx,
+        connected_rx,
+    })
+}
+
+#[test]
+fn test_remote_certificate_fingerprint_is_the_peers() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> Result<()> {
+    let runtime = default_runtime().ok_or_else(|| std::io::Error::other("no async runtime"))?;
+
+    let mut offerer = build_peer(runtime.clone()).await?;
+    let mut answerer = build_peer(runtime.clone()).await?;
+
+    // Nothing has been presented yet.
+    assert_eq!(
+        offerer.fingerprint(Instant::now(), Side::Remote).await,
+        None,
+        "there is no remote certificate before the handshake"
+    );
+
+    // A data channel gives the connection something to negotiate.
+    offerer.pc.create_data_channel("probe", None).await?;
+
+    let offer = offerer.pc.create_offer(None).await?;
+    offerer.pc.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offerer.gather_rx.recv()).await;
+    let offer_sdp = offerer
+        .pc
+        .local_description()
+        .await
+        .expect("offerer local description");
+
+    answerer.pc.set_remote_description(offer_sdp).await?;
+    let answer = answerer.pc.create_answer(None).await?;
+    answerer.pc.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answerer.gather_rx.recv()).await;
+    let answer_sdp = answerer
+        .pc
+        .local_description()
+        .await
+        .expect("answerer local description");
+    offerer.pc.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), offerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: offerer connect"))?;
+    timeout(Duration::from_secs(5), answerer.connected_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: answerer connect"))?;
+
+    let now = Instant::now();
+    let offerer_sees = offerer
+        .fingerprint(now, Side::Remote)
+        .await
+        .expect("offerer should see the answerer's certificate");
+    let answerer_sees = answerer
+        .fingerprint(now, Side::Remote)
+        .await
+        .expect("answerer should see the offerer's certificate");
+
+    let offerer_own = offerer
+        .fingerprint(now, Side::Local)
+        .await
+        .expect("offerer local certificate");
+    let answerer_own = answerer
+        .fingerprint(now, Side::Local)
+        .await
+        .expect("answerer local certificate");
+
+    // The cross-check: each side's "remote" is the other side's "local".
+    assert_eq!(
+        offerer_sees, answerer_own,
+        "what the offerer sees as remote must be the answerer's certificate"
+    );
+    assert_eq!(
+        answerer_sees, offerer_own,
+        "what the answerer sees as remote must be the offerer's certificate"
+    );
+
+    // Guards the cross-check above: were both peers to reuse one certificate, the two
+    // assertions would hold no matter which side the lookup returned.
+    assert_ne!(
+        offerer_own, answerer_own,
+        "the two peers must have distinct certificates for this test to mean anything"
+    );
+
+    // Shape check -- colon-separated SHA-256 hex, per RFC 4572 section 5.
+    assert_eq!(
+        offerer_sees.split(':').count(),
+        32,
+        "expected 32 colon-separated bytes, got {offerer_sees:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Addresses #827.

> **Revised after review.** The original version added
> `PeerConnection::remote_certificate_fingerprint`. @rainliu pointed out that it is not a W3C API
> and that `PeerConnection` should stay compact and compliant — a fair call, so the method is gone.
> What remains is the part that makes the W3C-shaped route actually usable from outside the crate.

## Problem

0.17 had a one-line accessor:

```rust
// webrtc 0.17, src/dtls_transport/mod.rs
pub async fn get_remote_certificate(&self) -> Bytes
```

0.20 has no equivalent. There is no `dtls_transport` module in the public surface, and nothing on
`PeerConnection` exposes the peer's certificate. The statistics report is the intended route — but
`get_stats` is a public trait method whose signature names types the crate does not export:

```rust
async fn get_stats(&self, now: Instant, selector: StatsSelector) -> RTCStatsReport;
```

`StatsSelector` and `RTCStatsReport` are `use`d rather than `pub use`d by `webrtc::peer_connection`,
and `webrtc` does not re-export `rtc` (only `rtc::shared::error`, via `webrtc::error`). So a caller
cannot name the argument or the return type without adding `rtc` to their own `Cargo.toml` — which
means restating a version this crate already pins and keeping the two in step by hand, while `rtc`
is still on release candidates.

And once you have the report, the lookup is indirect: it carries one certificate entry per side and
neither says which is which. You have to find the transport entry, read `local_certificate_id` /
`remote_certificate_id`, and match those back against the certificate entries — a traversal that is
not discoverable from the types.

## Change

- **`pub use` for `StatsSelector`, `RTCStatsReport` and `RTCStatsReportEntry`**, so `get_stats` is
  callable and its result readable. These types already appear in this crate's public signatures, so
  re-exporting them doesn't widen the API — it makes the existing one usable. The neighbouring
  `pub use rtc::interceptor::…` and `pub use rtc::peer_connection::…` lines in the same file follow
  the same principle.
- **Docs on `get_stats`** describing the certificate lookup and pointing at the test as a worked
  example.
- **`tests/remote_certificate_fingerprint.rs`**, which doubles as that example.

## Why it matters

libp2p's [WebRTC-Direct][spec] runs a Noise handshake whose prologue binds **both** DTLS
fingerprints:

```
libp2p-webrtc-noise:<client-fingerprint><server-fingerprint>
```

Both ends must derive the same prologue or the handshake fails. Each side knows its own fingerprint,
and the dialer learns the listener's from the multiaddr it dialed (`/webrtc-direct/certhash/...`).
That leaves exactly one value nobody can supply out of band: the listener needs the dialer's, and it
exists only in the certificate presented during DTLS. The 0.17-based transport in rust-libp2p does
precisely this:

```rust
async fn get_remote_fingerprint(conn: &RTCPeerConnection) -> Fingerprint {
    let cert_bytes = conn.sctp().transport().get_remote_certificate().await;
    Fingerprint::from_certificate(&cert_bytes)
}
```

On 0.20 the application performs the stats traversal itself. That is the intended shape — it just
needs the types to be nameable.

[spec]: https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md

## Test

`tests/remote_certificate_fingerprint.rs` connects two peers over loopback and cross-checks both
directions: what one peer reports as *remote* must equal what the other reports as *local*. It also
asserts the two certificates differ, so the cross-check cannot pass by coincidence, and that nothing
is returned before the handshake.

That shape is deliberate. Reading the local fingerprint by mistake is a silent failure — a pinning
check would compare a fingerprint against itself and accept every peer. Swapping
`remote_certificate_id` for `local_certificate_id` in the helper makes the test fail with the two
fingerprints printed side by side; a simple "is it non-empty" assertion would not have caught it.

`cargo fmt --check`, `cargo test` and `cargo clippy` are clean locally.

## Disclosure

This change was developed with AI assistance (Claude Code). I hit the gap building a WebRTC-Direct
libp2p transport on 0.20, worked around it with the stats traversal above, and opened #827 before
writing this. I have read every line of the diff and can explain it in review.
