### PR TITLE
feat(runtime): expose the GRO buffer-sizing and recv-error helpers

### DIFF
--- a/src/peer_connection/transports/mod.rs
+++ b/src/peer_connection/transports/mod.rs
@@ -7,11 +7,11 @@ pub(crate) mod tcp_transport;
 pub(crate) mod turn_relayer;
 
 /// Plain single-datagram UDP receive buffer size (no GRO coalescing).
-pub(crate) const UDP_RECV_BUF_LEN: usize = 2000;
+pub const UDP_RECV_BUF_LEN: usize = 2000;
 
 /// Upper bound on the number of datagrams the kernel may coalesce into one UDP GRO
 /// receive (`UDP_SEGMENT`/GRO cap is 64 per buffer).
-pub(crate) const MAX_GRO_SEGMENTS: usize = 64;
+pub const MAX_GRO_SEGMENTS: usize = 64;
 
 /// Upper bound on datagrams coalesced into one UDP GSO send. The kernel caps
 /// `UDP_SEGMENT` at 64 segments per `sendmsg`; a socket may report fewer.
@@ -43,7 +43,7 @@ pub(crate) const MIN_GSO_RUN: usize = 16;
 /// datagrams well under this (DTLS/SCTP MTU ~1200); the 1500 headroom covers a peer
 /// sending up to standard-MTU-sized datagrams. Jumbo-frame paths (MTU > 1500) are not
 /// supported for GRO and would truncate.
-pub(crate) const GRO_RECV_SEGMENT_LEN: usize = 1500;
+pub const GRO_RECV_SEGMENT_LEN: usize = 1500;
 
 /// Size a UDP receive buffer for a socket that may coalesce `max_gro` datagrams via
 /// GRO. Falls back to the plain single-datagram size when GRO is unavailable.
@@ -54,7 +54,7 @@ pub(crate) const GRO_RECV_SEGMENT_LEN: usize = 1500;
 /// [`GRO_RECV_SEGMENT_LEN`]); the buffers are zero-initialized so pages stay unmapped
 /// until actually written. Measured net effect is still an RSS *reduction* under load
 /// because batching cuts per-packet allocator churn far more than the buffers cost.
