### PR TITLE
fix(peer-connection): rebind UDP sockets on ICE restart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crypto-ring = ["rtc/crypto-ring"]
 crypto-aws-lc-rs = ["rtc/crypto-aws-lc-rs"]
 
 [dependencies]
-rtc = { git = "https://github.com/alinejun/rtc", rev = "492959c3df52ae935c20b48ffffa1b751a87cdf6", default-features = false }
+rtc = { git = "https://github.com/alinejun/rtc", rev = "47e6abd5f8fe98b68f1f89dfb77b3073ddd2444f", default-features = false }
 
 bytes = "1.12.0"
 async-trait = "0.1.89"
@@ -50,7 +50,7 @@ tokio = { version = "1.52.3", features = ["net", "time", "sync", "rt", "rt-multi
 smol = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
-signal = { git = "https://github.com/alinejun/rtc", rev = "492959c3df52ae935c20b48ffffa1b751a87cdf6", package = "rtc-signal" }
+signal = { git = "https://github.com/alinejun/rtc", rev = "47e6abd5f8fe98b68f1f89dfb77b3073ddd2444f", package = "rtc-signal" }
 
 env_logger = "0.11.11"
 chrono = "0.4.45"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crypto-ring = ["rtc/crypto-ring"]
 crypto-aws-lc-rs = ["rtc/crypto-aws-lc-rs"]
 
 [dependencies]
-rtc = { version = "0.21.0-alpha.1", path = "rtc", default-features = false }
+rtc = { git = "https://github.com/alinejun/rtc", rev = "492959c3df52ae935c20b48ffffa1b751a87cdf6", default-features = false }
 
 bytes = "1.12.0"
 async-trait = "0.1.89"
@@ -50,7 +50,7 @@ tokio = { version = "1.52.3", features = ["net", "time", "sync", "rt", "rt-multi
 smol = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
-signal = { version = "0.21.0-alpha.1", path = "rtc/examples/signal", package = "rtc-signal" }
+signal = { git = "https://github.com/alinejun/rtc", rev = "492959c3df52ae935c20b48ffffa1b751a87cdf6", package = "rtc-signal" }
 
 env_logger = "0.11.11"
 chrono = "0.4.45"

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -183,7 +183,9 @@ pub(crate) enum PeerConnectionDriverEvent {
         ice_servers: Vec<RTCIceServer>,
         ice_transport_policy: RTCIceTransportPolicy,
     },
-    IceGathering,
+    IceGathering {
+        rebind_udp_sockets: bool,
+    },
     Close,
 }
 
@@ -200,6 +202,7 @@ where
     tcp_transport: RTCTcpTransport,
     mdns_socket: Option<Arc<dyn AsyncUdpSocket>>,
     udp_sockets: HashMap<SocketAddr, Arc<dyn AsyncUdpSocket>>,
+    udp_bind_addrs: Vec<SocketAddr>,
     /// Reused scratch buffer for concatenating a run of same-destination datagrams
     /// into one UDP GSO send (see [`flush_writes`](Self::flush_writes)).
     gso_scratch: Vec<u8>,
@@ -232,6 +235,7 @@ where
         turn_relayer: RTCTurnRelayer,
         mdns_socket: Option<Arc<dyn AsyncUdpSocket>>,
         udp_sockets: HashMap<SocketAddr, Arc<dyn AsyncUdpSocket>>,
+        udp_bind_addrs: Vec<SocketAddr>,
         tcp_listeners: HashMap<SocketAddr, Arc<dyn AsyncTcpListener>>,
     ) -> Result<Self> {
         if udp_sockets.is_empty() && tcp_listeners.is_empty() {
@@ -244,6 +248,7 @@ where
             turn_relayer,
             mdns_socket,
             udp_sockets,
+            udp_bind_addrs,
             gso_scratch: Vec::new(),
             tcp_transport: RTCTcpTransport::new(tcp_listeners),
             ice_gathering_active: false,
@@ -252,6 +257,23 @@ where
             pending_ice_configuration: None,
             pending_data_channel_events: HashMap::new(),
         })
+    }
+
+    fn rebind_udp_sockets(&mut self) -> Result<()> {
+        let mut udp_sockets = HashMap::with_capacity(self.udp_bind_addrs.len());
+        for bind_addr in &self.udp_bind_addrs {
+            let socket = std::net::UdpSocket::bind(bind_addr)?;
+            socket.set_nonblocking(true)?;
+            let local_addr = socket.local_addr()?;
+            udp_sockets.insert(local_addr, self.inner.runtime.wrap_udp_socket(socket)?);
+        }
+
+        let local_addrs = udp_sockets.keys().copied().collect::<Vec<_>>();
+        self.stun_gatherer
+            .restart_with_local_addrs(local_addrs.clone());
+        self.turn_relayer.restart_with_local_addrs(local_addrs);
+        self.udp_sockets = udp_sockets;
+        Ok(())
     }
 
     /// Mark the connection closing and wake any sender parked in send back-pressure.
@@ -277,7 +299,7 @@ where
         mut driver_event_rx: Receiver<PeerConnectionDriverEvent>,
     ) -> Result<()> {
         // Collect socket info into a vec for indexed access
-        let udp_socket_list: Vec<(SocketAddr, Arc<dyn AsyncUdpSocket>)> = self
+        let mut udp_socket_list: Vec<(SocketAddr, Arc<dyn AsyncUdpSocket>)> = self
             .udp_sockets
             .iter()
             .map(|(addr, sock)| (*addr, sock.clone()))
@@ -460,36 +482,39 @@ where
             };
             futures::pin_mut!(consumed);
 
