### PR TITLE
Apply the SettingEngine TURN allocation Refresh cap

### DIFF
--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -57,7 +57,7 @@ use log::error;
 use std::collections::{HashMap, HashSet};
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::data_channel::{DataChannel, DataChannelEvent, DataChannelImpl};
 use crate::media_stream::{track_local::TrackLocal, track_remote::TrackRemote};
@@ -363,6 +363,8 @@ where
         self.setting_engine
             .set_crypto_provider(crypto_provider.clone());
         let mdns_mode = self.setting_engine.multicast_dns().mode;
+        let turn_allocation_refresh_interval_cap =
+            self.setting_engine.turn_allocation_refresh_interval_cap();
 
         // The core is told the time from here on; this is the seed every construction-time
         // instant inside it derives from, and under a `MockRuntime` it is the virtual clock's.
@@ -389,6 +391,7 @@ where
             self.tcp_addrs,
             self.dedicated_reactor_pool_size,
             data_channel_send_buffer_limit,
+            turn_allocation_refresh_interval_cap,
             crypto_provider,
         )
         .await
@@ -660,6 +663,7 @@ where
         tcp_addrs: Vec<A>,
         dedicated_reactor_pool_size: usize,
         data_channel_send_buffer_limit: usize,
+        turn_allocation_refresh_interval_cap: Option<Duration>,
         crypto_provider: Arc<dyn crypto::RTCCryptoProvider>,
     ) -> Result<Self> {
         // Bind the std sockets up front (synchronous, and needed to compute the
@@ -733,6 +737,7 @@ where
             ice_servers,
             ice_gather_policy,
             Arc::clone(&runtime),
+            turn_allocation_refresh_interval_cap,
             crypto_provider,
         );
 

--- a/src/peer_connection/transport/turn_relayer.rs
+++ b/src/peer_connection/transport/turn_relayer.rs
@@ -20,7 +20,7 @@ use rtc::turn::proto::chandata::ChannelData;
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 const MAX_PENDING_PACKETS_PER_PEER: usize = 64;
 
@@ -60,6 +60,7 @@ pub(crate) struct RTCTurnRelayer {
     /// Taken from the peer connection rather than resolved here: the whole connection shares one
     /// provider, and no async-layer code selects crypto on its own.
     crypto_provider: Arc<dyn RTCCryptoProvider>,
+    allocation_refresh_interval_cap: Option<Duration>,
     clients: HashMap<FourTuple, ManagedTurnClient>,
     relay_addrs: HashMap<SocketAddr, FourTuple>,
     pending_permissions: HashMap<rtc::stun::message::TransactionId, PendingPermission>,
@@ -76,6 +77,7 @@ impl RTCTurnRelayer {
         ice_servers: Vec<RTCIceServer>,
         ice_gather_policy: RTCIceTransportPolicy,
         runtime: Arc<dyn Runtime>,
+        allocation_refresh_interval_cap: Option<Duration>,
         crypto_provider: Arc<dyn RTCCryptoProvider>,
     ) -> Self {
         Self {
@@ -85,6 +87,7 @@ impl RTCTurnRelayer {
             state: RTCIceGatheringState::New,
             runtime,
             crypto_provider,
+            allocation_refresh_interval_cap,
             clients: HashMap::new(),
             relay_addrs: HashMap::new(),
             pending_permissions: HashMap::new(),
@@ -308,6 +311,7 @@ impl RTCTurnRelayer {
                             realm: String::new(),
                             software: String::new(),
                             rto_in_ms: 0,
+                            allocation_refresh_interval_cap: self.allocation_refresh_interval_cap,
                             ..Default::default()
                         },
                         Arc::clone(&self.crypto_provider),
@@ -797,6 +801,7 @@ mod tests {
                 }],
                 RTCIceTransportPolicy::Relay,
                 crate::runtime::default_runtime().expect("test requires a runtime feature"),
+                None,
                 rtc::crypto::default_provider().expect("a built-in crypto provider for tests"),
             );
 


### PR DESCRIPTION
Depends on [webrtc-rs/rtc#166](https://github.com/webrtc-rs/rtc/pull/166)

### Summary

- update the `rtc` submodule to include the TURN `SettingEngine` option;
- read the allocation Refresh interval cap during peer-connection construction;
- forward it through `PeerConnectionImpl` and `RTCTurnRelayer`;
- apply it to each `rtc-turn::ClientConfig`.

### Why

The async WebRTC layer owns TURN client construction, while advanced transport policy is configured through `SettingEngine`.

This change bridges those layers: the async wrapper reads the configured cap before moving the setting engine into the core peer connection, then applies the same value to every TURN client it creates.

A shorter opt-in cap can keep an otherwise idle client-to-server NAT mapping active. When no cap is configured, TURN retains its existing half-allocation-lifetime refresh cadence.

### Compatibility

The option remains disabled by default, so existing applications have no behavioral change.

### AI disclosure

This change was developed with GPT-5.6-sol assistance.
