### PR TITLE
remove data channel event sender on drop

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -44,7 +44,7 @@
 //! ```
 
 use crate::peer_connection::PeerConnectionRef;
-use crate::runtime::{Mutex, Receiver};
+use crate::runtime::{AsyncMutex as _, Mutex, Receiver};
 use bytes::BytesMut;
 use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
@@ -249,6 +249,17 @@ where
         futures::select! {
             _ = self.inner.data_channel_backpressure.notified().fuse() => {}
             _ = crate::runtime::sleep(Duration::from_millis(50)).fuse() => {}
+        }
+    }
+}
+
+impl<I> Drop for DataChannelImpl<I>
+where
+    I: Interceptor,
+{
+    fn drop(&mut self) {
+        if let Some(mut data_channels) = self.inner.data_channel_events_tx.try_lock() {
+            data_channels.remove(&self.id);
         }
     }
 }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -39,7 +39,6 @@ use rtc::shared::error::{Error, Result};
 use rtc::shared::{FourTuple, TaggedBytesMut, TransportContext, TransportProtocol};
 use rtc::{rtcp, rtp};
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -564,20 +563,19 @@ where
                         core.data_channel(channel_id).is_some()
                     };
 
-                    if data_channel_exist {
-                        let (evt_tx, evt_rx) = channel(DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
-                        let data_channel =
-                            Arc::new(DataChannelImpl::new(channel_id, self.inner.clone(), evt_rx));
-
+                    if data_channel_exist
+                        && let Some(evt_rx) = self
+                            .inner
+                            .insert_data_channel_event_sender(channel_id)
+                            .await
                         {
-                            let mut data_channels = self.inner.data_channel_events_tx.lock().await;
-                            if let Entry::Vacant(e) = data_channels.entry(channel_id) {
-                                e.insert(evt_tx);
-                            }
+                            let data_channel = Arc::new(DataChannelImpl::new(
+                                channel_id,
+                                self.inner.clone(),
+                                evt_rx,
+                            ));
+                            self.inner.handler.on_data_channel(data_channel).await;
                         }
-
-                        self.inner.handler.on_data_channel(data_channel).await;
-                    }
                 }
 
                 let data_channels = self.inner.data_channel_events_tx.lock().await;

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -62,7 +62,7 @@ use crate::data_channel::{DataChannel, DataChannelEvent, DataChannelImpl};
 use crate::media_stream::{track_local::TrackLocal, track_remote::TrackRemote};
 use crate::rtp_transceiver::{RtpReceiver, RtpSender, RtpTransceiver, RtpTransceiverImpl};
 use crate::runtime::{JoinHandle, Runtime, default_runtime};
-use crate::runtime::{Mutex, Sender, channel};
+use crate::runtime::{AsyncSender as _, Mutex, Receiver, Sender, channel};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use driver::{
@@ -640,6 +640,27 @@ where
             crate::runtime::yield_now().await;
         }
     }
+
+    /// Insert a data-channel event sender for `channel_id` if the slot is vacant
+    /// or the existing sender is closed. Returns the receiver when insertion
+    /// happened.
+    pub(crate) async fn insert_data_channel_event_sender(
+        &self,
+        channel_id: RTCDataChannelId,
+    ) -> Option<Receiver<DataChannelEvent>> {
+        let (evt_tx, evt_rx) = channel(DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
+        let mut data_channels = self.data_channel_events_tx.lock().await;
+        let should_insert = match data_channels.entry(channel_id) {
+            std::collections::hash_map::Entry::Vacant(_) => true,
+            std::collections::hash_map::Entry::Occupied(e) => e.get().is_closed(),
+        };
+        if should_insert {
+            data_channels.insert(channel_id, evt_tx);
+            Some(evt_rx)
+        } else {
+            None
+        }
+    }
 }
 
 impl<I> PeerConnectionImpl<I>
