### PR TITLE
wrap deferred SCTP stream-id data channels

### DIFF
--- a/examples/data-channels-close/data-channels-close.rs
+++ b/examples/data-channels-close/data-channels-close.rs
@@ -73,18 +73,18 @@ impl PeerConnectionEventHandler for TestHandler {
                     return;
                 }
             };
-            let id = data_channel.id();
-            println!("New DataChannel {label} {id}");
+            let id = data_channel.id().await;
+            println!("New DataChannel {label} {id:?}");
 
             let done = Notify::new();
             while let Some(event) = data_channel.poll().await {
                 match event {
                     DataChannelEvent::OnOpen => {
-                        println!("Data channel '{label}'-'{id}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
+                        println!("Data channel '{label}'-'{id:?}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
                         let data_channel = data_channel.clone();
                         let done_rx = done.clone();
                         runtime.spawn(Box::pin(async move {
-                            let id2 = data_channel.id();
+                            let id2 = data_channel.id().await;
                             let mut result = Result::<()>::Ok(());
                             let mut close_after = 5;
                             while result.is_ok() {
@@ -102,7 +102,7 @@ impl PeerConnectionEventHandler for TestHandler {
 
                                         close_after-=1;
                                         if close_after <= 0 {
-                                            println!("Sent times out. Closing data channel '{id2}'.");
+                                            println!("Sent times out. Closing data channel '{id2:?}'.");
                                             let _ = data_channel.close().await;
                                             break;
                                         }
@@ -112,7 +112,7 @@ impl PeerConnectionEventHandler for TestHandler {
                         }));
                     }
                     DataChannelEvent::OnClose => {
-                        println!("Data channel '{label}'-'{id}' closed.");
+                        println!("Data channel '{label}'-'{id:?}' closed.");
                         done.notify_waiters();
                         let _ = pc_done_tx.try_send(());
                         break;

--- a/examples/data-channels-create/data-channels-create.rs
+++ b/examples/data-channels-create/data-channels-create.rs
@@ -152,12 +152,12 @@ async fn async_main() -> anyhow::Result<()> {
                 return;
             }
         };
-        let id = data_channel.id();
+        let id = data_channel.id().await;
 
         while let Some(event) = data_channel.poll().await {
             match event {
                 DataChannelEvent::OnOpen => {
-                    println!("Data channel '{label}'-'{id}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
+                    println!("Data channel '{label}'-'{id:?}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
 
                     let data_channel = data_channel.clone();
                     runtime_clone.spawn(Box::pin(async move {
@@ -177,7 +177,7 @@ async fn async_main() -> anyhow::Result<()> {
                     }));
                 }
                 DataChannelEvent::OnClose => {
-                    println!("Data channel {id} is closed");
+                    println!("Data channel {id:?} is closed");
                     break;
                 }
                 DataChannelEvent::OnMessage(msg) => {

--- a/examples/data-channels-offer-answer/data-channels-answer.rs
+++ b/examples/data-channels-offer-answer/data-channels-answer.rs
@@ -67,7 +67,7 @@ impl PeerConnectionEventHandler for AnswerHandler {
         self.runtime.spawn(Box::pin(async move {
             let mut opened = false;
             let label = dc.label().await.unwrap_or_default();
-            let id = dc.id();
+            let id = dc.id().await;
             let mut count = 0u32;
             let mut send_timer = Box::pin(sleep(Duration::from_secs(5)));
 
@@ -99,7 +99,7 @@ impl PeerConnectionEventHandler for AnswerHandler {
                 } else {
                     match dc.poll().await {
                         Some(DataChannelEvent::OnOpen) => {
-                            println!("Data channel '{label}'-'{id}' open");
+                            println!("Data channel '{label}'-'{id:?}' open");
                             opened = true;
                             send_timer = Box::pin(sleep(Duration::from_secs(5)));
                         }
@@ -112,7 +112,7 @@ impl PeerConnectionEventHandler for AnswerHandler {
                 }
             }
 
-            println!("exit loop for DataChannel '{label}'-'{id}'");
+            println!("exit loop for DataChannel '{label}'-'{id:?}'");
         }));
     }
 }

--- a/examples/data-channels-offer-answer/data-channels-offer.rs
+++ b/examples/data-channels-offer-answer/data-channels-offer.rs
@@ -130,7 +130,7 @@ async fn async_main(cli: Cli) -> Result<()> {
                 return;
             }
         };
-        let id = data_channel.id();
+        let id = data_channel.id().await;
         let mut count = 0u32;
         let mut send_timer = Box::pin(sleep(Duration::from_secs(5)));
 
@@ -158,7 +158,7 @@ async fn async_main(cli: Cli) -> Result<()> {
             } else {
                 match data_channel.poll().await {
                     Some(DataChannelEvent::OnOpen) => {
-                        println!("Data channel '{label}'-'{id}' open");
+                        println!("Data channel '{label}'-'{id:?}' open");
                         opened = true;
                         send_timer = Box::pin(sleep(Duration::from_secs(5)));
                     }
@@ -168,7 +168,7 @@ async fn async_main(cli: Cli) -> Result<()> {
             }
         }
 
-        println!("exit loop for DataChannel '{label}'-'{id}'");
+        println!("exit loop for DataChannel '{label}'-'{id:?}'");
     }));
 
     // Create offer and wait for ICE gathering to complete (non-trickle)

--- a/examples/data-channels/data-channels.rs
+++ b/examples/data-channels/data-channels.rs
@@ -72,13 +72,13 @@ impl PeerConnectionEventHandler for TestHandler {
                     return;
                 }
             };
-            let id = data_channel.id();
-            println!("New DataChannel {label} {id}");
+            let id = data_channel.id().await;
+            println!("New DataChannel {label} {id:?}");
 
             while let Some(event) = data_channel.poll().await {
                 match event {
                     DataChannelEvent::OnOpen => {
-                        println!("Data channel '{label}'-'{id}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
+                        println!("Data channel '{label}'-'{id:?}' open. Random messages will now be sent to any connected DataChannels every 5 seconds");
                         let data_channel = data_channel.clone();
                         runtime.spawn(Box::pin(async move {
                             let mut result = Result::<()>::Ok(());
@@ -97,7 +97,7 @@ impl PeerConnectionEventHandler for TestHandler {
                         }));
                     }
                     DataChannelEvent::OnClose => {
-                        println!("Data channel {id} is closed");
+                        println!("Data channel {id:?} is closed");
                         break;
                     }
                     DataChannelEvent::OnMessage(msg) => {

--- a/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
@@ -176,17 +176,17 @@ async fn async_main(cli: Cli) -> Result<()> {
     let dc = pc_arc.create_data_channel("data", None).await?;
 
     let label = dc.label().await.unwrap_or_default();
-    let id = dc.id();
+    let id = dc.id().await;
 
     runtime.spawn(Box::pin(async move {
         loop {
             match dc.poll().await {
                 Some(DataChannelEvent::OnOpen) => {
-                    println!("[Offer] Data channel '{label}'-'{id}' is open!");
+                    println!("[Offer] Data channel '{label}'-'{id:?}' is open!");
                     break;
                 }
                 Some(DataChannelEvent::OnClose) | None => {
-                    println!("[Offer] Data channel '{label}'-'{id}' closed before opening.");
+                    println!("[Offer] Data channel '{label}'-'{id:?}' closed before opening.");
                     return;
                 }
                 _ => {}
@@ -204,7 +204,7 @@ async fn async_main(cli: Cli) -> Result<()> {
                             println!("[Offer] Message from DataChannel '{label}': '{text}'");
                         }
                         Some(DataChannelEvent::OnClose) | None => {
-                            println!("[Offer] Data channel '{label}'-'{id}' closed.");
+                            println!("[Offer] Data channel '{label}'-'{id:?}' closed.");
                             break;
                         }
                         _ => {}

--- a/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
@@ -83,18 +83,18 @@ impl PeerConnectionEventHandler for AnswerHandler {
 
     async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
         let label = dc.label().await.unwrap_or_default();
-        let id = dc.id();
-        println!("[Answer] New DataChannel: '{label}'-'{id}'");
+        let id = dc.id().await;
+        println!("[Answer] New DataChannel: '{label}'-'{id:?}'");
 
         self.runtime.spawn(Box::pin(async move {
             loop {
                 match dc.poll().await {
                     Some(DataChannelEvent::OnOpen) => {
-                        println!("[Answer] Data channel '{label}'-'{id}' is open!");
+                        println!("[Answer] Data channel '{label}'-'{id:?}' is open!");
                         break;
                     }
                     Some(DataChannelEvent::OnClose) | None => {
-                        println!("[Answer] Data channel '{label}'-'{id}' closed before opening.");
+                        println!("[Answer] Data channel '{label}'-'{id:?}' closed before opening.");
                         return;
                     }
                     _ => {}
@@ -112,7 +112,7 @@ impl PeerConnectionEventHandler for AnswerHandler {
                                 println!("[Answer] Message from DataChannel '{label}': '{text}'");
                             }
                             Some(DataChannelEvent::OnClose) | None => {
-                                println!("[Answer] Data channel '{label}'-'{id}' closed.");
+                                println!("[Answer] Data channel '{label}'-'{id:?}' closed.");
                                 break;
                             }
                             _ => {}

--- a/examples/ice-tcp/ice-tcp.rs
+++ b/examples/ice-tcp/ice-tcp.rs
@@ -75,18 +75,18 @@ impl PeerConnectionEventHandler for IceTcpHandler {
 
     async fn on_data_channel(&self, dc: Arc<dyn DataChannel>) {
         let label = dc.label().await.unwrap_or_default();
-        let id = dc.id();
-        println!("New DataChannel: '{label}'-'{id}'");
+        let id = dc.id().await;
+        println!("New DataChannel: '{label}'-'{id:?}'");
 
         self.runtime.spawn(Box::pin(async move {
             loop {
                 match dc.poll().await {
                     Some(DataChannelEvent::OnOpen) => {
-                        println!("Data channel '{label}'-'{id}' is open!");
+                        println!("Data channel '{label}'-'{id:?}' is open!");
                         break;
                     }
                     Some(DataChannelEvent::OnClose) | None => {
-                        println!("Data channel '{label}'-'{id}' closed before opening.");
+                        println!("Data channel '{label}'-'{id:?}' closed before opening.");
                         return;
                     }
                     _ => {}
@@ -104,7 +104,7 @@ impl PeerConnectionEventHandler for IceTcpHandler {
                                 println!("Message from DataChannel '{label}': '{text}'");
                             }
                             Some(DataChannelEvent::OnClose) | None => {
-                                println!("Data channel '{label}'-'{id}' closed.");
+                                println!("Data channel '{label}'-'{id:?}' closed.");
                                 break;
                             }
                             _ => {}

--- a/examples/mdns-query-and-gather/mdns-query-and-gather.rs
+++ b/examples/mdns-query-and-gather/mdns-query-and-gather.rs
@@ -102,11 +102,11 @@ impl PeerConnectionEventHandler for MdnsHandler {
         let runtime = self.runtime.clone();
         runtime.spawn(Box::pin(async move {
             let label = dc.label().await.unwrap_or_default();
-            let id = dc.id();
+            let id = dc.id().await;
             loop {
                 match dc.poll().await {
                     Some(DataChannelEvent::OnOpen) => {
-                        println!("Data channel '{label}'-'{id}' open");
+                        println!("Data channel '{label}'-'{id:?}' open");
                     }
                     Some(DataChannelEvent::OnMessage(msg)) => {
                         let text = String::from_utf8(msg.data.to_vec()).unwrap_or_default();

--- a/examples/trickle_ice_common/mod.rs
+++ b/examples/trickle_ice_common/mod.rs
@@ -200,7 +200,7 @@ impl PeerConnectionEventHandler for TrickleHandler {
         let runtime = self.runtime.clone();
         runtime.spawn(Box::pin(async move {
             let label = dc.label().await.unwrap_or_default();
-            let id = dc.id();
+            let id = dc.id().await;
             let mut opened = false;
             let mut count = 0u32;
             let mut send_timer = Box::pin(sleep(Duration::from_secs(3)));
@@ -234,7 +234,7 @@ impl PeerConnectionEventHandler for TrickleHandler {
                 } else {
                     match dc.poll().await {
                         Some(DataChannelEvent::OnOpen) => {
-                            println!("Data channel '{label}'-'{id}' open");
+                            println!("Data channel '{label}'-'{id:?}' open");
                             opened = true;
                             send_timer = Box::pin(sleep(Duration::from_secs(3)));
                         }

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -53,7 +53,8 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 pub use rtc::data_channel::{
-    RTCDataChannelId, RTCDataChannelInit, RTCDataChannelMessage, RTCDataChannelState,
+    RTCDataChannelHandle, RTCDataChannelId, RTCDataChannelInit, RTCDataChannelMessage,
+    RTCDataChannelState,
 };
 
 /// Object-safe trait exposing all public DataChannel operations.
@@ -77,11 +78,11 @@ pub trait DataChannel: crate::sealed::Sealed + Send + Sync + 'static {
     async fn negotiated(&self) -> Result<bool>;
     /// Returns the identifier for this data channel.
     ///
-    /// The value is initially null — which is what is returned if the id was not provided
-    /// at channel creation time and the DTLS role of the SCTP transport has not yet been
-    /// negotiated. Otherwise it returns the id that was either selected by the application
-    /// or generated. Once set to a non-null value it does not change.
-    fn id(&self) -> RTCDataChannelId;
+    /// `None` (null) is returned if no id was provided at channel creation time and the DTLS
+    /// role of the SCTP transport has not yet been negotiated (W3C section 6.1 step 18). Otherwise it
+    /// returns the id that was either selected by the application or generated. Once set to a
+    /// non-null value it does not change.
+    async fn id(&self) -> Option<RTCDataChannelId>;
     /// Returns the current state of this data channel.
     async fn ready_state(&self) -> Result<RTCDataChannelState>;
     /// Returns the threshold at which the buffered amount is considered to be *high*.
@@ -259,8 +260,12 @@ pub enum DataChannelEvent {
 ///
 /// This wraps a data channel and provides async send/receive APIs.
 pub(crate) struct DataChannelImpl {
-    /// Unique identifier for this data channel
-    id: RTCDataChannelId,
+    /// Stable handle for this data channel, assigned at creation and never changed. The stream
+    /// identifier (`id()`) is only assigned once the DTLS role is negotiated / SCTP connected.
+    handle: RTCDataChannelHandle,
+
+    /// Stream identifier; `None` until the core assigns one once SCTP is connected.
+    id: crate::runtime::primitives::Mutex<Option<RTCDataChannelId>>,
 
     /// Inner PeerConnection Reference
     inner: Arc<PeerConnectionRef>,
@@ -272,15 +277,26 @@ pub(crate) struct DataChannelImpl {
 impl DataChannelImpl {
     /// Create a new data channel wrapper
     pub(crate) fn new(
-        id: RTCDataChannelId,
+        handle: RTCDataChannelHandle,
         inner: Arc<PeerConnectionRef>,
         evt_rx: Receiver<DataChannelEvent>,
     ) -> Self {
         Self {
-            id,
+            handle,
+            id: crate::runtime::primitives::Mutex::new(None),
             inner,
             evt_rx: Mutex::new(evt_rx),
         }
+    }
+
+    /// The stable handle for this data channel.
+    pub(crate) fn handle(&self) -> RTCDataChannelHandle {
+        self.handle
+    }
+
+    /// Stores the stream identifier assigned by the core once SCTP is connected.
+    pub(crate) async fn set_id(&self, id: RTCDataChannelId) {
+        *self.id.lock().await = Some(id);
     }
 
     /// Park until the driver signals send-buffer progress, or a 50 ms liveness backstop
@@ -304,7 +320,15 @@ impl DataChannelImpl {
 impl Drop for DataChannelImpl {
     fn drop(&mut self) {
         if let Some(mut data_channels) = self.inner.data_channel_events_tx.try_lock() {
-            data_channels.remove(&self.id);
+            data_channels.remove(&self.handle);
+        }
+        if let Some(mut impls) = self.inner.data_channel_impls.try_lock() {
+            impls.remove(&self.handle);
+        }
+        // Best-effort reverse-map cleanup; `OnClose` covers the contended case.
+        if let Some(mut ids) = self.inner.data_channel_ids.try_lock() {
+            let handle = self.handle;
+            ids.retain(|_, h| *h != handle);
         }
     }
 }
@@ -320,7 +344,7 @@ impl DataChannel for DataChannelImpl {
         let mut peer_connection = self.inner.core.lock().await;
 
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .label()
             .to_owned())
@@ -331,7 +355,7 @@ impl DataChannel for DataChannelImpl {
     async fn ordered(&self) -> Result<bool> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .ordered())
     }
@@ -341,7 +365,7 @@ impl DataChannel for DataChannelImpl {
     async fn max_packet_life_time(&self) -> Result<Option<u16>> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .max_packet_life_time())
     }
@@ -351,7 +375,7 @@ impl DataChannel for DataChannelImpl {
     async fn max_retransmits(&self) -> Result<Option<u16>> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .max_retransmits())
     }
@@ -361,7 +385,7 @@ impl DataChannel for DataChannelImpl {
     async fn protocol(&self) -> Result<String> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .protocol()
             .to_owned())
@@ -372,21 +396,21 @@ impl DataChannel for DataChannelImpl {
     async fn negotiated(&self) -> Result<bool> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .negotiated())
     }
 
     // Documented on `DataChannel::id`.
-    fn id(&self) -> RTCDataChannelId {
-        self.id
+    async fn id(&self) -> Option<RTCDataChannelId> {
+        *self.id.lock().await
     }
 
     /// ready_state represents the state of the DataChannel object.
     async fn ready_state(&self) -> Result<RTCDataChannelState> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .ready_state())
     }
@@ -395,7 +419,7 @@ impl DataChannel for DataChannelImpl {
     async fn buffered_amount_high_threshold(&self) -> Result<u32> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .buffered_amount_high_threshold())
     }
@@ -406,7 +430,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?
                 .set_buffered_amount_high_threshold(threshold);
         }
@@ -419,7 +443,7 @@ impl DataChannel for DataChannelImpl {
     async fn buffered_amount_low_threshold(&self) -> Result<u32> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .buffered_amount_low_threshold())
     }
@@ -427,7 +451,7 @@ impl DataChannel for DataChannelImpl {
     async fn outstanding_bytes(&self) -> Result<usize> {
         let mut peer_connection = self.inner.core.lock().await;
         Ok(peer_connection
-            .data_channel(self.id)
+            .data_channel_handle(self.handle)
             .ok_or(Error::ErrDataChannelClosed)?
             .outstanding_bytes())
     }
@@ -438,7 +462,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?
                 .set_buffered_amount_low_threshold(threshold);
         }
@@ -458,7 +482,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             let mut dc = peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?;
             dc.send(self.inner.runtime.now(), data)?;
         }
@@ -476,7 +500,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             let mut dc = peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?;
             dc.send_text(self.inner.runtime.now(), text)?;
         }
@@ -506,7 +530,7 @@ impl DataChannel for DataChannelImpl {
             {
                 let mut peer_connection = self.inner.core.lock().await;
                 let outstanding = peer_connection
-                    .data_channel(self.id)
+                    .data_channel_handle(self.handle)
                     .ok_or(Error::ErrDataChannelClosed)?
                     .outstanding_bytes();
                 // Below the limit ⇒ writable. An empty buffer (`0 < limit`) also passes, so
@@ -532,7 +556,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             let mut dc = peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?;
             let outstanding = dc.outstanding_bytes();
             // Reject once the message would push outstanding bytes past the limit — but
@@ -558,7 +582,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             let mut dc = peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?;
             let outstanding = dc.outstanding_bytes();
             if outstanding != 0 && outstanding.saturating_add(text.len()) > limit {
@@ -596,7 +620,7 @@ impl DataChannel for DataChannelImpl {
         {
             let mut peer_connection = self.inner.core.lock().await;
             peer_connection
-                .data_channel(self.id)
+                .data_channel_handle(self.handle)
                 .ok_or(Error::ErrDataChannelClosed)?
                 .close()?;
         }
@@ -653,7 +677,7 @@ mod tests {
         async fn negotiated(&self) -> Result<bool> {
             unimplemented!()
         }
-        fn id(&self) -> RTCDataChannelId {
+        async fn id(&self) -> Option<RTCDataChannelId> {
             unimplemented!()
         }
         async fn ready_state(&self) -> Result<RTCDataChannelState> {
@@ -739,7 +763,7 @@ mod tests {
         rt.block_on(Box::pin(async {
             let (inner, _driver_event_rx) = new_test_peer_connection().await;
 
-            let channel_id = 0;
+            let channel_id = RTCDataChannelHandle::new(0);
             let (evt_tx, evt_rx) = channel::<DataChannelEvent>(1);
             inner
                 .data_channel_events_tx
@@ -754,7 +778,31 @@ mod tests {
                     .contains_key(&channel_id)
             );
 
-            let dc = DataChannelImpl::new(channel_id, inner.clone(), evt_rx);
+            // Pre-seed the reverse map and the cached id, then drop: both must be cleaned up.
+            let stream_id: RTCDataChannelId = 7;
+            inner
+                .data_channel_ids
+                .lock()
+                .await
+                .insert(stream_id, channel_id);
+            let dc = Arc::new(DataChannelImpl::new(channel_id, inner.clone(), evt_rx));
+            dc.set_id(stream_id).await;
+            // Register as a weak reference, matching `create_data_channel`.
+            inner
+                .data_channel_impls
+                .lock()
+                .await
+                .insert(channel_id, Arc::downgrade(&dc));
+            assert!(
+                inner
+                    .data_channel_impls
+                    .lock()
+                    .await
+                    .get(&channel_id)
+                    .is_some_and(|weak| weak.upgrade().is_some()),
+                "the registered weak ref must upgrade while the wrapper is alive"
+            );
+
             drop(dc);
 
             assert!(
@@ -763,6 +811,19 @@ mod tests {
                     .lock()
                     .await
                     .contains_key(&channel_id)
+            );
+            assert!(
+                !inner.data_channel_ids.lock().await.contains_key(&stream_id),
+                "dropping a DataChannelImpl must remove its stream-id reverse-map entry"
+            );
+            assert!(
+                inner
+                    .data_channel_impls
+                    .lock()
+                    .await
+                    .get(&channel_id)
+                    .is_none(),
+                "dropping a DataChannelImpl must remove its impl-map entry (breaking the cycle)"
             );
         }));
     }

--- a/src/peer_connection/driver.rs
+++ b/src/peer_connection/driver.rs
@@ -6,7 +6,7 @@ use super::transport::stun_gatherer::{
     RTCStunGatherEventIn, RTCStunGatherEventOut, RTCStunGatherer,
 };
 use super::transport::turn_relayer::{RTCTurnRelayEventIn, RTCTurnRelayEventOut, RTCTurnRelayer};
-use crate::data_channel::{DataChannelEvent, DataChannelImpl, RTCDataChannelId};
+use crate::data_channel::{DataChannelEvent, DataChannelImpl, RTCDataChannelHandle};
 use crate::media_stream::track_local::TrackLocalEvent;
 use crate::media_stream::track_remote::static_rtp::TrackRemoteStaticRTP;
 use crate::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
@@ -124,13 +124,13 @@ const DEFAULT_TIMEOUT_DURATION: Duration = Duration::from_secs(86400); // 1 day 
 /// by elapsed time catches every shape.
 const MIN_IMMEDIATE_TIMEOUT_INTERVAL: Duration = Duration::from_millis(1);
 
-/// Insert `sender` for `channel_id`, returning `true` if the channel should be announced.
+/// Insert `sender` for `channel_handle`, returning `true` if the channel should be announced.
 pub(crate) fn insert_data_channel_event_sender(
-    data_channels: &mut HashMap<RTCDataChannelId, Sender<DataChannelEvent>>,
-    channel_id: RTCDataChannelId,
+    data_channels: &mut HashMap<RTCDataChannelHandle, Sender<DataChannelEvent>>,
+    channel_handle: RTCDataChannelHandle,
     sender: Sender<DataChannelEvent>,
 ) -> bool {
-    match data_channels.entry(channel_id) {
+    match data_channels.entry(channel_handle) {
         Entry::Vacant(e) => {
             e.insert(sender);
             true
@@ -328,7 +328,7 @@ pub(crate) struct PeerConnectionDriver<A = SocketAddr> {
     ///
     /// Every variant goes in here, not just `OnMessage`: lifecycle events share the queue, so
     /// retaining uniformly is what preserves their order relative to the data around them.
-    pending_data_channel_events: HashMap<RTCDataChannelId, VecDeque<DataChannelEvent>>,
+    pending_data_channel_events: HashMap<RTCDataChannelHandle, VecDeque<DataChannelEvent>>,
     /// The addresses as the application configured them, held **unresolved** and re-resolved on
     /// every bind by [`resolve_bind_addrs`].
     ///
@@ -1101,51 +1101,83 @@ where
                 self.inner.handler.on_connection_state_change(state).await;
             }
             RTCPeerConnectionEvent::OnDataChannel(evt) => {
-                let channel_id = match evt {
-                    RTCDataChannelEvent::OnOpen(id) => id,
-                    RTCDataChannelEvent::OnError(id) => id,
-                    RTCDataChannelEvent::OnClosing(id) => id,
-                    RTCDataChannelEvent::OnClose(id) => id,
-                    RTCDataChannelEvent::OnBufferedAmountLow(id) => id,
-                    RTCDataChannelEvent::OnBufferedAmountHigh(id) => id,
+                // Overflow / exhaustion failures are keyed by handle, not stream id, so route
+                // them straight to the owning wrapper without touching the stream-id reverse map.
+                if let RTCDataChannelEvent::OnErrorByHandle(h)
+                | RTCDataChannelEvent::OnCloseByHandle(h) = &evt
+                {
+                    let ev = if matches!(evt, RTCDataChannelEvent::OnCloseByHandle(_)) {
+                        DataChannelEvent::OnClose
+                    } else {
+                        DataChannelEvent::OnError
+                    };
+                    // Upgrade the weak wrapper first, releasing the impl-map lock before we
+                    // re-borrow `self` to deliver the event.
+                    let live = {
+                        let impls = self.inner.data_channel_impls.lock().await;
+                        impls.get(h).and_then(|weak| weak.upgrade()).is_some()
+                    };
+                    if live {
+                        self.deliver_data_channel_event(*h, ev).await;
+                    }
+                    return;
+                }
+
+                // Map the stream-id-keyed core event to a handle.
+                let stream_id = match &evt {
+                    RTCDataChannelEvent::OnOpen(id) => *id,
+                    RTCDataChannelEvent::OnError(id) => *id,
+                    RTCDataChannelEvent::OnClosing(id) => *id,
+                    RTCDataChannelEvent::OnClose(id) => *id,
+                    RTCDataChannelEvent::OnBufferedAmountLow(id) => *id,
+                    RTCDataChannelEvent::OnBufferedAmountHigh(id) => *id,
                     _ => {
                         warn!("Ignoring unknown RTCDataChannelEvent variant");
                         return;
                     }
                 };
 
+                // Resolve the real handle from the core on OnOpen.
                 if let RTCDataChannelEvent::OnOpen(_) = &evt {
-                    let data_channel_exist = {
+                    let stream_id_for_open = stream_id;
+                    let resolve_handle = {
                         let mut core = self.inner.core.lock().await;
-                        core.data_channel(channel_id).is_some()
+                        core.data_channel(stream_id_for_open).map(|dc| dc.handle())
                     };
-
-                    if data_channel_exist {
-                        let (evt_tx, evt_rx) =
-                            channel(DRIVER_TO_DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
-
-                        let should_announce = {
-                            let mut data_channels = self.inner.data_channel_events_tx.lock().await;
-                            insert_data_channel_event_sender(&mut data_channels, channel_id, evt_tx)
-                        };
-
-                        if should_announce {
-                            let data_channel = Arc::new(DataChannelImpl::new(
-                                channel_id,
-                                self.inner.clone(),
-                                evt_rx,
-                            ));
-                            self.inner.handler.on_data_channel(data_channel).await;
-                        }
+                    if let Some(resolve_handle) = resolve_handle {
+                        let mut ids = self.inner.data_channel_ids.lock().await;
+                        ids.insert(stream_id_for_open, resolve_handle);
                     }
                 }
 
-                // overflow: retained — six lifecycle sends. They share the queue with
-                // `OnMessage` (see `handle_rtc_message`), so they go through the same
-                // retain-and-retry path and in the same order: a retained `OnClose` must not
-                // overtake messages that preceded it, which W3C's task-queue ordering
-                // requires.
-                let event = match evt {
+                // Use the updated reverse map, falling back to the core.
+                let handle = {
+                    let ids = self.inner.data_channel_ids.lock().await;
+                    ids.get(&stream_id).copied()
+                };
+                let handle = if let Some(handle) = handle {
+                    handle
+                } else {
+                    let mut core = self.inner.core.lock().await;
+                    let Some(dc) = core.data_channel(stream_id) else {
+                        return;
+                    };
+                    dc.handle()
+                };
+
+                // Upgrade the weak wrapper. Dead local channels are ignored; a dead remote
+                // channel is announced again only on the opening event.
+                let locally_created = self
+                    .inner
+                    .locally_created_handles
+                    .lock()
+                    .await
+                    .contains(&handle);
+                let impl_ = {
+                    let impls = self.inner.data_channel_impls.lock().await;
+                    impls.get(&handle).and_then(|weak| weak.upgrade())
+                };
+                let event = match &evt {
                     RTCDataChannelEvent::OnOpen(_) => DataChannelEvent::OnOpen,
                     RTCDataChannelEvent::OnError(_) => DataChannelEvent::OnError,
                     RTCDataChannelEvent::OnClosing(_) => DataChannelEvent::OnClosing,
@@ -1161,7 +1193,65 @@ where
                         return;
                     }
                 };
-                self.deliver_data_channel_event(channel_id, event).await;
+                let mut announced = None;
+                if let Some(impl_) = impl_ {
+                    // Set the assigned stream id on the cached impl so the synchronous `id()`
+                    // works; the event below is delivered to the wrapper's channel.
+                    impl_.set_id(stream_id).await;
+                } else if locally_created {
+                    debug!(
+                        "data channel {} was dropped locally; ignoring {:?}",
+                        handle, evt
+                    );
+                    return;
+                } else if matches!(event, DataChannelEvent::OnOpen) {
+                    // The application released the wrapper, so the open event re-announces it.
+                    let (evt_tx, evt_rx) = channel(DRIVER_TO_DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
+
+                    let should_announce = {
+                        let mut data_channels = self.inner.data_channel_events_tx.lock().await;
+                        insert_data_channel_event_sender(&mut data_channels, handle, evt_tx)
+                    };
+
+                    if should_announce {
+                        let data_channel =
+                            Arc::new(DataChannelImpl::new(handle, self.inner.clone(), evt_rx));
+                        data_channel.set_id(stream_id).await;
+                        let mut impls = self.inner.data_channel_impls.lock().await;
+                        impls.insert(handle, Arc::downgrade(&data_channel));
+                        drop(impls);
+                        self.inner
+                            .handler
+                            .on_data_channel(data_channel.clone())
+                            .await;
+                        // Keep the wrapper alive until the open event is delivered below.
+                        announced = Some(data_channel);
+                    }
+                } else if matches!(event, DataChannelEvent::OnClose) {
+                    // The application released the wrapper; keep the reverse map in step.
+                    let mut ids = self.inner.data_channel_ids.lock().await;
+                    ids.remove(&stream_id);
+                    return;
+                } else {
+                    // The application released the wrapper and the event is not (re)opening,
+                    // so there is no live receiver; drop it.
+                    return;
+                }
+
+                // OnClose removes the reverse map entry; other events refresh it.
+                let mut ids = self.inner.data_channel_ids.lock().await;
+                match event {
+                    DataChannelEvent::OnClose => {
+                        ids.remove(&stream_id);
+                    }
+                    _ => {
+                        ids.entry(stream_id).or_insert(handle);
+                    }
+                }
+                drop(ids);
+
+                self.deliver_data_channel_event(handle, event).await;
+                drop(announced);
             }
             RTCPeerConnectionEvent::OnTrack(evt) => {
                 let track_id = match &evt {
@@ -1336,12 +1426,20 @@ where
                 // promises delivery; this used to discard it on a full queue. Now the
                 // message is kept and the driver stops pulling reads from the core until the
                 // consumer drains, so back-pressure reaches SCTP's receive window and the
-                // peer throttles.
-                self.deliver_data_channel_event(
-                    channel_id,
-                    DataChannelEvent::OnMessage(dc_message),
-                )
-                .await;
+                // peer throttles. The core keys the message by stream id; map it to the
+                // channel handle for routing.
+                let handle = self
+                    .inner
+                    .data_channel_ids
+                    .lock()
+                    .await
+                    .get(&channel_id)
+                    .copied();
+                let Some(handle) = handle else {
+                    return;
+                };
+                self.deliver_data_channel_event(handle, DataChannelEvent::OnMessage(dc_message))
+                    .await;
             }
             RTCMessage::RtpPacket(track_id, packet) => {
                 let track_remotes = self.inner.track_remote_events_tx.lock().await;
@@ -1604,23 +1702,23 @@ where
     /// anything is retained.
     async fn deliver_data_channel_event(
         &mut self,
-        channel_id: RTCDataChannelId,
+        channel_handle: RTCDataChannelHandle,
         event: DataChannelEvent,
     ) {
         // Anything already retained for this channel must go first, or a later event would
         // overtake an earlier one — W3C queues `message` and `close` as tasks on the same
         // event loop, so a close must never arrive before data that preceded it.
-        if let Some(pending) = self.pending_data_channel_events.get_mut(&channel_id) {
+        if let Some(pending) = self.pending_data_channel_events.get_mut(&channel_handle) {
             pending.push_back(event);
             return;
         }
 
         let evt_tx = {
             let data_channels = self.inner.data_channel_events_tx.lock().await;
-            data_channels.get(&channel_id).cloned()
+            data_channels.get(&channel_handle).cloned()
         };
         let Some(evt_tx) = evt_tx else {
-            error!("Failed to get data_channel: {} for event", channel_id);
+            error!("Failed to get data_channel: {} for event", channel_handle);
             return;
         };
 
@@ -1629,7 +1727,7 @@ where
             Ok(()) => {}
             Err(TrySendError::Full(event)) => {
                 self.pending_data_channel_events
-                    .entry(channel_id)
+                    .entry(channel_handle)
                     .or_default()
                     .push_back(event);
                 self.inner
@@ -1638,7 +1736,7 @@ where
             }
             Err(TrySendError::Disconnected(_)) => {
                 // The application dropped its `DataChannel`; there is nobody to deliver to.
-                debug!("data channel {} has no live receiver", channel_id);
+                debug!("data channel {} has no live receiver", channel_handle);
             }
         }
     }
@@ -1649,7 +1747,7 @@ where
             return false;
         }
 
-        let senders: HashMap<RTCDataChannelId, Sender<DataChannelEvent>> =
+        let senders: HashMap<RTCDataChannelHandle, Sender<DataChannelEvent>> =
             self.inner.data_channel_events_tx.lock().await.clone();
 
         for (channel_id, pending) in self.pending_data_channel_events.iter_mut() {
@@ -1978,8 +2076,8 @@ mod tests {
 
     #[test]
     fn insert_data_channel_event_sender_replaces_closed_sender() {
-        let mut map: HashMap<RTCDataChannelId, Sender<DataChannelEvent>> = HashMap::new();
-        let channel_id = 0;
+        let mut map: HashMap<RTCDataChannelHandle, Sender<DataChannelEvent>> = HashMap::new();
+        let channel_id = RTCDataChannelHandle::new(0);
 
         let (old_tx, old_rx) = channel::<DataChannelEvent>(1);
         drop(old_rx);
@@ -1997,8 +2095,8 @@ mod tests {
 
     #[test]
     fn insert_data_channel_event_sender_skips_live_sender() {
-        let mut map: HashMap<RTCDataChannelId, Sender<DataChannelEvent>> = HashMap::new();
-        let channel_id = 0;
+        let mut map: HashMap<RTCDataChannelHandle, Sender<DataChannelEvent>> = HashMap::new();
+        let channel_id = RTCDataChannelHandle::new(0);
 
         let (live_tx, _live_rx) = channel::<DataChannelEvent>(1);
         map.insert(channel_id, live_tx);
@@ -2009,6 +2107,259 @@ mod tests {
 
         let sender = map.get(&channel_id).cloned().unwrap();
         assert!(!sender.is_closed());
+    }
+
+    // Unit tests for data-channel event routing through `handle_rtc_event`.
+    #[cfg(all(test, any(feature = "crypto-ring", feature = "crypto-aws-lc-rs")))]
+    mod data_channel_routing_tests {
+        use super::*;
+        use crate::data_channel::{DataChannel, RTCDataChannelInit};
+        use crate::peer_connection::new_test_peer_connection;
+        use crate::peer_connection::{
+            PeerConnection, PeerConnectionEventHandler, PeerConnectionImpl, PeerConnectionRef,
+        };
+        use crate::runtime::{Mutex, TryRecvError, default_runtime, timeout};
+        use rtc::peer_connection::RTCPeerConnectionBuilder;
+        use rtc::peer_connection::configuration::RTCIceTransportPolicy;
+        use std::collections::HashSet;
+        use std::sync::Mutex as StdMutex;
+        use std::sync::atomic::AtomicBool;
+
+        /// Records every channel announced through `on_data_channel`.
+        #[derive(Default)]
+        struct RecordingHandler {
+            announced: StdMutex<Vec<Arc<dyn DataChannel>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl PeerConnectionEventHandler for RecordingHandler {
+            async fn on_data_channel(&self, data_channel: Arc<dyn DataChannel>) {
+                self.announced.lock().unwrap().push(data_channel);
+            }
+        }
+
+        async fn new_recording_peer_connection() -> (
+            Arc<PeerConnectionRef>,
+            Arc<RecordingHandler>,
+            crate::runtime::Receiver<PeerConnectionDriverEvent>,
+        ) {
+            let core = RTCPeerConnectionBuilder::new()
+                .build(Instant::now())
+                .unwrap();
+            let runtime = default_runtime().expect("test requires a runtime feature");
+            let recorded = Arc::new(RecordingHandler::default());
+            let handler: Arc<dyn PeerConnectionEventHandler> = recorded.clone();
+            let (driver_event_tx, driver_event_rx) =
+                crate::runtime::channel::<PeerConnectionDriverEvent>(1);
+
+            let inner = Arc::new(PeerConnectionRef {
+                core: Mutex::new(core),
+                runtime,
+                handler,
+                driver_event_tx,
+                write_pending: AtomicBool::new(false),
+                write_backpressure: std::sync::atomic::AtomicUsize::new(0),
+                closing: AtomicBool::new(false),
+                data_channel_send_buffer_limit: usize::MAX,
+                data_channel_backpressure: crate::runtime::Notify::new(),
+                data_channel_delivery_blocked: AtomicBool::new(false),
+                data_channel_consumed: crate::runtime::Notify::new(),
+                data_channel_events_tx: Mutex::new(HashMap::new()),
+                data_channel_impls: Mutex::new(HashMap::new()),
+                data_channel_ids: Mutex::new(HashMap::new()),
+                locally_created_handles: Mutex::new(HashSet::new()),
+                track_remote_events_tx: Mutex::new(HashMap::new()),
+                track_local_events_tx: Mutex::new(HashMap::new()),
+                rtp_transceivers: Mutex::new(HashMap::new()),
+                discard_local_candidates_during_ice_restart: false,
+                ice_restart_rebind_pending: AtomicBool::new(false),
+            });
+
+            (inner, recorded, driver_event_rx)
+        }
+
+        fn driver_for(inner: Arc<PeerConnectionRef>) -> PeerConnectionDriver {
+            PeerConnectionDriver::new(
+                inner,
+                Vec::new(),
+                Vec::new(),
+                MulticastDnsMode::Disabled,
+                Vec::new(),
+                RTCIceTransportPolicy::All,
+                rtc::crypto::default_provider().expect("a built-in crypto provider for tests"),
+                false,
+                None,
+            )
+        }
+
+        /// Dropping a DataChannel must not keep the connection alive.
+        #[test]
+        fn drop_data_channel_allows_peer_connection_drop() {
+            let rt = default_runtime().expect("test requires a runtime feature");
+            rt.block_on(Box::pin(async {
+                let (inner, _driver_event_rx) = new_test_peer_connection().await;
+                let pc = PeerConnectionImpl {
+                    inner: inner.clone(),
+                    driver_handle: Mutex::new(None),
+                    dedicated_reactor: false,
+                };
+                let dc = pc.create_data_channel("test", None).await.unwrap();
+
+                let weak_inner = Arc::downgrade(&inner);
+                drop(dc);
+                drop(pc);
+                drop(inner);
+
+                assert!(
+                    weak_inner.upgrade().is_none(),
+                    "no reference cycle through the data-channel wrapper"
+                );
+            }));
+        }
+
+        /// OnOpen routes to the freshly resolved handle, not a stale reverse-map entry.
+        #[test]
+        fn onopen_uses_freshly_resolved_handle() {
+            let rt = default_runtime().expect("test requires a runtime feature");
+            rt.block_on(Box::pin(async {
+                let (inner, recorded, _driver_event_rx) = new_recording_peer_connection().await;
+
+                // The core holds a real channel on stream id 5 (negotiated, so the id is known
+                // at creation). Its handle is allocated by the core (handle 0 for the first
+                // channel) and differs from the stale handle seeded below.
+                let real_handle = {
+                    let mut core = inner.core.lock().await;
+                    core.create_data_channel(
+                        "remote",
+                        Some(RTCDataChannelInit {
+                            negotiated: Some(5),
+                            ..Default::default()
+                        }),
+                    )
+                    .unwrap()
+                    .handle()
+                };
+
+                // Stale wrapper-side state: the reverse map aliases stream id 5 to a different,
+                // dead handle, and a live event sender (and impl) is registered under it.
+                let stale_handle = RTCDataChannelHandle::new(100);
+                assert_ne!(stale_handle, real_handle);
+                let (stale_tx, mut stale_rx) = channel::<DataChannelEvent>(1);
+                inner
+                    .data_channel_events_tx
+                    .lock()
+                    .await
+                    .insert(stale_handle, stale_tx);
+                let (_, stale_impl_rx) = channel::<DataChannelEvent>(1);
+                let stale_impl = Arc::new(DataChannelImpl::new(
+                    stale_handle,
+                    inner.clone(),
+                    stale_impl_rx,
+                ));
+                inner
+                    .data_channel_impls
+                    .lock()
+                    .await
+                    .insert(stale_handle, Arc::downgrade(&stale_impl));
+                inner.data_channel_ids.lock().await.insert(5, stale_handle);
+
+                // The core announces the channel open on stream id 5.
+                let mut driver = driver_for(inner.clone());
+                driver
+                    .handle_rtc_event(RTCPeerConnectionEvent::OnDataChannel(
+                        RTCDataChannelEvent::OnOpen(5),
+                    ))
+                    .await;
+
+                // The event must reach the fresh wrapper for the *real* handle, not the stale one.
+                assert!(
+                    matches!(stale_rx.try_recv(), Err(TryRecvError::Empty)),
+                    "OnOpen must not be delivered to the stale handle"
+                );
+
+                let first = {
+                    let announced = recorded.announced.lock().unwrap();
+                    assert_eq!(
+                        announced.len(),
+                        1,
+                        "exactly one wrapper is announced for the remote channel"
+                    );
+                    announced[0].clone()
+                };
+                let event = first.poll().await;
+                assert!(
+                    matches!(event, Some(DataChannelEvent::OnOpen)),
+                    "the newly announced wrapper receives the OnOpen event"
+                );
+
+                // And the reverse map now points at the freshly resolved handle.
+                let ids = inner.data_channel_ids.lock().await;
+                assert_eq!(ids.get(&5), Some(&real_handle));
+            }));
+        }
+
+        /// A post-SCTP channel's open event routes to the existing wrapper, with no duplicate.
+        #[test]
+        fn create_data_channel_after_sctp_no_duplicate_wrapper() {
+            let rt = default_runtime().expect("test requires a runtime feature");
+            rt.block_on(Box::pin(async {
+                let (inner, recorded, _driver_event_rx) = new_recording_peer_connection().await;
+                let pc = PeerConnectionImpl {
+                    inner: inner.clone(),
+                    driver_handle: Mutex::new(None),
+                    dedicated_reactor: false,
+                };
+
+                // A negotiated channel is the post-SCTP shape: id assigned at creation, wrapper
+                // maps populated by `create_data_channel`, and the caller holds the impl.
+                let dc = pc
+                    .create_data_channel(
+                        "post-sctp",
+                        Some(RTCDataChannelInit {
+                            negotiated: Some(5),
+                            ..Default::default()
+                        }),
+                    )
+                    .await
+                    .unwrap();
+
+                let handle = {
+                    let mut core = inner.core.lock().await;
+                    core.data_channel(5).unwrap().handle()
+                };
+
+                // The core announces the channel open (as it would once SCTP connects).
+                let mut driver = driver_for(inner.clone());
+                driver
+                    .handle_rtc_event(RTCPeerConnectionEvent::OnDataChannel(
+                        RTCDataChannelEvent::OnOpen(5),
+                    ))
+                    .await;
+
+                // Single wrapper: the caller's, keyed by the caller's handle.
+                let impls = inner.data_channel_impls.lock().await;
+                assert_eq!(impls.len(), 1, "no duplicate wrapper may be created");
+                let weak = impls
+                    .get(&handle)
+                    .expect("the caller's wrapper is registered under its handle");
+                assert!(
+                    weak.upgrade().is_some(),
+                    "the caller's wrapper remains alive"
+                );
+                drop(impls);
+
+                assert!(
+                    recorded.announced.lock().unwrap().is_empty(),
+                    "an already-wrapped local channel must not be re-announced"
+                );
+
+                // And the open event was delivered into the caller's own wrapper.
+                let event = timeout(&*rt, Duration::from_secs(1), dc.poll())
+                    .await
+                    .expect("OnOpen within 1s");
+                assert!(matches!(event, Some(DataChannelEvent::OnOpen)));
+            }));
+        }
     }
 
     #[test]

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -56,7 +56,7 @@ use crate::peer_connection::transport::{SctpTransport, SctpTransportImpl};
 use log::error;
 use std::collections::{HashMap, HashSet};
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use crate::data_channel::{DataChannel, DataChannelEvent, DataChannelImpl};
@@ -71,7 +71,7 @@ use driver::{
     PeerConnectionDriver,
 };
 
-use rtc::data_channel::{RTCDataChannelId, RTCDataChannelInit};
+use rtc::data_channel::{RTCDataChannelHandle, RTCDataChannelId, RTCDataChannelInit};
 use rtc::ice::mdns::MulticastDnsMode;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::{RTCAnswerOptions, RTCOfferOptions};
@@ -586,8 +586,16 @@ pub(crate) struct PeerConnectionRef {
     /// `data_channel_send_buffer_limit` is configured — a `usize::MAX` (default) limit
     /// never parks on it.
     pub(crate) data_channel_backpressure: crate::runtime::Notify,
-    /// Channels for incoming data channel events
-    pub(crate) data_channel_events_tx: Mutex<HashMap<RTCDataChannelId, Sender<DataChannelEvent>>>,
+    /// Channels for incoming data channel events, keyed by the channel's stable handle.
+    pub(crate) data_channel_events_tx:
+        Mutex<HashMap<RTCDataChannelHandle, Sender<DataChannelEvent>>>,
+    /// Live wrappers keyed by handle, held weakly to break the cycle
+    /// `DataChannelImpl` -> `PeerConnectionRef` -> impl map.
+    pub(crate) data_channel_impls: Mutex<HashMap<RTCDataChannelHandle, Weak<DataChannelImpl>>>,
+    /// Reverse lookup from stream id to handle for routing core events.
+    pub(crate) data_channel_ids: Mutex<HashMap<RTCDataChannelId, RTCDataChannelHandle>>,
+    /// Handles created locally. Distinguishes dropped local channels from remote channels.
+    pub(crate) locally_created_handles: Mutex<HashSet<RTCDataChannelHandle>>,
     /// Channels for incoming track remote events
     #[allow(clippy::type_complexity)]
     pub(crate) track_remote_events_tx:
@@ -776,6 +784,9 @@ impl PeerConnectionImpl {
                 core: Mutex::new(core),
                 runtime: runtime.clone(),
                 data_channel_events_tx: Mutex::new(HashMap::new()),
+                data_channel_impls: Mutex::new(HashMap::new()),
+                data_channel_ids: Mutex::new(HashMap::new()),
+                locally_created_handles: Mutex::new(HashSet::new()),
                 track_remote_events_tx: Mutex::new(HashMap::new()),
                 track_local_events_tx: Mutex::new(HashMap::new()),
                 rtp_transceivers: Mutex::new(HashMap::new()),
@@ -1112,26 +1123,45 @@ impl PeerConnection for PeerConnectionImpl {
         label: &str,
         options: Option<RTCDataChannelInit>,
     ) -> Result<Arc<dyn DataChannel>> {
-        // Create the data channel via the core
-        let channel_id = {
+        // Create the data channel via the core, addressed by its stable handle.
+        let (channel_handle, assigned_id) = {
             let mut core = self.inner.core.lock().await;
             let rtc_dc = core.create_data_channel(label, options)?;
-            rtc_dc.id()
+            // Record the handle as locally created before the driver sees its events.
+            self.inner
+                .locally_created_handles
+                .lock()
+                .await
+                .insert(rtc_dc.handle());
+            (rtc_dc.handle(), rtc_dc.id())
         };
 
         let (evt_tx, evt_rx) = channel(DRIVER_TO_DATA_CHANNEL_EVENT_CHANNEL_CAPACITY);
         {
             let mut data_channels = self.inner.data_channel_events_tx.lock().await;
-            data_channels.insert(channel_id, evt_tx);
+            data_channels.insert(channel_handle, evt_tx);
+        }
+        if let Some(stream_id) = assigned_id {
+            let mut ids = self.inner.data_channel_ids.lock().await;
+            ids.insert(stream_id, channel_handle);
         }
 
         self.inner.wake_writes().await;
 
-        Ok(Arc::new(DataChannelImpl::new(
-            channel_id,
+        let impl_ = Arc::new(DataChannelImpl::new(
+            channel_handle,
             self.inner.clone(),
             evt_rx,
-        )))
+        ));
+        if let Some(stream_id) = assigned_id {
+            impl_.set_id(stream_id).await;
+        }
+        {
+            let mut impls = self.inner.data_channel_impls.lock().await;
+            impls.insert(channel_handle, Arc::downgrade(&impl_));
+        }
+
+        Ok(impl_)
     }
 
     /// Get the list of rtp sender
@@ -1374,6 +1404,9 @@ mod tests {
             data_channel_delivery_blocked: AtomicBool::new(false),
             data_channel_consumed: crate::runtime::Notify::new(),
             data_channel_events_tx: Mutex::new(HashMap::new()),
+            data_channel_impls: Mutex::new(HashMap::new()),
+            data_channel_ids: Mutex::new(HashMap::new()),
+            locally_created_handles: Mutex::new(HashSet::new()),
             track_remote_events_tx: Mutex::new(HashMap::new()),
             track_local_events_tx: Mutex::new(HashMap::new()),
             rtp_transceivers: Mutex::new(HashMap::new()),

--- a/tests/data_channel_id_resolves_after_open.rs
+++ b/tests/data_channel_id_resolves_after_open.rs
@@ -1,0 +1,207 @@
+//! Wrapper-level `DataChannel::id()` deferral: a locally-created in-band channel reports
+//! `id() == None` until the DTLS role is resolved and the SCTP transport connects (W3C section 6.1
+//! step 18 / section 6.1.1.3). Once the channel opens, `id()` must resolve to the assigned stream id
+//! and stay stable; it is served synchronously from the impl's cached value without the async core
+//! lock.
+//!
+//! This is the direct wrapper unit/integration pin for the deferral contract that the rtc
+//! integration tests (`data_channel_stream_id_deferral.rs`) and the tokio-peer matrix cover
+//! only transitively.
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Duration;
+
+use webrtc::data_channel::{DataChannelEvent, RTCDataChannelId, RTCDataChannelInit};
+use webrtc::peer_connection::{PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler};
+use webrtc::peer_connection::{RTCIceGatheringState, RTCPeerConnectionState};
+use webrtc::runtime::{Sender, channel};
+
+mod common;
+use common::{block_on, runtime, timeout};
+
+struct Handler {
+    gather_tx: Sender<()>,
+    connected_tx: Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for Handler {
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        if state == RTCIceGatheringState::Complete {
+            let _ = self.gather_tx.try_send(());
+        }
+    }
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if state == RTCPeerConnectionState::Connected {
+            let _ = self.connected_tx.try_send(());
+        }
+    }
+}
+
+#[test]
+fn test_data_channel_id_is_none_before_open_and_resolves_after() {
+    block_on(run()).unwrap();
+}
+
+async fn run() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let runtime = runtime();
+
+    let (offer_gather_tx, mut offer_gather_rx) = channel::<()>(1);
+    let (offer_conn_tx, mut offer_conn_rx) = channel::<()>(1);
+    let (answer_gather_tx, mut answer_gather_rx) = channel::<()>(1);
+    let (answer_conn_tx, mut answer_conn_rx) = channel::<()>(1);
+
+    let offerer = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(Handler {
+            gather_tx: offer_gather_tx,
+            connected_tx: offer_conn_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let dc = offerer
+        .create_data_channel(
+            "deferred-id",
+            Some(RTCDataChannelInit {
+                ordered: true,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    // Created before any SDP is exchanged -> DTLS role unresolved -> id is null.
+    assert_eq!(
+        dc.id().await,
+        None,
+        "a channel created while the DTLS role is Auto must report id() == None"
+    );
+
+    // Drive the channel to OnOpen.
+    let (open_tx, mut open_rx) = channel::<()>(1);
+    {
+        let dc = dc.clone();
+        runtime.spawn(Box::pin(async move {
+            while let Some(event) = dc.poll().await {
+                match event {
+                    DataChannelEvent::OnOpen => {
+                        let _ = open_tx.try_send(());
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
+                }
+            }
+        }));
+    }
+
+    let offer = offerer.create_offer(None).await?;
+    offerer.set_local_description(offer).await?;
+    let _ = timeout(Duration::from_secs(5), offer_gather_rx.recv()).await;
+    let offer_sdp = offerer.local_description().await.expect("offer");
+
+    let answerer = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(Handler {
+            gather_tx: answer_gather_tx,
+            connected_tx: answer_conn_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    answerer.set_remote_description(offer_sdp).await?;
+    let answer = answerer.create_answer(None).await?;
+    answerer.set_local_description(answer).await?;
+    let _ = timeout(Duration::from_secs(5), answer_gather_rx.recv()).await;
+    let answer_sdp = answerer.local_description().await.expect("answer");
+    offerer.set_remote_description(answer_sdp).await?;
+
+    timeout(Duration::from_secs(15), offer_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: offerer connect"))?;
+    timeout(Duration::from_secs(5), answer_conn_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: answerer connect"))?;
+    timeout(Duration::from_secs(10), open_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout: data channel open"))?;
+
+    // Once the channel opens, id() must resolve to a concrete stream id...
+    let resolved: RTCDataChannelId = dc
+        .id()
+        .await
+        .expect("a channel that has opened must have a non-null id");
+    // ...and that id must carry the offerer's DTLS-role parity (RFC 8832 section 6: client even,
+    // server odd). Both roles exercise the assignment; the assertion also guards against a
+    // stale `None` cache.
+    assert_eq!(
+        dc.id().await,
+        Some(resolved),
+        "id() must be stable once assigned"
+    );
+
+    let _ = offerer.close().await;
+    let _ = answerer.close().await;
+    Ok(())
+}
+
+#[test]
+fn test_negotiated_data_channel_has_id_immediately() {
+    block_on(run_negotiated()).unwrap();
+}
+
+/// A negotiated channel with an explicit stream id has its id assigned up-front by the core,
+/// so the wrapper's `create_data_channel` must take the `assigned_id.is_some()` branch and seed
+/// `id()` without waiting for the DTLS role to resolve or SCTP to connect.
+async fn run_negotiated() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let runtime = runtime();
+
+    let (gather_tx, _gather_rx) = channel::<()>(1);
+    let (connected_tx, _connected_rx) = channel::<()>(1);
+
+    let pc = PeerConnectionBuilder::new()
+        .with_handler(Arc::new(Handler {
+            gather_tx,
+            connected_tx,
+        }))
+        .with_runtime(runtime.clone())
+        .with_udp_addrs(vec!["127.0.0.1:0".to_string()])
+        .build()
+        .await?;
+
+    let id: RTCDataChannelId = 0;
+    let dc = pc
+        .create_data_channel(
+            "negotiated-id",
+            Some(RTCDataChannelInit {
+                negotiated: Some(id),
+                ordered: true,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    // Covers `peer_connection/mod.rs` `if let Some(stream_id) = assigned_id` branches:
+    // the negotiated id is seeded into the wrapper synchronously at creation.
+    assert_eq!(
+        dc.id().await,
+        Some(id),
+        "a negotiated channel with an explicit id must report id() == Some(id) at creation"
+    );
+
+    let _ = pc.close().await;
+    Ok(())
+}


### PR DESCRIPTION
This PR wraps the `rtc` stream-id deferral ([https://github.com/webrtc-rs/rtc/pull/209](https://github.com/webrtc-rs/rtc/pull/209)) for the async API. In [https://github.com/webrtc-rs/rtc/pull/209](https://github.com/webrtc-rs/rtc/pull/209), `rtc` defers data channel stream id assignment until the DTLS role is resolved (W3C section 6.1 step 18 / section 6.1.1.3, RFC 8832 section 6); a channel created while the role is `Auto` has no id until SCTP connects. 

This PR bridges that into the wrapper so `DataChannel::id()` returns `Option` and resolves once the role is known. Closes [https://github.com/webrtc-rs/rtc/issues/199](https://github.com/webrtc-rs/rtc/issues/199).

**Depends on** [https://github.com/webrtc-rs/rtc/pull/209](https://github.com/webrtc-rs/rtc/pull/209): the `rtc` deferral must merge first.

## Changes

### Breaking

- `DataChannel::id()` returns `Option<RTCDataChannelId>` (`None` while unassigned).

### Handle-based wrapper identity (internal)

- `DataChannelImpl` holds a stable handle plus an async `runtime::primitives::Mutex<Option<RTCDataChannelId>>`:
  - The driver calls `set_id().await` once the core assigns the id.
  - `id()` is `async` and locks the runtime `Mutex` to read the assigned id.
- `PeerConnectionRef` routes events by handle:
  - Adds a handle-keyed `data_channel_impls` map and a stream-id reverse map (`data_channel_ids`).
  - Each `create_data_channel` captures the handle and pre-registers any immediately-assigned id (negotiated channels, or channels created after the SCTP association exists).
  - Pre-registration lets the driver route an `OnClose` that arrives before its `OnOpen` instead of dropping it.

### Reference-cycle fix

- `data_channel_impls` now holds `Weak<DataChannelImpl>` instead of a strong `Arc`, breaking the cycle (`DataChannelImpl` -> `PeerConnectionRef` -> impl map) that leaked the connection until the process exited.
- The driver upgrades the weak reference when routing an event and drops it afterwards.
- A dropped *local* channel (tracked in a new `locally_created_handles` set) is never re-announced.
- A *remote* channel without a live wrapper is re-created and announced as before.

### Fresh-handle `OnOpen` routing

- Events are routed by the handle re-derived from the updated reverse map after `OnOpen`, so an open that corrected a stale stream-id -> handle mapping reaches the resolved channel rather than the stale one.

### Reverse-map cleanup

- A closed or dropped channel no longer leaves a stale stream-id -> handle entry:
  - `DataChannelImpl::Drop` best-effort removes its handle from `data_channel_ids` (via `try_lock`, non-blocking) alongside the existing `data_channel_events_tx` / `data_channel_impls` cleanup.
  - The driver's `OnClose` handling removes the stream id from `data_channel_ids` instead of re-inserting it, so a reused stream id cannot alias a dead handle.
  - `Drop` is the fallback that covers the case where no clean `OnClose` arrives (e.g. teardown).

### Handle-keyed routing

- Core event/message routing (already stream-id based in `rtc`) is translated to handle-keyed wrapper maps via `data_channel_ids`, matching the handle-keyed `create_data_channel` path.
- **Handle-keyed overflow routing.** The driver routes the core's `OnErrorByHandle` / `OnCloseByHandle` overflow events (emitted when SCTP stream ids are exhausted) straight to the owning wrapper by handle:
  - The stream-id reverse map is not consulted.
  - The failing channel - which never received an id - is notified correctly rather than misrouted via stream id 0.

The wrapper's public event surface (`DataChannelEvent`, `on_data_channel`) is unchanged.

## Tests

- New integration test `tests/data_channel_id_resolves_after_open.rs`: `test_data_channel_id_is_none_before_open_and_resolves_after` asserts `id() == None` before connection and that `id()` resolves to a non-null, stable stream id after `OnOpen`; `test_negotiated_data_channel_has_id_immediately` asserts a negotiated channel (`RTCDataChannelInit { negotiated: Some(id) }`) reports `id() == Some(id)` immediately at creation, covering the pre-registered-id path in `create_data_channel`.
- New unit tests: `drop_data_channel_allows_peer_connection_drop` (no reference cycle), `onopen_uses_freshly_resolved_handle` (stale reverse-map entry is corrected), and `create_data_channel_after_sctp_no_duplicate_wrapper` (no duplicate wrapper after SCTP). `drop_removes_event_sender` was extended to exercise the real weak-reference path.
- Existing wrapper unit and integration suites pass.

## Spec references

- [W3C WebRTC section 6.2 RTCDataChannel.id](https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-id): the id is null until the DTLS role of the SCTP transport has been negotiated.

  > The value is initially null, which is what will be returned if the ID was not provided at channel creation time, and the DTLS role of the SCTP transport has not yet been negotiated. Otherwise, it will return the ID that was either selected by the script or generated by the user agent according to [RFC8832]. After the ID is set to a non-null value, it will not change.

## Verification

```bash
cargo test --tests -- --test-threads=4
cargo clippy --lib -- -D warnings
```
