### PR TITLE
Re-export the remaining public-signature argument types

### DIFF
--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -74,7 +74,6 @@ use transport::stun_gatherer::RTCStunGatherer;
 use transport::turn_relayer::RTCTurnRelayer;
 
 use rtc::data_channel::{RTCDataChannelId, RTCDataChannelInit};
-use rtc::ice::mdns::MulticastDnsMode;
 use rtc::mdns::MulticastSocket;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::{RTCAnswerOptions, RTCOfferOptions};
@@ -92,26 +91,40 @@ use crate::peer_connection::driver::PeerConnectionDriverEvent;
 use crate::rtp_transceiver::rtp_sender::RtpSenderImpl;
 pub use rtc::interceptor::{Interceptor, NoopInterceptor, Registry};
 
-// Argument types for `SettingEngine`'s DTLS/SRTP setters. Re-exported because `rtc` is a
-// private dependency of this crate: without these, calling `set_dtls_cipher_suites` or
-// `set_srtp_protection_profiles` would force an application to add a second, version-locked
-// dependency just to name the enum it passes in.
-/// The crypto provider API, re-exported for the same reason: `SettingEngine::set_crypto_provider`
-/// takes an `Arc<dyn RTCCryptoProvider>`, and an application implementing its own provider needs
-/// the traits too.
+// Argument types for this crate's public API. Re-exported because `rtc` is a private
+// dependency: naming one of these types otherwise forces an application to add its own
+// `rtc` dependency, which resolves to a *different* source than the submodule used here.
+// The two copies are then distinct types and the call does not compile — a confusing way
+// to discover a missing re-export, since both spellings look identical in the error.
+//
+// The rule is that every type reachable in a public signature is nameable from `webrtc`.
+// It currently covers:
+//
+//   crypto::*            with_crypto_provider, and `SignatureScheme` for RTCCertificate
+//   CipherSuiteId        with_dtls_cipher_suites
+//   SrtpProtectionProfile with_srtp_protection_profiles
+//   MulticastDnsMode     with_multicast_dns_mode
+//   NetworkType          with_network_types
+//   RTCDtlsRole          with_answering_dtls_role
+//   SctpMaxMessageSize   with_sctp_max_message_size
+//   CertificateParams    RTCCertificate::{generate, generate_from_signing_key}
+//
+// `tests/public_api_is_nameable_from_webrtc.rs` names each of them through `webrtc::` and
+// never imports `rtc`, so a future setter taking an un-exported type fails to compile there.
 pub use rtc::crypto;
 pub use rtc::dtls::cipher_suite::CipherSuiteId;
 pub use rtc::dtls::extension::extension_use_srtp::SrtpProtectionProfile;