-            let timer = self.inner.runtime.sleep(delay_from_now);
-            futures::pin_mut!(timer);
+            let mut deferred_driver_event = None;
+            {
+                let timer = self.inner.runtime.sleep(delay_from_now);
+                futures::pin_mut!(timer);
 
-            let udp_recv_future: OptionFuture<_> = if !udp_recv_futures.is_empty() {
-                Some(udp_recv_futures.next())
-            } else {
-                None
-            }
-            .into();
-            futures::pin_mut!(udp_recv_future);
-
-            let tcp_accept_future: OptionFuture<_> =
-                if !self.tcp_transport.accept_futures.is_empty() {
-                    Some(self.tcp_transport.accept_futures.next())
+                let udp_recv_future: OptionFuture<_> = if !udp_recv_futures.is_empty() {
+                    Some(udp_recv_futures.next())
                 } else {
                     None
                 }
                 .into();
-            futures::pin_mut!(tcp_accept_future);
+                futures::pin_mut!(udp_recv_future);
 
-            let tcp_read_future: OptionFuture<_> = if !self.tcp_transport.read_futures.is_empty() {
-                Some(self.tcp_transport.read_futures.next())
-            } else {
-                None
-            }
-            .into();
-            futures::pin_mut!(tcp_read_future);
+                let tcp_accept_future: OptionFuture<_> =
+                    if !self.tcp_transport.accept_futures.is_empty() {
+                        Some(self.tcp_transport.accept_futures.next())
+                    } else {
+                        None
+                    }
+                    .into();
+                futures::pin_mut!(tcp_accept_future);
 
-            // Runtime-agnostic select!
-            futures::select! {
+                let tcp_read_future: OptionFuture<_> =
+                    if !self.tcp_transport.read_futures.is_empty() {
+                        Some(self.tcp_transport.read_futures.next())
+                    } else {
+                        None
+                    }
+                    .into();
+                futures::pin_mut!(tcp_read_future);
+
+                // Runtime-agnostic select!
+                futures::select! {
                 // A blocked consumer freed a slot: hand over what was retained, now.
                 _ = consumed.fuse() => {}
 
@@ -501,10 +526,21 @@ where
                 // Driver events (RTP, RTCP, or ICE candidate)
                 evt = driver_event_rx.recv().fuse() => {
                     if let Some(evt) = evt {
-                        let is_closed = self.handle_driver_event(evt).await;
-                        if is_closed {
-                            trace!("Driver event channel closed, exiting event loop");
-                            return Ok(());
+                        if matches!(
+                            evt,
+                            PeerConnectionDriverEvent::IceGathering {
+                                rebind_udp_sockets: true
+                            }
+                        ) {
+                            // The receive futures borrow the current socket set. Defer
+                            // replacement until this select scope has dropped those borrows.
+                            deferred_driver_event = Some(evt);
+                        } else {
+                            let is_closed = self.handle_driver_event(evt).await;
+                            if is_closed {
+                                trace!("Driver event channel closed, exiting event loop");
+                                return Ok(());
+                            }
                         }
                     }
                 }
@@ -602,6 +638,54 @@ where
                             }
                         }
                     }
+                }
+                }
+            }
+
+            if let Some(evt) = deferred_driver_event {
+                // Drop every reference to the old sockets before rebinding. This
+                // also permits callers that configured fixed ports to reclaim the
+                // same address, while `:0` bindings receive a fresh ephemeral port.
+                udp_recv_futures.clear();
+                udp_socket_list.clear();
+                self.udp_sockets.clear();
+                self.rebind_udp_sockets()?;
+
+                udp_socket_list = self
+                    .udp_sockets
+                    .iter()
+                    .map(|(addr, sock)| (*addr, sock.clone()))
+                    .chain(self.mdns_socket.iter().filter_map(|socket| {
+                        socket
+                            .local_addr()
+                            .ok()
+                            .map(|local_addr| (local_addr, socket.clone()))
+                    }))
+                    .collect();
+                udp_socket_buffers = udp_socket_list
+                    .iter()
+                    .map(|(_, socket)| vec![0u8; gro_recv_buf_len(socket.max_gro_segments())])
+                    .collect();
+                udp_recv_futures = udp_socket_list
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, (local_addr, socket))| {
+                        let buf = std::mem::take(&mut udp_socket_buffers[idx]);
+                        create_udp_recv_future(idx, *local_addr, socket.clone(), buf).boxed()
+                    })
+                    .collect();
+                active_socket_count = udp_socket_list.len();
+                let burst_buf_len = udp_socket_list
+                    .iter()
+                    .map(|(_, socket)| gro_recv_buf_len(socket.max_gro_segments()))
+                    .max()
+                    .unwrap_or(UDP_RECV_BUF_LEN);
+                burst_buf.resize(burst_buf_len, 0);
+
+                let is_closed = self.handle_driver_event(evt).await;
+                if is_closed {
+                    trace!("Driver event channel closed, exiting event loop");
+                    return Ok(());
                 }
             }
         }
