### PR TITLE
Fix duplicate stream identifiers for ORTC data channels

### DIFF
--- a/webrtc/src/data_channel/data_channel_test.rs
+++ b/webrtc/src/data_channel/data_channel_test.rs
@@ -1715,6 +1715,45 @@ async fn signal_ortc_pair(stack_a: Arc<TestOrtcStack>, stack_b: Arc<TestOrtcStac
 }
 
 #[tokio::test]
+async fn test_data_channel_ortc_stream_identifiers() -> Result<()> {
+    let api = APIBuilder::new().build();
+
+    let (stack_a, stack_b) = new_ortc_pair(&api).await?;
+
+    signal_ortc_pair(Arc::clone(&stack_a), Arc::clone(&stack_b)).await?;
+
+    let first = api
+        .new_data_channel(
+            Arc::clone(&stack_a.sctp),
+            DataChannelParameters {
+                label: "First".to_owned(),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let second = api
+        .new_data_channel(
+            Arc::clone(&stack_a.sctp),
+            DataChannelParameters {
+                label: "Second".to_owned(),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert_ne!(
+        first.id(),
+        second.id(),
+        "data channels created on the same transport must not share a stream identifier"
+    );
+
+    stack_a.close().await?;
+    stack_b.close().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_data_channel_ortc_e2e() -> Result<()> {
     let api = APIBuilder::new().build();
 

--- a/webrtc/src/sctp_transport/mod.rs
+++ b/webrtc/src/sctp_transport/mod.rs
@@ -81,6 +81,9 @@ pub struct RTCSctpTransport {
 
     // DataChannels
     pub(crate) data_channels: Arc<Mutex<Vec<Arc<RTCDataChannel>>>>,
+    // Stream identifiers that have been handed out to data channels, including the
+    // ones created directly on this transport through the ORTC API.
+    data_channel_ids_used: Arc<Mutex<HashSet<u16>>>,
     pub(crate) data_channels_opened: Arc<AtomicU32>,
     pub(crate) data_channels_requested: Arc<AtomicU32>,
     data_channels_accepted: Arc<AtomicU32>,
@@ -106,6 +109,7 @@ impl RTCSctpTransport {
             on_data_channel_opened_handler: Arc::new(ArcSwapOption::empty()),
 
             data_channels: Arc::new(Mutex::new(vec![])),
+            data_channel_ids_used: Arc::new(Mutex::new(HashSet::new())),
             data_channels_opened: Arc::new(AtomicU32::new(0)),
             data_channels_requested: Arc::new(AtomicU32::new(0)),
             data_channels_accepted: Arc::new(AtomicU32::new(0)),
@@ -423,11 +427,15 @@ impl RTCSctpTransport {
             }
         }
 
+        let mut ids_used = self.data_channel_ids_used.lock().await;
+        ids_map.extend(ids_used.iter());
+
         let max = self.max_channels();
         while id < max - 1 {
             if ids_map.contains(&id) {
                 id += 2;
             } else {
+                ids_used.insert(id);
                 return Ok(id);
             }
         }


### PR DESCRIPTION
`API::new_data_channel` never registers the channel on the SCTP transport, so `generate_and_set_data_channel_id` only ever sees accepted channels. Creating two channels on the same transport therefore hands out the same stream identifier twice, and opening the second one fails with `ErrStreamAlreadyExist`.

Keep track of the identifiers that were handed out on the transport itself, similar to `dataChannelIDsUsed` in pion.

The added test creates two data channels over an ORTC stack and fails on v0.17.x without this change.