+pub use rtc::ice::{mdns::MulticastDnsMode, network_type::NetworkType};
 use rtc::media_stream::MediaStreamTrackId;
 pub use rtc::peer_connection::{
     RTCPeerConnection,
-    certificate::RTCCertificate,
+    certificate::{CertificateParams, RTCCertificate},
     configuration::{
         RTCBundlePolicy, RTCConfiguration, RTCConfigurationBuilder, RTCIceServer,
         RTCIceTransportPolicy, RTCRtcpMuxPolicy,
         interceptor_registry::*,
         media_engine::MediaEngine,
-        setting_engine::{SettingEngine, SettingEngineBuilder},
+        setting_engine::{SctpMaxMessageSize, SettingEngine, SettingEngineBuilder},
     },
     event::{
         RTCDataChannelEvent, RTCPeerConnectionEvent, RTCPeerConnectionIceErrorEvent,
@@ -121,7 +134,9 @@ pub use rtc::peer_connection::{
     state::{
         RTCIceConnectionState, RTCIceGatheringState, RTCPeerConnectionState, RTCSignalingState,
     },
-    transport::{RTCIceCandidate, RTCIceCandidateInit, RTCIceCandidateType, RTCIceProtocol},
+    transport::{
+        RTCDtlsRole, RTCIceCandidate, RTCIceCandidateInit, RTCIceCandidateType, RTCIceProtocol,
+    },
 };
 
 /// Trait for handling peer connection events asynchronously

--- a/tests/public_api_is_nameable_from_webrtc.rs
+++ b/tests/public_api_is_nameable_from_webrtc.rs
@@ -1,0 +1,45 @@
+//! Every type reachable in a public signature must be nameable from `webrtc` alone.
+//!
+//! `rtc` is a private dependency: it is a git submodule of this repository, so an
+//! application that adds its own `rtc` dependency resolves a *different* source. The two
+//! copies are distinct types, and passing one where the other is expected does not compile
+//! — the failure surfaces at the call site with two identically-spelled types, which is a
+//! confusing way to learn that a re-export is missing.
+//!
+//! This file therefore names each argument type through `webrtc::` **and never imports
+//! `rtc`**. Adding a builder method that takes an `rtc` type without re-exporting it makes
+//! this test fail to compile, which is the point.
+
+use webrtc::peer_connection::{
+    CertificateParams, MulticastDnsMode, NetworkType, RTCCertificate, RTCDtlsRole,
+    SctpMaxMessageSize, SettingEngineBuilder, crypto,
+};
+
+/// Builds a `SettingEngine` naming every argument type through `webrtc::`.
+#[test]
+fn setting_engine_arguments_are_nameable() {
+    let _ = SettingEngineBuilder::new()
+        .with_multicast_dns_mode(MulticastDnsMode::Disabled)
+        .with_network_types(vec![NetworkType::Udp4, NetworkType::Udp6])
+        .with_answering_dtls_role(RTCDtlsRole::Server)
+        .with_sctp_max_message_size(SctpMaxMessageSize::Bounded(16 * 1024))
+        .build();
+}
+
+/// Generates a certificate naming every argument type through `webrtc::`.
+///
+/// `SignatureScheme` and the provider traits arrive via the `crypto` module, which is
+/// already re-exported; `CertificateParams` is the one this asserts.
+#[test]
+fn certificate_arguments_are_nameable() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = crypto::default_provider()?;
+    let params = CertificateParams::new(vec!["localhost".to_owned()])?;
+
+    RTCCertificate::generate(
+        provider.crypto(),
+        crypto::SignatureScheme::EcdsaP256Sha256,
+        params,
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Summary

- re-export `MulticastDnsMode`, `NetworkType`, `RTCDtlsRole`, `SctpMaxMessageSize` and
  `CertificateParams` from `webrtc::peer_connection`;
- state the rule the existing re-exports follow, and list what it currently covers;
- add a test that names each of those types through `webrtc::` and never imports `rtc`.

### Why

`rtc` is a private dependency — it is a git submodule of this repository, referenced as
`rtc = { version = "…", path = "rtc" }`. An application that needs to name one of these
types has to add its own `rtc` dependency, which resolves to a *different* source than the
submodule. The two copies are then distinct types and the call does not compile:

```text
expected trait `webrtc::peer_connection::rtc_crypto::RTCCrypto`,
   found trait `rtc::rtc_crypto::RTCCrypto`
```

Both spellings look identical in the error, which is a confusing way to discover that a
re-export is missing. `[patch.crates-io]` does not help either — it cannot reach a path
dependency.

The comment above the existing re-exports already states exactly this reason, for
`set_dtls_cipher_suites` and `set_srtp_protection_profiles`. The five types added here sit
in the same position — arguments to `SettingEngineBuilder` methods and to
`RTCCertificate::generate` — so this looks like the rule not having been applied
uniformly rather than a deliberate omission.

For what it's worth, `tests/sctp_receive_buffer.rs` already reaches around it in-tree
(`use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;`), which
works only because the test shares this workspace.

I ran into this porting a libp2p WebRTC transport from 0.20 to 0.21: it configures
ICE-lite, disables mDNS, restricts the network types and answers as the DTLS server, so it
needs four of the five, plus `CertificateParams` for the persisted DTLS certificate.

**Not included:** `UDPNetwork`, `InterfaceFilterFn` and `IpFilterFn`. They belong to the
same rule, but their imports are still `//TODO:`-commented in `setting_engine.rs`, so I
left them for whoever wires those setters up.

### Validation

- `cargo test --test public_api_is_nameable_from_webrtc` — 2 passed
- `cargo test --lib` — 25 passed
- `cargo fmt --check`, `cargo clippy --lib` — clean
- Negative check: downgrading the new `pub use rtc::ice::{…}` to a private `use` makes the
  new test fail with `E0603: enum MulticastDnsMode is private`, so it does catch the
  regression it is meant to catch.

One incidental change: the private `use rtc::ice::mdns::MulticastDnsMode;` at the top of
`peer_connection/mod.rs` is removed, since the new `pub use` brings the same name into
scope and the two collide (`E0252`).

### AI disclosure

This PR was co-authored by Claude Opus 5 (Claude Code). The missing-symbol audit was done
by walking every `pub fn` on `SettingEngineBuilder` and `RTCCertificate` and checking each
non-primitive parameter type against the re-exports in `peer_connection/mod.rs`; the
patch, the test and the negative check above were produced and run in that session.