@@ -1137,7 +1221,7 @@ where
                 // takes effect when the next gathering phase starts.
                 self.pending_ice_configuration = Some((ice_servers, ice_transport_policy));
             }
-            PeerConnectionDriverEvent::IceGathering => {
+            PeerConnectionDriverEvent::IceGathering { .. } => {
                 if let Some((ice_servers, ice_transport_policy)) =
                     self.pending_ice_configuration.take()
                 {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1081,19 +1081,9 @@ where
     }
 
     async fn restart_ice(&self) -> Result<()> {
-        {
-            let mut core = self.inner.core.lock().await;
-            core.restart_ice();
-        }
-
-        // overflow: awaited — producer is the application in `restart_ice`.
-        self.inner
-            .driver_event_tx
-            .send(PeerConnectionDriverEvent::IceGathering {
-                rebind_udp_sockets: false,
-            })
-            .await
-            .map_err(|e| Error::Other(format!("{:?}", e)))
+        let mut core = self.inner.core.lock().await;
+        core.restart_ice();
+        Ok(())
     }
 
     async fn get_configuration(&self) -> RTCConfiguration {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -193,6 +193,7 @@ where
     /// Held rather than forwarded immediately, so [`build`](Self::build) can resolve the crypto
     /// provider and inject it before the core connection is constructed — see there for why.
     setting_engine: SettingEngine,
+    fresh_udp_sockets_on_ice_restart: bool,
 }
 
 impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
@@ -205,6 +206,7 @@ impl<A: ToSocketAddrs> Default for PeerConnectionBuilder<A, NoopInterceptor> {
             tcp_addrs: vec![],
             dedicated_reactor_pool_size: 0,
             setting_engine: SettingEngine::default(),
+            fresh_udp_sockets_on_ice_restart: false,
             // `usize::MAX` = unbounded: no send back-pressure unless the application
             // opts in via `with_data_channel_send_buffer_limit`. This keeps `send`/
             // `send_text` non-blocking by default (zero behaviour change).
@@ -264,6 +266,7 @@ where
             dedicated_reactor_pool_size: self.dedicated_reactor_pool_size,
             data_channel_send_buffer_limit: self.data_channel_send_buffer_limit,
             setting_engine: self.setting_engine,
+            fresh_udp_sockets_on_ice_restart: self.fresh_udp_sockets_on_ice_restart,
         }
     }
 
@@ -282,6 +285,18 @@ where
     /// Configures the builder with the local UDP socket addresses to bind.
     pub fn with_udp_addrs(mut self, udp_addrs: Vec<A>) -> Self {
         self.udp_addrs = udp_addrs;
+        self
+    }
+
+    /// Rebinds the configured UDP addresses when the ICE core applies a restart.
+    ///
+    /// This is intended to be paired with
+    /// [`SettingEngine::set_discard_local_candidates_during_ice_restart`]. The
+    /// setting removes the previous candidate generation from the ICE agent;
+    /// this option replaces the sockets that back those candidates so ephemeral
+    /// addresses receive fresh ports and network mappings.
+    pub fn with_fresh_udp_sockets_on_ice_restart(mut self, enabled: bool) -> Self {
+        self.fresh_udp_sockets_on_ice_restart = enabled;
         self
     }
 
@@ -390,6 +405,7 @@ where
             self.dedicated_reactor_pool_size,
             data_channel_send_buffer_limit,
             crypto_provider,
+            self.fresh_udp_sockets_on_ice_restart,
         )
         .await
     }
