### PR TITLE
wake writes after create_data_channel

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -718,44 +718,11 @@ mod tests {
 
     #[test]
     fn drop_removes_event_sender() {
-        use crate::peer_connection::PeerConnectionEventHandler;
-        use crate::runtime::{Notify, channel, default_runtime};
-        use rtc::peer_connection::RTCPeerConnectionBuilder;
-        use std::collections::HashMap;
-        use std::sync::Arc;
-        use std::sync::atomic::AtomicBool;
-
-        #[derive(Clone)]
-        struct DummyHandler;
-
-        unsafe impl Send for DummyHandler {}
-        unsafe impl Sync for DummyHandler {}
-
-        #[async_trait::async_trait]
-        impl PeerConnectionEventHandler for DummyHandler {}
+        use crate::peer_connection::new_test_peer_connection;
+        use crate::runtime::{block_on, channel};
 
         block_on(async {
-            let core = RTCPeerConnectionBuilder::new().build().unwrap();
-            let runtime = default_runtime().expect("test requires a runtime feature");
-            let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(DummyHandler);
-            let (driver_event_tx, _driver_event_rx) =
-                channel::<crate::peer_connection::driver::PeerConnectionDriverEvent>(1);
-
-            let inner = Arc::new(PeerConnectionRef {
-                core: Mutex::new(core),
-                runtime,
-                handler,
-                driver_event_tx,
-                write_pending: AtomicBool::new(false),
-                write_backpressure: AtomicUsize::new(0),
-                closing: AtomicBool::new(false),
-                data_channel_send_buffer_limit: usize::MAX,
-                data_channel_backpressure: Notify::new(),
-                data_channel_events_tx: Mutex::new(HashMap::new()),
-                track_remote_events_tx: Mutex::new(HashMap::new()),
-                track_local_events_tx: Mutex::new(HashMap::new()),
-                rtp_transceivers: Mutex::new(HashMap::new()),
-            });
+            let (inner, _driver_event_rx) = new_test_peer_connection().await;
 
             let channel_id = 0;
             let (evt_tx, evt_rx) = channel::<DataChannelEvent>(1);

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1070,6 +1070,8 @@ where
             data_channels.insert(channel_id, evt_tx);
         }
 
+        self.inner.wake_writes().await;
+
         Ok(Arc::new(DataChannelImpl::new(
             channel_id,
             self.inner.clone(),
@@ -1239,5 +1241,74 @@ where
     async fn get_stats(&self, now: Instant, selector: StatsSelector) -> RTCStatsReport {
         let mut core = self.inner.core.lock().await;
         core.get_stats(now, selector)
+    }
+}
+
+#[cfg(test)]
+pub(crate) use tests::new_test_peer_connection;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{block_on, channel, default_runtime, timeout};
+    use rtc::peer_connection::RTCPeerConnectionBuilder;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::time::Duration;
+
+    #[derive(Clone)]
+    struct DummyHandler;
+
+    #[async_trait::async_trait]
+    impl PeerConnectionEventHandler for DummyHandler {}
+
+    pub(crate) async fn new_test_peer_connection() -> (
+        Arc<PeerConnectionRef>,
+        crate::runtime::Receiver<PeerConnectionDriverEvent>,
+    ) {
+        let core = RTCPeerConnectionBuilder::new().build().unwrap();
+        let runtime = default_runtime().expect("test requires a runtime feature");
+        let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(DummyHandler);
+        let (driver_event_tx, driver_event_rx) = channel::<PeerConnectionDriverEvent>(1);
+
+        let inner = Arc::new(PeerConnectionRef {
+            core: Mutex::new(core),
+            runtime,
+            handler,
+            driver_event_tx,
+            write_pending: AtomicBool::new(false),
+            write_backpressure: AtomicUsize::new(0),
+            closing: AtomicBool::new(false),
+            data_channel_send_buffer_limit: usize::MAX,
+            data_channel_backpressure: crate::runtime::Notify::new(),
+            data_channel_events_tx: Mutex::new(HashMap::new()),
+            track_remote_events_tx: Mutex::new(HashMap::new()),
+            track_local_events_tx: Mutex::new(HashMap::new()),
+            rtp_transceivers: Mutex::new(HashMap::new()),
+        });
+
+        (inner, driver_event_rx)
+    }
+
+    #[test]
+    fn create_data_channel_wakes_driver() {
+        block_on(async {
+            let (inner, mut driver_event_rx) = new_test_peer_connection().await;
+
+            let pc = PeerConnectionImpl {
+                inner,
+                driver_handle: Mutex::new(None),
+                dedicated_reactor: false,
+            };
+
+            let _dc = pc.create_data_channel("test", None).await.unwrap();
+
+            let event = timeout(Duration::from_secs(1), driver_event_rx.recv())
+                .await
+                .expect("driver should be woken within 1s")
+                .expect("driver event channel should not be closed");
+            assert!(matches!(event, PeerConnectionDriverEvent::WriteNotify));
+        });
     }
 }


### PR DESCRIPTION
Hi again - another small sans-I/O fix. I noticed that locally created data channels stayed in `connecting` indefinitely after `create_data_channel` returned. The DCEP `DATA_CHANNEL_OPEN` message was queued in the core, but the driver was never woken, so it sat until an unrelated packet or timer happened to poke the loop. All 15 integration tests in my suite time out without this line.

## Summary

`create_data_channel` now follows the same coalescing wake pattern used by `send`, `close`, and `set_remote_description`: after registering the new channel's event sender, it calls `self.inner.wake_writes().await`. This ensures the sans-I/O driver promptly drains the core's pending writes and emits `PeerConnectionDriverEvent::WriteNotify`.

This aligns with [W3C WebRTC Sec. 6.1 `createDataChannel`, step 23](https://w3c.github.io/webrtc-pc/#dom-peerconnection-createdatachannel): "Create channel's associated underlying data transport and configure it according to the present negotiation state in parallel."

## Changes

- `src/peer_connection/mod.rs`:
  - `create_data_channel`: call `self.inner.wake_writes().await` after inserting the data channel event sender.
  - Added a `tests::new_test_peer_connection` helper plus a shared `DummyHandler`, used by both `peer_connection` and `data_channel` tests to cut `PeerConnectionRef` construction boilerplate.

## Tests

- `src/peer_connection/mod.rs`: added `create_data_channel_wakes_driver`.
  - Builds a `PeerConnectionImpl` via the new helper, calls `create_data_channel`, and asserts `PeerConnectionDriverEvent::WriteNotify` is received within 1 s.
  - Fails before the fix (1 s receive timeout) and passes after.
- `src/data_channel/mod.rs`: refactored `drop_removes_event_sender` (from #833) to use the same helper.

## Verification

```bash
cd webrtc/
cargo fmt
cargo test --lib
cargo clippy -- -D warnings
```
