### PR TITLE
Fix ICE server updates after set_configuration

### DIFF
--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -28,7 +28,7 @@ use rtc::ice::candidate::Candidate;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
 use rtc::mdns::MDNS_PORT;
 use rtc::media_stream::MediaStreamTrack;
-use rtc::peer_connection::configuration::RTCIceTransportPolicy;
+use rtc::peer_connection::configuration::{RTCIceServer, RTCIceTransportPolicy};
 use rtc::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent, RTCTrackEvent};
 use rtc::peer_connection::message::RTCMessage;
 use rtc::peer_connection::state::RTCIceGatheringState;
@@ -66,6 +66,10 @@ pub(crate) enum PeerConnectionDriverEvent {
     RemoteIceTcpPassiveCandidate(Candidate),
     IncomingTcpStream(FourTuple, Arc<dyn AsyncTcpStream>),
     WriteNotify,
+    UpdateIceConfiguration {
+        ice_servers: Vec<RTCIceServer>,
+        ice_transport_policy: RTCIceTransportPolicy,
+    },
     IceGathering,
     Close,
 }
@@ -89,6 +93,7 @@ where
     ice_gathering_active: bool,
     stun_gathering_complete: bool,
     turn_gathering_complete: bool,
+    pending_ice_configuration: Option<(Vec<RTCIceServer>, RTCIceTransportPolicy)>,
 }
 
 impl<I> PeerConnectionDriver<I>
@@ -119,6 +124,7 @@ where
             ice_gathering_active: false,
             stun_gathering_complete: false,
             turn_gathering_complete: false,
+            pending_ice_configuration: None,
         })
     }
 
@@ -876,7 +882,24 @@ where
                 // the top of the loop) ensures a burst of sends enqueues at most
                 // one of these.
             }
