### PR TITLE
clean up stale data channel event senders on drop

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -44,7 +44,7 @@
 //! ```
 
 use crate::peer_connection::PeerConnectionRef;
-use crate::runtime::{Mutex, Receiver};
+use crate::runtime::{AsyncMutex as _, Mutex, Receiver};
 use bytes::BytesMut;
 use futures::FutureExt;
 use rtc::interceptor::{Interceptor, NoopInterceptor};
@@ -249,6 +249,17 @@ where
         futures::select! {
             _ = self.inner.data_channel_backpressure.notified().fuse() => {}
             _ = crate::runtime::sleep(Duration::from_millis(50)).fuse() => {}
+        }
+    }
+}
+
+impl<I> Drop for DataChannelImpl<I>
+where
+    I: Interceptor,
+{
+    fn drop(&mut self) {
+        if let Some(mut data_channels) = self.inner.data_channel_events_tx.try_lock() {
+            data_channels.remove(&self.id);
         }
     }
 }
@@ -711,5 +722,74 @@ mod tests {
             "the DataChannel::try_send_text default must delegate to send_text()"
         );
         assert_eq!(dc.sends.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn drop_removes_event_sender() {
+        use crate::peer_connection::PeerConnectionEventHandler;
+        use crate::runtime::{Notify, channel, default_runtime};
+        use rtc::peer_connection::RTCPeerConnectionBuilder;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        #[derive(Clone)]
+        struct DummyHandler;
+
+        unsafe impl Send for DummyHandler {}
+        unsafe impl Sync for DummyHandler {}
+
+        #[async_trait::async_trait]
+        impl PeerConnectionEventHandler for DummyHandler {}
+
+        block_on(async {
+            let core = RTCPeerConnectionBuilder::new().build().unwrap();
+            let runtime = default_runtime().expect("test requires a runtime feature");
+            let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(DummyHandler);
+            let (driver_event_tx, _driver_event_rx) =
+                channel::<crate::peer_connection::driver::PeerConnectionDriverEvent>(1);
+
+            let inner = Arc::new(PeerConnectionRef {
+                core: Mutex::new(core),
+                runtime,
+                handler,
+                driver_event_tx,
+                write_pending: AtomicBool::new(false),
+                write_backpressure: AtomicUsize::new(0),
+                closing: AtomicBool::new(false),
+                data_channel_send_buffer_limit: usize::MAX,
+                data_channel_backpressure: Notify::new(),
+                data_channel_events_tx: Mutex::new(HashMap::new()),
+                track_remote_events_tx: Mutex::new(HashMap::new()),
+                track_local_events_tx: Mutex::new(HashMap::new()),
+                rtp_transceivers: Mutex::new(HashMap::new()),
+            });
+
+            let channel_id = 0;
+            let (evt_tx, evt_rx) = channel::<DataChannelEvent>(1);
+            inner
+                .data_channel_events_tx
+                .lock()
+                .await
+                .insert(channel_id, evt_tx);
+            assert!(
+                inner
+                    .data_channel_events_tx
+                    .lock()
+                    .await
+                    .contains_key(&channel_id)
+            );
+
+            let dc = DataChannelImpl::new(channel_id, inner.clone(), evt_rx);
+            drop(dc);
+
+            assert!(
+                !inner
+                    .data_channel_events_tx
+                    .lock()
+                    .await
+                    .contains_key(&channel_id)
+            );
+        });
     }
 }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -6,7 +6,7 @@ use super::transports::stun_gatherer::{
     RTCStunGatherEventIn, RTCStunGatherEventOut, RTCStunGatherer,
 };
 use super::transports::turn_relayer::{RTCTurnRelayEventIn, RTCTurnRelayEventOut, RTCTurnRelayer};
-use crate::data_channel::{DataChannelEvent, DataChannelImpl};
+use crate::data_channel::{DataChannelEvent, DataChannelImpl, RTCDataChannelId};
 use crate::media_stream::track_local::TrackLocalEvent;
 use crate::media_stream::track_remote::static_rtp::TrackRemoteStaticRTP;
 use crate::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
@@ -18,7 +18,9 @@ use crate::peer_connection::transports::{
 };
 use crate::rtp_transceiver::rtp_receiver::RtpReceiverImpl;
 use crate::rtp_transceiver::{RtpReceiver, RtpTransceiverImpl};
-use crate::runtime::{AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, Receiver, channel};
+use crate::runtime::{
+    AsyncSender as _, AsyncTcpListener, AsyncTcpStream, AsyncUdpSocket, Receiver, Sender, channel,
+};
 use bytes::BytesMut;
 use futures::FutureExt; // For .fuse() in futures::select!
 use futures::future::OptionFuture;