-pub(crate) fn gro_recv_buf_len(max_gro: usize) -> usize {
+pub fn gro_recv_buf_len(max_gro: usize) -> usize {
     if max_gro > 1 {
         max_gro.min(MAX_GRO_SEGMENTS) * GRO_RECV_SEGMENT_LEN
     } else {
@@ -96,7 +96,27 @@ pub(crate) enum TcpReadResult {
     },
 }
 
-pub(crate) fn is_retryable_socket_recv_error(err: &io::Error) -> bool {
+/// Whether a socket receive error is one peer's problem rather than a failure of the
+/// socket itself.
+///
+/// A socket serving many peers learns about per-peer failures through the *socket*: an
+/// ICMP port-unreachable from a peer that went away can surface on a later receive as
+/// [`ConnectionRefused`] (Linux) or [`ConnectionReset`] (Windows). [`Interrupted`]
+/// (a signal delivered mid-`recvmsg`), [`WouldBlock`] and [`TimedOut`] are transient for
+/// the same reason — nothing about the socket has changed. A receive loop has to resume
+/// after all of these; treating any one of them as fatal tears down a listener that is
+/// perfectly healthy, with no way back short of rebinding.
+///
+/// Both the UDP and the TCP receive paths classify errors with this, and so must anything
+/// that implements or drives an [`AsyncUdpSocket`](crate::runtime::AsyncUdpSocket) of its
+/// own.
+///
+/// [`ConnectionRefused`]: io::ErrorKind::ConnectionRefused
+/// [`ConnectionReset`]: io::ErrorKind::ConnectionReset
+/// [`Interrupted`]: io::ErrorKind::Interrupted
+/// [`WouldBlock`]: io::ErrorKind::WouldBlock
+/// [`TimedOut`]: io::ErrorKind::TimedOut
+pub fn is_retryable_socket_recv_error(err: &io::Error) -> bool {
     matches!(
         err.kind(),
         io::ErrorKind::Interrupted
@@ -123,5 +143,47 @@ mod gro_buf_tests {
         );
         // GRO unavailable (max_gro <= 1): plain single-datagram buffer.
         assert_eq!(gro_recv_buf_len(1), UDP_RECV_BUF_LEN);
+    }
+}
+
+#[cfg(test)]
+mod recv_error_tests {
+    use super::is_retryable_socket_recv_error;
+    use std::io;
+
+    /// Pin the whole set: the way this goes wrong is by *omitting* a variant, and each
+    /// omission is a receive loop that tears down a healthy socket. `ConnectionRefused`
+    /// is the one to watch — it is how an ICMP port-unreachable can surface on Linux, so
+    /// dropping it lets any peer that goes away kill a listener.
+    #[test]
+    fn transient_errors_keep_the_receive_loop_alive() {
+        for kind in [
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::WouldBlock,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::TimedOut,
+        ] {
+            assert!(
+                is_retryable_socket_recv_error(&io::Error::from(kind)),
+                "{kind:?} must not be treated as fatal"
+            );
+        }
+    }
+
+    /// The complement: errors that really do mean the socket is unusable must stay
+    /// fatal, or a dead socket spins the receive loop forever.
+    #[test]
+    fn fatal_errors_are_not_retried() {
+        for kind in [
+            io::ErrorKind::AddrNotAvailable,
+            io::ErrorKind::NotConnected,
+            io::ErrorKind::PermissionDenied,
+        ] {
+            assert!(
+                !is_retryable_socket_recv_error(&io::Error::from(kind)),
+                "{kind:?} must be treated as fatal"
+            );
+        }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -62,6 +62,16 @@ pub use primitives::{
     TrySendError, UdpSockRef, UdpSocketState, broadcast_channel, channel,
 };
 
+/// Receive-path helpers an [`AsyncUdpSocket`] implementor (or anything driving one)
+/// needs to match what this crate's own driver does: how large a receive buffer must be
+/// for a socket that may coalesce datagrams via GRO, and which receive errors are
+/// transient. Defined alongside the driver that uses them and re-exported here, next to
+/// the socket traits they belong to.
+pub use crate::peer_connection::transports::{
+    GRO_RECV_SEGMENT_LEN, MAX_GRO_SEGMENTS, UDP_RECV_BUF_LEN, gro_recv_buf_len,
+    is_retryable_socket_recv_error,
+};
+
 pub(crate) const MAX_REACTOR_POOL_SIZE: usize = 1024;
 
 /// A handle to a task spawned via [`Runtime::spawn`].


### PR DESCRIPTION
# feat(runtime): expose the GRO buffer-sizing and recv-error helpers

## Problem

`examples/custom-runtime` promises that writing a `Runtime` takes "No `#[cfg]` edits, no
fork, and no changes to library internals", and its README points anyone who wants a
production-grade one straight at the built-ins:

> A production runtime would enable UDP GSO/GRO the way the built-in ones do — construct a
> `webrtc::runtime::UdpSocketState` at wrap time, report its `max_gso_segments()` /
> `gro_segments()`, pass the whole `Transmit` to its `send`, and adapt its scatter/gather
> `recv` to the single-datagram shape `poll_recv` returns (see `src/runtime/tokio.rs` or
> `smol.rs`).

Following that advice runs into two things the built-ins rely on but downstream cannot
reach:

| helper | needed for |
|---|---|
| `gro_recv_buf_len` | sizing a receive buffer for a socket that may coalesce datagrams via GRO |
| `is_retryable_socket_recv_error` | telling "one peer went away" apart from "this socket is dead" |

Both are `pub(crate)`. On current `master`, with a throwaway probe in `tests/` (not added
by this PR):

```
error[E0432]: unresolved imports `webrtc::runtime::GRO_RECV_SEGMENT_LEN`,
`webrtc::runtime::MAX_GRO_SEGMENTS`, `webrtc::runtime::UDP_RECV_BUF_LEN`,
`webrtc::runtime::gro_recv_buf_len`, `webrtc::runtime::is_retryable_socket_recv_error`
 --> tests/downstream_visibility.rs:4:5
```

So the only option is to reimplement them from reading the source, and both are easy to
get subtly wrong.

**Buffer sizing.** `max_gro_segments()` documents that it is "Used to size each receive
buffer", but not the formula. The correct one needs `GRO_RECV_SEGMENT_LEN` (a coalesced
segment is at most one wire MTU — *not* the caller's max datagram size) and the
`MAX_GRO_SEGMENTS` clamp (`max_gro_segments()` comes from an arbitrary socket impl and is
used here as an allocation multiplier). Nothing catches a wrong segment length: too large
only wastes memory, and too small makes the kernel silently drop the tail datagrams, which
presents as unexplained packet loss.

**Error classification.** Omitting one variant means a receive loop tears down a healthy
listener. `ConnectionRefused` is the one to watch: it is how an ICMP port-unreachable can
surface on Linux, so dropping it lets any peer that goes away close a listening socket,
with no way back short of rebinding.

I hit both building a WebRTC-Direct libp2p transport that muxes one UDP port across many
`PeerConnection`s (a custom `Runtime` whose `wrap_udp_socket` hands each connection a
branch of a shared socket). I reimplemented both helpers and got both wrong: the buffer by
~5.5x (used my own max-datagram size as the segment length, and no clamp), and the error
set by omitting `Interrupted`, `WouldBlock` and `ConnectionRefused`.

## Change

- `gro_recv_buf_len`, `is_retryable_socket_recv_error`, and the three constants the former
  is defined in terms of (`GRO_RECV_SEGMENT_LEN`, `MAX_GRO_SEGMENTS`, `UDP_RECV_BUF_LEN`)
  become `pub`, re-exported from `runtime` next to the socket traits they serve.
- `is_retryable_socket_recv_error` gains a doc comment — it had none, and `missing_docs` is
  warned on, so it needs one to be public.
- A test pins the retryable set and its complement.

Purely additive, so it is a minor-version change; no behaviour change, and no existing call
site moves. The GSO-side constants (`MAX_GSO_SEGMENTS`, `MAX_GSO_BATCH_BYTES`,
`MIN_GSO_RUN`) deliberately stay private — those are the driver's send-batching policy,
not part of the socket contract.

## On placement

I left the definitions in `peer_connection::transports` and only added the re-export, to
keep this diff to the visibility change.

There is an argument for moving them into `runtime` outright: `is_retryable_socket_recv_error`
serves both the UDP and the TCP receive path, and all three socket traits live in
`runtime`. I kept that out of this PR so a move would not be mixed in with an API change —
happy to do it that way instead if you prefer.

## Testing

`cargo build`, `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` and
`cargo doc --no-deps` all pass (macOS). clippy reports no new warnings in `src/`; the
pre-existing ones are all in `examples/` and `tests/`. `cargo doc` is clean, so the new doc
comment satisfies `missing_docs` and its intra-doc links resolve.

Reachability was verified with the throwaway probe quoted above: it fails to compile on
`master` with that error and passes on this branch.

## Disclosure

This change was developed with AI assistance (Claude Code). I ran into the gap building a
WebRTC-Direct libp2p transport on 0.20, and I have read every line of the diff and can
explain it in review.