+            PeerConnectionDriverEvent::UpdateIceConfiguration {
+                ice_servers,
+                ice_transport_policy,
+            } => {
+                // Keep the active gathering/allocation intact. The new configuration
+                // takes effect when the next gathering phase starts.
+                self.pending_ice_configuration = Some((ice_servers, ice_transport_policy));
+            }
             PeerConnectionDriverEvent::IceGathering => {
+                if let Some((ice_servers, ice_transport_policy)) =
+                    self.pending_ice_configuration.take()
+                {
+                    self.stun_gatherer
+                        .update_configuration(ice_servers.clone(), ice_transport_policy);
+                    self.turn_relayer
+                        .update_configuration(ice_servers, ice_transport_policy);
+                }
+
                 self.ice_gathering_active = true;
                 self.stun_gathering_complete = false;
                 self.turn_gathering_complete = false;

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1020,8 +1020,24 @@ where
     }
 
     async fn set_configuration(&self, configuration: RTCConfiguration) -> Result<()> {
-        let mut core = self.inner.core.lock().await;
-        core.set_configuration(configuration)
+        let (ice_servers, ice_transport_policy) = {
+            let mut core = self.inner.core.lock().await;
+            core.set_configuration(configuration)?;
+            let configuration = core.get_configuration();
+            (
+                configuration.ice_servers().to_vec(),
+                configuration.ice_transport_policy(),
+            )
+        };
+
+        self.inner
+            .driver_event_tx
+            .send(PeerConnectionDriverEvent::UpdateIceConfiguration {
+                ice_servers,
+                ice_transport_policy,
+            })
+            .await
+            .map_err(|_| Error::Other("peer connection driver stopped".to_owned()))
     }
 
     async fn create_data_channel(

--- a/src/peer_connection/transports/stun_gatherer.rs
+++ b/src/peer_connection/transports/stun_gatherer.rs
@@ -80,6 +80,21 @@ impl RTCStunGatherer {
         self.state
     }
 
+    pub(crate) fn update_configuration(
+        &mut self,
+        ice_servers: Vec<RTCIceServer>,
+        ice_gather_policy: RTCIceTransportPolicy,
+    ) {
+        for (_, mut stun_client) in self.stun_clients.drain() {
+            let _ = stun_client.close();
+        }
+        self.wouts.clear();
+        self.events.clear();
+        self.ice_servers = ice_servers;
+        self.ice_gather_policy = ice_gather_policy;
+        self.state = RTCIceGatheringState::New;
+    }
+
     pub(crate) fn is_stun_message(&self, msg: &TaggedBytesMut) -> bool {
         for four_tuple in self.stun_clients.keys() {
             if four_tuple.peer_addr == msg.transport.peer_addr

--- a/src/peer_connection/transports/turn_relayer.rs
+++ b/src/peer_connection/transports/turn_relayer.rs
@@ -89,6 +89,27 @@ impl RTCTurnRelayer {
         self.state
     }
 
+    pub(crate) fn update_configuration(
+        &mut self,
+        ice_servers: Vec<RTCIceServer>,
+        ice_gather_policy: RTCIceTransportPolicy,
+    ) {
+        let keys: Vec<FourTuple> = self.clients.keys().copied().collect();
+        for key in keys {
+            self.remove_client(key);
+        }
+        self.relay_addrs.clear();
+        self.pending_permissions.clear();
+        self.pending_permission_pairs.clear();
+        self.pending_packets.clear();
+        self.wouts.clear();
+        self.routs.clear();
+        self.events.clear();
+        self.ice_servers = ice_servers;
+        self.ice_gather_policy = ice_gather_policy;
+        self.state = RTCIceGatheringState::New;
+    }
+
     pub(crate) fn is_turn_message(&self, msg: &TaggedBytesMut) -> bool {
         self.matching_client_key(msg).is_some()
     }

--- a/tests/ice_test.rs
+++ b/tests/ice_test.rs
@@ -2,13 +2,13 @@
 
 use rtc::ice::mdns::MulticastDnsMode;
 use rtc::peer_connection::transport::RTCIceCandidate;
-use rtc::stun::attributes::{ATTR_NONCE, ATTR_REALM};
+use rtc::stun::attributes::{ATTR_NONCE, ATTR_REALM, ATTR_USERNAME};
 use rtc::stun::error_code::CODE_UNAUTHORIZED;
 use rtc::stun::message::{
-    CLASS_ERROR_RESPONSE, CLASS_SUCCESS_RESPONSE, METHOD_ALLOCATE, METHOD_CREATE_PERMISSION,
-    Message as StunMessage, MessageType,
+    CLASS_ERROR_RESPONSE, CLASS_SUCCESS_RESPONSE, Getter, METHOD_ALLOCATE,
+    METHOD_CREATE_PERMISSION, Message as StunMessage, MessageType,
 };
-use rtc::stun::textattrs::{Nonce, Realm};
+use rtc::stun::textattrs::{Nonce, Realm, Username};
 use rtc::turn::proto::lifetime::Lifetime;
 use rtc::turn::proto::relayaddr::RelayedAddress;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -76,7 +76,11 @@ impl PeerConnectionEventHandler for CandidateTypeTracker {
     }
 }
 
-async fn run_mock_turn_server(turn_socket: Arc<dyn AsyncUdpSocket>, relay_addr: SocketAddr) {
+async fn run_mock_turn_server(
+    turn_socket: Arc<dyn AsyncUdpSocket>,
+    relay_addr: SocketAddr,
+    username_tx: Option<Sender<String>>,
+) {
     let mut buf = vec![0u8; 2048];
     loop {
         let Ok((n, peer_addr)) = turn_socket.recv_from(&mut buf).await else {
@@ -92,6 +96,12 @@ async fn run_mock_turn_server(turn_socket: Arc<dyn AsyncUdpSocket>, relay_addr: 
         let response = match msg.typ.method {
             METHOD_ALLOCATE => {
                 if msg.get(ATTR_NONCE).is_ok() {
+                    if let Some(username_tx) = &username_tx {
+                        let mut username = Username::new(ATTR_USERNAME, String::new());
+                        if username.get_from(&msg).is_ok() {
+                            let _ = username_tx.try_send(username.text);
+                        }
+                    }
                     build_turn_allocate_success(msg.transaction_id, relay_addr)
                 } else {
                     build_turn_allocate_unauthorized(msg.transaction_id)
@@ -496,7 +506,11 @@ fn test_turn_relay_gathering_with_mock_turn_server() {
             .wrap_udp_socket(turn_socket)
             .expect("failed to wrap mock TURN socket");
         let relay_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50000);
-        let turn_task = runtime.spawn(Box::pin(run_mock_turn_server(turn_socket, relay_addr)));
+        let turn_task = runtime.spawn(Box::pin(run_mock_turn_server(
+            turn_socket,
+            relay_addr,
+            None,
+        )));
 
         let mut media_engine = MediaEngine::default();
         media_engine
@@ -552,6 +566,98 @@ fn test_turn_relay_gathering_with_mock_turn_server() {
             "Relay-only policy should not publish host candidates: {:?}",
             gathered
         );
+
+        turn_task.abort();
+    });
+}
+
+#[test]
+fn test_set_configuration_updates_turn_credentials_on_ice_restart() {
+    block_on(async {
+        let runtime = default_runtime().expect("no async runtime available");
+        let turn_socket =
+            std::net::UdpSocket::bind("127.0.0.1:0").expect("failed to bind mock TURN server");
+        let turn_addr = turn_socket
+            .local_addr()
+            .expect("failed to get mock TURN address");
+        let turn_socket = runtime
+            .wrap_udp_socket(turn_socket)
+            .expect("failed to wrap mock TURN socket");
+        let relay_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50000);
+        let (username_tx, mut username_rx) = channel(8);
+        let turn_task = runtime.spawn(Box::pin(run_mock_turn_server(
+            turn_socket,
+            relay_addr,
+            Some(username_tx),
+        )));
+
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("Failed to register codecs");
+
+        let turn_url = format!("turn:{}?transport=udp", turn_addr);
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec![turn_url.clone()],
+                username: "username-a".to_owned(),
+                credential: "password-a".to_owned(),
+            }])
+            .with_ice_transport_policy(RTCIceTransportPolicy::Relay)
+            .build();
+
+        let candidates = Arc::new(Mutex::new(Vec::new()));
+        let (gathering_tx, mut gathering_rx) = channel(8);
+        let handler = Arc::new(CandidateTypeTracker {
+            candidates,
+            gathering_tx,
+        });
+
+        let pc = PeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(media_engine)
+            .with_handler(handler)
+            .with_udp_addrs(vec!["127.0.0.1:0"])
+            .build()
+            .await
+            .unwrap();
+
+        let _ = pc.create_data_channel("channel1", None).await.unwrap();
+        let offer = pc.create_offer(None).await.expect("Failed to create offer");
+        pc.set_local_description(offer)
+            .await
+            .expect("Failed to set local description");
+
+        timeout(Duration::from_secs(5), gathering_rx.recv())
+            .await
+            .expect("Timed out waiting for initial relay gathering");
+        let initial_username = timeout(Duration::from_secs(5), username_rx.recv())
+            .await
+            .expect("Timed out waiting for initial authenticated Allocate")
+            .expect("TURN username channel closed");
+        assert_eq!(initial_username, "username-a");
+
+        let new_config = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec![turn_url],
+                username: "username-b".to_owned(),
+                credential: "password-b".to_owned(),
+            }])
+            .with_ice_transport_policy(RTCIceTransportPolicy::Relay)
+            .build();
+        pc.set_configuration(new_config)
+            .await
+            .expect("Failed to update ICE server configuration");
+        pc.restart_ice().await.expect("Failed to restart ICE");
+
+        let restarted_username = timeout(Duration::from_secs(5), username_rx.recv())
+            .await
+            .expect("Timed out waiting for restarted authenticated Allocate")
+            .expect("TURN username channel closed");
+        assert_eq!(restarted_username, "username-b");
+        timeout(Duration::from_secs(5), gathering_rx.recv())
+            .await
+            .expect("Timed out waiting for restarted relay gathering");
 
         turn_task.abort();
     });


### PR DESCRIPTION
## Summary

- propagate the effective ICE server list and transport policy from `set_configuration` to the async peer-connection driver
- defer applying the update until the next ICE gathering phase, so `set_configuration` alone does not tear down the active TURN allocation
- reset the STUN/TURN gatherers when that phase begins, so an ICE restart creates a new TURN allocation with the updated credentials
- add a mock TURN regression test that verifies the authenticated Allocate username changes after `set_configuration` + `restart_ice`

This follows the configuration propagation model used by Pion in [pion/webrtc#3339](https://github.com/pion/webrtc/pull/3339).

Fixes #830.

## Motivation

Actrium uses short-lived TURN credentials and is currently blocked on reliable credential rotation, so an expedited review would be greatly appreciated.

## Tests

Tested against `webrtc-rs/webrtc` master `33bc418` with rtc submodule `c6544977`.

- confirmed the new regression test fails on unpatched master because no second authenticated Allocate is sent
- `cargo fmt`
- `cargo clippy --fix --lib --bins --all-targets --allow-dirty`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=4 cargo test --all --no-fail-fast`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=4 cargo test --all --no-fail-fast --no-default-features --features runtime-smol`