@@ -564,6 +580,12 @@ where
     /// that closes the reactor-thread leak window; the `Close` event is only the
     /// fast wake.
     pub(crate) closing: AtomicBool,
+    /// Whether an applied ICE restart should replace the UDP sockets before
+    /// the next local candidate gathering phase.
+    pub(crate) fresh_udp_sockets_on_ice_restart: bool,
+    /// Set when the sans-I/O core applies an ICE restart and consumed by the
+    /// next `set_local_description` gathering notification.
+    pub(crate) udp_socket_rebind_pending: AtomicBool,
     /// Per-channel data-channel send-buffer limit in bytes (`usize::MAX` = unbounded,
     /// the default). When a limit is configured, [`DataChannel::send`]/[`send_text`](DataChannel::send_text)
     /// block until a channel's `outstanding_bytes` drops below it, and
@@ -611,6 +633,13 @@ impl<I> PeerConnectionRef<I>
 where
     I: Interceptor,
 {
+    fn observe_ice_restart(&self, before: u64, after: u64) {
+        if self.fresh_udp_sockets_on_ice_restart && before != after {
+            self.udp_socket_rebind_pending
+                .store(true, Ordering::Release);
+        }
+    }
+
     /// Coalescing driver wake for pending writes — the pion `awakeWriteLoop`
     /// equivalent. Marks a flush as pending and pokes the driver only on the
     /// `false -> true` transition, so a burst of sends yields at most one wake.
@@ -661,6 +690,7 @@ where
         dedicated_reactor_pool_size: usize,
         data_channel_send_buffer_limit: usize,
         crypto_provider: Arc<dyn crypto::RTCCryptoProvider>,
+        fresh_udp_sockets_on_ice_restart: bool,
     ) -> Result<Self> {
         // Bind the std sockets up front (synchronous, and needed to compute the
         // local addresses used for ICE gathering / SDP). Wrapping them into async
@@ -674,11 +704,19 @@ where
             None
         };
 
+        let mut udp_bind_addrs = Vec::new();
         let mut std_udp_sockets = Vec::new();
         for addr in udp_addrs {
-            let socket = std::net::UdpSocket::bind(addr)?;
+            let resolved = addr.to_socket_addrs()?.collect::<Vec<_>>();
+            let socket = std::net::UdpSocket::bind(resolved.as_slice())?;
             socket.set_nonblocking(true)?;
             let local_addr = socket.local_addr()?;
+            let bind_addr = resolved
+                .iter()
+                .copied()
+                .find(|candidate| candidate.ip() == local_addr.ip())
+                .unwrap_or(local_addr);
+            udp_bind_addrs.push(bind_addr);
             std_udp_sockets.push((local_addr, socket));
         }
 