@@ -56,6 +58,25 @@ pub(crate) const TRACK_REMOTE_EVENT_CHANNEL_CAPACITY: usize = 256;
 pub(crate) const TRACK_LOCAL_EVENT_CHANNEL_CAPACITY: usize = 256;
 
 const DEFAULT_TIMEOUT_DURATION: Duration = Duration::from_secs(86400); // 1 day duration
+
+/// Insert `sender` for `channel_id`, returning `true` if the channel should be announced.
+pub(crate) fn insert_data_channel_event_sender(
+    data_channels: &mut HashMap<RTCDataChannelId, Sender<DataChannelEvent>>,
+    channel_id: RTCDataChannelId,
+    sender: Sender<DataChannelEvent>,
+) -> bool {
+    match data_channels.entry(channel_id) {
+        Entry::Vacant(e) => {
+            e.insert(sender);
+            true
+        }
+        Entry::Occupied(mut e) if e.get().is_closed() => {
+            e.insert(sender);
+            true
+        }
+        Entry::Occupied(_) => false,
+    }
+}
 
 /// Unified inner message type for the peer connection driver
 #[derive(Debug)]
@@ -573,22 +594,12 @@ where
                     if data_channel_exist {
                         let (evt_tx, evt_rx) = channel(DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
 
-                        // A vacant entry means the peer opened this channel: locally created
-                        // ones are registered by `create_data_channel` before their `OnOpen`
-                        // ever reaches us. Only those get announced through the handler --
-                        // `on_data_channel` is for remotely opened channels.
-                        let opened_by_peer = {
+                        let should_announce = {
                             let mut data_channels = self.inner.data_channel_events_tx.lock().await;
-                            match data_channels.entry(channel_id) {
-                                Entry::Vacant(e) => {
-                                    e.insert(evt_tx);
-                                    true
-                                }
-                                Entry::Occupied(_) => false,
-                            }
+                            insert_data_channel_event_sender(&mut data_channels, channel_id, evt_tx)
                         };
 
-                        if opened_by_peer {
+                        if should_announce {
                             let data_channel = Arc::new(DataChannelImpl::new(
                                 channel_id,
                                 self.inner.clone(),
@@ -1256,5 +1267,46 @@ where
         let mut core = self.inner.core.lock().await;
         core.handle_timeout(now)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::channel;
+
+    #[test]
+    fn insert_data_channel_event_sender_replaces_closed_sender() {
+        let mut map: HashMap<RTCDataChannelId, Sender<DataChannelEvent>> = HashMap::new();
+        let channel_id = 0;
+
+        let (old_tx, old_rx) = channel::<DataChannelEvent>(1);
+        drop(old_rx);
+        map.insert(channel_id, old_tx);
+
+        let (new_tx, _new_rx) = channel::<DataChannelEvent>(1);
+        let should_announce = insert_data_channel_event_sender(&mut map, channel_id, new_tx);
+        // Before the fix this returns false (Occupied check refuses);
+        // after the fix it returns true (closed sender is replaced).
+        assert!(should_announce);
+
+        let sender = map.get(&channel_id).cloned().unwrap();
+        assert!(!sender.is_closed());
+    }
+
+    #[test]
+    fn insert_data_channel_event_sender_skips_live_sender() {
+        let mut map: HashMap<RTCDataChannelId, Sender<DataChannelEvent>> = HashMap::new();
+        let channel_id = 0;
+
+        let (live_tx, _live_rx) = channel::<DataChannelEvent>(1);
+        map.insert(channel_id, live_tx);
+
+        let (new_tx, _new_rx) = channel::<DataChannelEvent>(1);
+        let should_announce = insert_data_channel_event_sender(&mut map, channel_id, new_tx);
+        assert!(!should_announce);
+
+        let sender = map.get(&channel_id).cloned().unwrap();
+        assert!(!sender.is_closed());
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -314,6 +314,10 @@ pub trait AsyncMutex<T: ?Sized>: Send + Sync {
 
     /// Lock the mutex asynchronously
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>>;
+
+    /// Try to lock the mutex without blocking. Returns `None` if the lock is
+    /// held by another task.
+    fn try_lock(&self) -> Option<Self::Guard<'_>>;
 }
 
 /// An async notification primitive
@@ -336,6 +340,9 @@ pub trait AsyncSender<T>: Send + Sync {
 
     /// Try to send a value without blocking
     fn try_send(&self, value: T) -> Result<(), TrySendError<T>>;
+
+    /// Returns `true` if the receiver for this sender has been dropped
+    fn is_closed(&self) -> bool;
 }
 
 /// Receiver half of an async channel

--- a/src/runtime/smol.rs
+++ b/src/runtime/smol.rs
@@ -438,6 +438,10 @@ impl<T: ?Sized + Send> AsyncMutex<T> for SmolMutex<T> {
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>> {
         Box::pin(self.0.lock())
     }
+
+    fn try_lock(&self) -> Option<Self::Guard<'_>> {
+        self.0.try_lock()
+    }
 }
 
 /// Smol-based notify wrapper using Event
@@ -556,6 +560,10 @@ impl<T: Send> AsyncSender<T> for SmolSender<T> {
             ::smol::channel::TrySendError::Full(v) => TrySendError::Full(v),
             ::smol::channel::TrySendError::Closed(v) => TrySendError::Disconnected(v),
         })
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 }
 

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -460,6 +460,10 @@ impl<T: ?Sized + Send> AsyncMutex<T> for TokioMutex<T> {
     fn lock(&self) -> Pin<Box<dyn Future<Output = Self::Guard<'_>> + Send + '_>> {
         Box::pin(self.0.lock())
     }
+
+    fn try_lock(&self) -> Option<Self::Guard<'_>> {
+        self.0.try_lock().ok()
+    }
 }
 
 /// Tokio-based notify wrapper
@@ -549,6 +553,10 @@ impl<T: Send> AsyncSender<T> for TokioSender<T> {
             ::tokio::sync::mpsc::error::TrySendError::Full(v) => TrySendError::Full(v),
             ::tokio::sync::mpsc::error::TrySendError::Closed(v) => TrySendError::Disconnected(v),
         })
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 }
 


### PR DESCRIPTION
Hey sorry about #829; I made the PR, but when I opened the draft, someone had completely modified the section of the code I was working on so I quickly closed it till I had more time to revise my work with the latest version of webrtc.

I encountered this issue when migrating from v0.17 to v0.20. The sans-io driver fires `on_data_channel` for both locally-created and remote-opened channels; my application opens 5 data channels per connection, and during teardown some DataChannel Impl instances are dropped without a clean `OnClose` driver event, leaving zombie senders in the map.

As for the "draft" status:

I followed the `webrtc` crate's convention of placing tests inline at the bottom of the module, since that's what I observed here (as opposed to the `rtc` crate's external test files). Happy to adjust if there's a preferred structure.


## Summary

Implements W3C WebRTC Sec.6.2.4 _Closing procedure_, step 3: "Remove `channel` from `connection.[[DataChannels]]`."

> <https://www.w3.org/TR/webrtc/#closing-procedure>

The `webrtc` crate mirrors `[[DataChannels]]` with an internal `data_channel_events_tx` map that routes driver events (OnOpen, OnMessage, OnClose, …) to each channel's `DataChannelImpl`.

When a `DataChannelImpl` was dropped without a clean `OnClose` driver event (e.g. during teardown), its event sender remained in the map. Dead senders accumulated, and if a new channel later reused the same id, the driver's `OnOpen` handler saw `Entry::Occupied` and silently discarded all events for that channel.

## Changes

- `src/runtime/mod.rs`, `tokio.rs`, `smol.rs`: add `try_lock()` to `AsyncMutex` and `is_closed()` to `AsyncSender`.
- `src/data_channel/mod.rs`: add `Drop for DataChannelImpl` that best-effort removes the event sender via `try_lock()`. The `try_lock()` is intentionally non-blocking: a contended mutex skips cleanup rather than blocking in `Drop`. The `OnOpen` closed-sender replacement is the fallback that covers the race.
- `src/peer_connection/driver.rs`: extract the sender-insertion logic into `insert_data_channel_event_sender` (a `pub(crate)` function for unit testability), which replaces an `Occupied` sender when its receiver is closed. The driver `OnOpen` handler uses the helper instead of the inline match.

## Tests

- `data_channel::tests::drop_removes_event_sender`: creates a sender, inserts it, drops the `DataChannelImpl`, and asserts the map entry is removed.
- `driver::tests::insert_data_channel_event_sender_replaces_closed_sender`: populates the map with a closed sender, calls the helper with a fresh sender, and asserts `true` (the sender was inserted and the channel should be announced).
- `driver::tests::insert_data_channel_event_sender_skips_live_sender`: same with a live sender; asserts `false` (no regression for the alive path).

No integration test is added because the bug (id reuse after stale sender) cannot be forced through the public WebRTC API: in-band channel IDs are partitioned by DTLS role parity, and negotiated channels do not emit cross-wire `OnOpen` events. The unit tests cover both the `Drop` cleanup and the `OnOpen` replacement paths directly.

## Verification

```bash
cargo test --lib
cargo clippy -- -D warnings
```