@@ -1211,5 +1232,101 @@ where
     async fn get_stats(&self, now: Instant, selector: StatsSelector) -> RTCStatsReport {
         let mut core = self.inner.core.lock().await;
         core.get_stats(now, selector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::block_on;
+    use crate::runtime::Notify;
+    use std::sync::atomic::AtomicUsize;
+
+    #[derive(Clone)]
+    struct DummyHandler;
+
+    #[async_trait::async_trait]
+    impl PeerConnectionEventHandler for DummyHandler {}
+
+    fn test_peer_connection_ref() -> Arc<PeerConnectionRef<NoopInterceptor>> {
+        let core = RTCPeerConnectionBuilder::new().build().unwrap();
+        let runtime = default_runtime().expect("test requires a runtime feature");
+        let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(DummyHandler);
+        let (driver_event_tx, _driver_event_rx) = channel::<PeerConnectionDriverEvent>(1);
+
+        Arc::new(PeerConnectionRef {
+            core: Mutex::new(core),
+            runtime,
+            handler,
+            rtp_transceivers: Mutex::new(HashMap::new()),
+            driver_event_tx,
+            write_pending: AtomicBool::new(false),
+            write_backpressure: AtomicUsize::new(0),
+            closing: AtomicBool::new(false),
+            data_channel_send_buffer_limit: usize::MAX,
+            data_channel_backpressure: Notify::new(),
+            data_channel_events_tx: Mutex::new(HashMap::new()),
+            track_remote_events_tx: Mutex::new(HashMap::new()),
+            track_local_events_tx: Mutex::new(HashMap::new()),
+        })
+    }
+
+    #[test]
+    fn data_channel_drop_removes_event_sender() {
+        block_on(async {
+            let inner = test_peer_connection_ref();
+            let channel_id = 0;
+
+            let (evt_tx, evt_rx) = channel::<DataChannelEvent>(1);
+            inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .insert(channel_id, evt_tx);
+            assert!(inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .contains_key(&channel_id));
+
+            let dc = DataChannelImpl::new(channel_id, inner.clone(), evt_rx);
+            drop(dc);
+
+            assert!(!inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .contains_key(&channel_id));
+        });
+    }
+
+    #[test]
+    fn insert_data_channel_event_sender_replaces_closed_sender() {
+        block_on(async {
+            let inner = test_peer_connection_ref();
+            let channel_id = 0;
+
+            let (old_tx, old_rx) = channel::<DataChannelEvent>(1);
+            drop(old_rx);
+            inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .insert(channel_id, old_tx);
+
+            let evt_rx = inner
+                .insert_data_channel_event_sender(channel_id)
+                .await;
+            assert!(evt_rx.is_some());
+
+            let sender = inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .get(&channel_id)
+                .cloned()
+                .unwrap();
+            assert!(!sender.is_closed());
+        });
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -314,6 +314,10 @@ pub trait AsyncMutex<T: ?Sized>: Send + Sync {
 
     /// Lock the mutex asynchronously
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>>;
+
+    /// Try to lock the mutex without blocking. Returns `None` if the lock is
+    /// held by another task.
+    fn try_lock(&self) -> Option<Self::Guard<'_>>;
 }
 
 /// An async notification primitive
@@ -336,6 +340,9 @@ pub trait AsyncSender<T>: Send + Sync {
 
     /// Try to send a value without blocking
     fn try_send(&self, value: T) -> Result<(), TrySendError<T>>;
+
+    /// Returns `true` if the receiver for this sender has been dropped
+    fn is_closed(&self) -> bool;
 }
 
 /// Receiver half of an async channel

--- a/src/runtime/smol.rs
+++ b/src/runtime/smol.rs
@@ -438,6 +438,10 @@ impl<T: ?Sized + Send> AsyncMutex<T> for SmolMutex<T> {
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>> {
         Box::pin(self.0.lock())
     }
+
+    fn try_lock(&self) -> Option<Self::Guard<'_>> {
+        self.0.try_lock()
+    }
 }
 
 /// Smol-based notify wrapper using Event
@@ -556,6 +560,10 @@ impl<T: Send> AsyncSender<T> for SmolSender<T> {
             ::smol::channel::TrySendError::Full(v) => TrySendError::Full(v),
             ::smol::channel::TrySendError::Closed(v) => TrySendError::Disconnected(v),
         })
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 }
 

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -460,6 +460,10 @@ impl<T: ?Sized + Send> AsyncMutex<T> for TokioMutex<T> {
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>> {
         Box::pin(self.0.lock())
     }
+
+    fn try_lock(&self) -> Option<Self::Guard<'_>> {
+        self.0.try_lock().ok()
+    }
 }
 
 /// Tokio-based notify wrapper
@@ -549,6 +553,10 @@ impl<T: Send> AsyncSender<T> for TokioSender<T> {
             ::tokio::sync::mpsc::error::TrySendError::Full(v) => TrySendError::Full(v),
             ::tokio::sync::mpsc::error::TrySendError::Closed(v) => TrySendError::Disconnected(v),
         })
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 }
 


### PR DESCRIPTION
I encountered this when migrating from v0.17 to v0.20. The sans-io driver fires `on_data_channel` for both locally-created and remote-opened channels; my application opens 5 data channels per connection, and during teardown some `DataChannelImpl` instances are dropped without a clean `OnClose` driver event, leaving zombie senders in the map.

## Summary

When a `DataChannelImpl` is dropped, its event sender in `data_channel_events_tx` was not cleaned up. Dead senders accumulated, and if a new channel reused the same id, the `Entry::Vacant` guard refused to insert the new sender -- silently losing all driver events for that channel.

Fix: (1) `Drop for DataChannelImpl` removes the entry via `try_lock()`. (2) OnOpen handler checks `Entry::Occupied if is_closed()` to replace stale senders left by concurrent drops.

## Changes

- `src/runtime/mod.rs`, `tokio.rs`, `smol.rs`: Added `try_lock()` to `AsyncMutex` and `is_closed()` to `AsyncSender`
- `src/data_channel/mod.rs`: Added `Drop for DataChannelImpl`
- `src/peer_connection/mod.rs`: Added `insert_data_channel_event_sender` helper + inline tests
- `src/peer_connection/driver.rs`: OnOpen handler calls the helper

## Tests

- `data_channel_drop_removes_event_sender`
- `insert_data_channel_event_sender_replaces_closed_sender`

## Verification

```bash
cd webrtc/
cargo test --lib
cargo clippy -- -D warnings
```

All pass; clippy clean.