@@ -709,6 +747,8 @@ where
                 write_pending: AtomicBool::new(false),
                 write_backpressure: std::sync::atomic::AtomicUsize::new(0),
                 closing: AtomicBool::new(false),
+                fresh_udp_sockets_on_ice_restart,
+                udp_socket_rebind_pending: AtomicBool::new(false),
                 data_channel_send_buffer_limit,
                 data_channel_backpressure: crate::runtime::Notify::new(),
                 data_channel_delivery_blocked: AtomicBool::new(false),
@@ -772,6 +812,7 @@ where
                     turn_relayer,
                     async_mdns_socket,
                     async_udp_sockets,
+                    udp_bind_addrs,
                     async_tcp_listeners,
                 )
                 .await
@@ -921,7 +962,11 @@ where
         options: Option<RTCOfferOptions>,
     ) -> Result<RTCSessionDescription> {
         let mut core = self.inner.core.lock().await;
-        core.create_offer(options)
+        let before = core.ice_restart_generation();
+        let offer = core.create_offer(options);
+        let after = core.ice_restart_generation();
+        self.inner.observe_ice_restart(before, after);
+        offer
     }
 
     async fn create_answer(
@@ -935,16 +980,23 @@ where
     async fn set_local_description(&self, desc: RTCSessionDescription) -> Result<()> {
         {
             let mut core = self.inner.core.lock().await;
+            let before = core.ice_restart_generation();
             core.set_local_description(self.inner.runtime.now(), desc)?;
+            let after = core.ice_restart_generation();
+            self.inner.observe_ice_restart(before, after);
         }
 
         // Wake the driver with MessageInner::IceGathering. Without this
         // notify the driver would sleep until its previous (possibly 1-day default)
         // timer expired and never send STUN binding requests.
+        let rebind_udp_sockets = self
+            .inner
+            .udp_socket_rebind_pending
+            .swap(false, Ordering::AcqRel);
         // overflow: awaited — producer is the application in `set_local_description`.
         self.inner
             .driver_event_tx
-            .send(PeerConnectionDriverEvent::IceGathering)
+            .send(PeerConnectionDriverEvent::IceGathering { rebind_udp_sockets })
             .await
             .map_err(|e| Error::Other(format!("{:?}", e)))
     }
@@ -972,7 +1024,10 @@ where
     async fn set_remote_description(&self, desc: RTCSessionDescription) -> Result<()> {
         {
             let mut core = self.inner.core.lock().await;
+            let before = core.ice_restart_generation();
             core.set_remote_description(self.inner.runtime.now(), desc)?;
+            let after = core.ice_restart_generation();
+            self.inner.observe_ice_restart(before, after);
         }
         // Wake the driver so it re-polls its timeout. When both local and remote
         // descriptions are set, set_remote_description triggers start_transports
@@ -1034,7 +1089,9 @@ where
         // overflow: awaited — producer is the application in `restart_ice`.
         self.inner
             .driver_event_tx
-            .send(PeerConnectionDriverEvent::IceGathering)
+            .send(PeerConnectionDriverEvent::IceGathering {
+                rebind_udp_sockets: false,
+            })
             .await
             .map_err(|e| Error::Other(format!("{:?}", e)))
     }
@@ -1319,6 +1376,8 @@ mod tests {
             write_pending: AtomicBool::new(false),
             write_backpressure: AtomicUsize::new(0),
             closing: AtomicBool::new(false),
+            fresh_udp_sockets_on_ice_restart: false,
+            udp_socket_rebind_pending: AtomicBool::new(false),
             data_channel_send_buffer_limit: usize::MAX,
             data_channel_backpressure: crate::runtime::Notify::new(),
             data_channel_delivery_blocked: AtomicBool::new(false),

--- a/src/peer_connection/transport/stun_gatherer.rs
+++ b/src/peer_connection/transport/stun_gatherer.rs
@@ -91,13 +91,22 @@ impl RTCStunGatherer {
         ice_servers: Vec<RTCIceServer>,
         ice_gather_policy: RTCIceTransportPolicy,
     ) {
+        self.reset();
+        self.ice_servers = ice_servers;
+        self.ice_gather_policy = ice_gather_policy;
+    }
+
+    pub(crate) fn restart_with_local_addrs(&mut self, local_addrs: Vec<SocketAddr>) {
+        self.reset();
+        self.local_addrs = local_addrs;
+    }
+
+    fn reset(&mut self) {
         for (_, mut stun_client) in self.stun_clients.drain() {
             let _ = stun_client.close();
         }
         self.wouts.clear();
         self.events.clear();
-        self.ice_servers = ice_servers;
-        self.ice_gather_policy = ice_gather_policy;
         self.state = RTCIceGatheringState::New;
     }
 

--- a/src/peer_connection/transport/turn_relayer.rs
+++ b/src/peer_connection/transport/turn_relayer.rs
@@ -123,6 +123,17 @@ impl RTCTurnRelayer {
             return;
         }
 
+        self.reset();
+        self.ice_servers = ice_servers;
+        self.ice_gather_policy = ice_gather_policy;
+    }
+
+    pub(crate) fn restart_with_local_addrs(&mut self, local_addrs: Vec<SocketAddr>) {
+        self.reset();
+        self.local_addrs = local_addrs;
+    }
+
+    fn reset(&mut self) {
         let keys: Vec<FourTuple> = self.clients.keys().copied().collect();
         for key in keys {
             self.remove_client(key);
@@ -134,8 +145,6 @@ impl RTCTurnRelayer {
         self.wouts.clear();
         self.routs.clear();
         self.events.clear();
-        self.ice_servers = ice_servers;
-        self.ice_gather_policy = ice_gather_policy;
         self.state = RTCIceGatheringState::New;
     }
 


### PR DESCRIPTION
## Summary

- add an opt-in `with_fresh_udp_sockets_on_ice_restart` builder setting
- replace configured UDP sockets when an ICE restart is applied
- reset STUN gathering and TURN relaying with the new local addresses
- defer restart gathering until `set_local_description` so the new transport and SDP generation stay aligned
- keep the existing behavior unchanged by default

## Motivation

Android may leave the UDP socket or its network path unusable after an application is suspended and returned to the foreground. Signaling and the restart offer/answer exchange still succeed, but ICE can remain in `Checking` because the restarted logical ICE generation continues to use the previous UDP transport generation.

With this option enabled, the driver drops references to the previous UDP sockets, binds the configured addresses again, refreshes STUN/TURN local addresses, and gathers candidates over the replacement sockets. For an ephemeral `:0` binding this produces a fresh local port and network mapping.

The setting is intended to be paired with:

```rust
setting_engine.set_discard_local_candidates_during_ice_restart(true);
```

This prevents candidates backed by the previous socket generation from being retained.

Fixes #868.

## Compatibility

The new behavior is opt-in:

```rust
PeerConnectionBuilder::new()
    .with_fresh_udp_sockets_on_ice_restart(true)
```

The default remains `false`, so existing applications retain the current ICE restart behavior.

## RTC dependency

The async wrapper needs to observe when the sans-I/O core actually applies an ICE restart. This branch pins [`alinejun/rtc@47e6abd`](https://github.com/alinejun/rtc/commit/47e6abd5f8fe98b68f1f89dfb77b3073ddd2444f), which exposes the applied ICE restart generation. The prerequisite is proposed upstream in [webrtc-rs/rtc#167](https://github.com/webrtc-rs/rtc/pull/167).

## Validation

Physical Android tests and detailed endpoint timelines are documented in #868. With the option enabled, two approximately 10-second background runs recovered the existing PeerConnection and data channels in 560 ms and 360 ms respectively, instead of waiting for a full connection rebuild.

Local checks completed:

- `cargo check --lib`
- `cargo fmt`
- `cargo clippy --fix --lib --bins --all-targets --allow-dirty`
- `cargo clippy --lib --bins --all-targets`

The full test suite was not run.
